### PR TITLE
fix: prevent dom validation warning

### DIFF
--- a/src/components/CurrentWallet.jsx
+++ b/src/components/CurrentWallet.jsx
@@ -78,7 +78,7 @@ export default function CurrentWallet ({ currentWallet }) {
       {walletInfo && walletInfo?.total_balance &&
         <>
           <p>Total Balance: {valueToUnit(walletInfo.total_balance, unit)}</p>
-          <p><rb.Form.Check type="switch" label="Display amounts in SATS" checked={unit === SATS} onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)} /></p>
+          <rb.Form.Check type="switch" label="Display amounts in SATS" checked={unit === SATS} onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)} />
         </>}
       {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} unit={unit} className="mb-4" />}
       {!!fidelityBonds?.length && (


### PR DESCRIPTION
Component `rb.Form.Check` renders as div which leads to a warning when placed inside a paragraph tag:
`Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.`

Removing the tag does not have a visual impact.