### PR TITLE
Add switch to show / hide balances

### DIFF
--- a/src/components/CurrentWallet.jsx
+++ b/src/components/CurrentWallet.jsx
@@ -8,12 +8,18 @@ import DisplayUTXOs from './DisplayUTXOs'
 
 export default function CurrentWallet ({ currentWallet }) {
   const [walletInfo, setWalletInfo] = useState(null)
+  const [redactBalances, setRedactBalances] = useState(!(window.localStorage.getItem('jm-redactBalances') === 'false'))
   const [unit, setUnit] = useState(window.localStorage.getItem('jm-unit') || BTC)
   const [utxos, setUtxos] = useState(null)
   const [fidelityBonds, setFidelityBonds] = useState(null)
   const [showUTXO, setShowUTXO] = useState(false)
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
+
+  const setAndPersistRedactBalances = redactBalances => {
+    setRedactBalances(redactBalances)
+    window.localStorage.setItem('jm-redactBalances', redactBalances)
+  }
 
   const setAndPersistUnit = unit => {
     setUnit(unit)
@@ -77,17 +83,18 @@ export default function CurrentWallet ({ currentWallet }) {
         </div>}
       {walletInfo && walletInfo?.total_balance &&
         <>
-          <p>Total Balance: {valueToUnit(walletInfo.total_balance, unit)}</p>
+          <p>Total Balance: {valueToUnit(walletInfo.total_balance, unit, redactBalances)}</p>
+          <rb.Form.Check type="switch" label="Show Balances" checked={!redactBalances} onChange={(e) => setAndPersistRedactBalances(!e.target.checked)} />
           <rb.Form.Check type="switch" label="Display amounts in SATS" checked={unit === SATS} onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)} />
         </>}
-      {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} unit={unit} className="mb-4" />}
+      {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} unit={unit} redactBalances={redactBalances} className="mb-4" />}
       {!!fidelityBonds?.length && (
         <div className="mt-5 mb-3 pe-3">
           <h5>Fidelity Bonds</h5>
-          <DisplayUTXOs utxos={fidelityBonds} unit={unit} className="pe-2" />
+          <DisplayUTXOs utxos={fidelityBonds} unit={unit} redactBalances={redactBalances} className="pe-2" />
         </div>)}
       {utxos && <rb.Button variant="outline-dark" onClick={() => { setShowUTXO(!showUTXO) }} className="mb-3">{showUTXO ? 'Hide UTXOs' : 'Show UTXOs'}</rb.Button>}
-      {utxos && showUTXO && <DisplayAccountUTXOs utxos={utxos} unit={unit} className="mt-3" />}
+      {utxos && showUTXO && <DisplayAccountUTXOs utxos={utxos} unit={unit} redactBalances={redactBalances} className="mt-3" />}
     </div>
   )
 }

--- a/src/components/CurrentWallet.jsx
+++ b/src/components/CurrentWallet.jsx
@@ -85,7 +85,7 @@ export default function CurrentWallet ({ currentWallet }) {
         <>
           <p>Total Balance: {valueToUnit(walletInfo.total_balance, unit, showBalances)}</p>
           <rb.Form.Check type="switch" label="Show Balances" checked={showBalances} onChange={(e) => setAndPersistShowBalances(e.target.checked)} />
-          <rb.Form.Check type="switch" label="Display amounts in SATS" checked={unit === SATS} onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)} />
+          <rb.Form.Check type="switch" label="Display amounts in SATS" checked={unit === SATS} onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)} className="mb-4" />
         </>}
       {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} unit={unit} showBalances={showBalances} className="mb-4" />}
       {!!fidelityBonds?.length && (

--- a/src/components/CurrentWallet.jsx
+++ b/src/components/CurrentWallet.jsx
@@ -8,7 +8,7 @@ import DisplayUTXOs from './DisplayUTXOs'
 
 export default function CurrentWallet ({ currentWallet }) {
   const [walletInfo, setWalletInfo] = useState(null)
-  const [redactBalances, setRedactBalances] = useState(!(window.localStorage.getItem('jm-redactBalances') === 'false'))
+  const [showBalances, setShowBalances] = useState(window.localStorage.getItem('jm-showBalances') === 'true')
   const [unit, setUnit] = useState(window.localStorage.getItem('jm-unit') || BTC)
   const [utxos, setUtxos] = useState(null)
   const [fidelityBonds, setFidelityBonds] = useState(null)
@@ -16,9 +16,9 @@ export default function CurrentWallet ({ currentWallet }) {
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
 
-  const setAndPersistRedactBalances = redactBalances => {
-    setRedactBalances(redactBalances)
-    window.localStorage.setItem('jm-redactBalances', redactBalances)
+  const setAndPersistShowBalances = showBalances => {
+    setShowBalances(showBalances)
+    window.localStorage.setItem('jm-showBalances', showBalances)
   }
 
   const setAndPersistUnit = unit => {
@@ -83,18 +83,18 @@ export default function CurrentWallet ({ currentWallet }) {
         </div>}
       {walletInfo && walletInfo?.total_balance &&
         <>
-          <p>Total Balance: {valueToUnit(walletInfo.total_balance, unit, redactBalances)}</p>
-          <rb.Form.Check type="switch" label="Show Balances" checked={!redactBalances} onChange={(e) => setAndPersistRedactBalances(!e.target.checked)} />
+          <p>Total Balance: {valueToUnit(walletInfo.total_balance, unit, showBalances)}</p>
+          <rb.Form.Check type="switch" label="Show Balances" checked={showBalances} onChange={(e) => setAndPersistShowBalances(e.target.checked)} />
           <rb.Form.Check type="switch" label="Display amounts in SATS" checked={unit === SATS} onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)} />
         </>}
-      {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} unit={unit} redactBalances={redactBalances} className="mb-4" />}
+      {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} unit={unit} showBalances={showBalances} className="mb-4" />}
       {!!fidelityBonds?.length && (
         <div className="mt-5 mb-3 pe-3">
           <h5>Fidelity Bonds</h5>
-          <DisplayUTXOs utxos={fidelityBonds} unit={unit} redactBalances={redactBalances} className="pe-2" />
+          <DisplayUTXOs utxos={fidelityBonds} unit={unit} showBalances={showBalances} className="pe-2" />
         </div>)}
       {utxos && <rb.Button variant="outline-dark" onClick={() => { setShowUTXO(!showUTXO) }} className="mb-3">{showUTXO ? 'Hide UTXOs' : 'Show UTXOs'}</rb.Button>}
-      {utxos && showUTXO && <DisplayAccountUTXOs utxos={utxos} unit={unit} redactBalances={redactBalances} className="mt-3" />}
+      {utxos && showUTXO && <DisplayAccountUTXOs utxos={utxos} unit={unit} showBalances={showBalances} className="mt-3" />}
     </div>
   )
 }

--- a/src/components/DisplayAccountUTXOs.jsx
+++ b/src/components/DisplayAccountUTXOs.jsx
@@ -12,7 +12,7 @@ const byAccount = utxos => {
   return ret
 }
 
-export default function DisplayAccountUTXOs({ utxos, unit, ...props }) {
+export default function DisplayAccountUTXOs({ utxos, unit, redactBalances, ...props }) {
   return (
     <rb.Accordion {...props}>
       {Object.entries(byAccount(utxos)).map(([account, utxos]) => (
@@ -21,7 +21,7 @@ export default function DisplayAccountUTXOs({ utxos, unit, ...props }) {
             <h5 className="mb-0">Account {account}</h5>
           </rb.Accordion.Header>
           <rb.Accordion.Body>
-            <DisplayUTXOs utxos={utxos} unit={unit} />
+            <DisplayUTXOs utxos={utxos} unit={unit} redactBalances={redactBalances} />
           </rb.Accordion.Body>
         </rb.Accordion.Item>
       ))}

--- a/src/components/DisplayAccountUTXOs.jsx
+++ b/src/components/DisplayAccountUTXOs.jsx
@@ -12,7 +12,7 @@ const byAccount = utxos => {
   return ret
 }
 
-export default function DisplayAccountUTXOs({ utxos, unit, redactBalances, ...props }) {
+export default function DisplayAccountUTXOs({ utxos, unit, showBalances, ...props }) {
   return (
     <rb.Accordion {...props}>
       {Object.entries(byAccount(utxos)).map(([account, utxos]) => (
@@ -21,7 +21,7 @@ export default function DisplayAccountUTXOs({ utxos, unit, redactBalances, ...pr
             <h5 className="mb-0">Account {account}</h5>
           </rb.Accordion.Header>
           <rb.Accordion.Body>
-            <DisplayUTXOs utxos={utxos} unit={unit} redactBalances={redactBalances} />
+            <DisplayUTXOs utxos={utxos} unit={unit} showBalances={showBalances} />
           </rb.Accordion.Body>
         </rb.Accordion.Item>
       ))}

--- a/src/components/DisplayAccounts.jsx
+++ b/src/components/DisplayAccounts.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import { titleize, valueToUnit } from '../utils'
 
-export default function DisplayAccounts({ accounts, unit, ...props }) {
+export default function DisplayAccounts({ accounts, unit, redactBalances, ...props }) {
   return (
     <rb.Accordion {...props}>
       {Object.values(accounts).map(({ account, account_balance: balance, branches }) => (
@@ -14,7 +14,7 @@ export default function DisplayAccounts({ accounts, unit, ...props }) {
                 <h5 className="mb-0">Account {account}</h5>
               </rb.Col>
               <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-                {valueToUnit(balance, unit)}
+                {valueToUnit(balance, unit, redactBalances)}
               </rb.Col>
             </rb.Row>
           </rb.Accordion.Header>
@@ -30,7 +30,7 @@ export default function DisplayAccounts({ accounts, unit, ...props }) {
                       <h6>{titleize(type)}</h6>
                     </rb.Col>
                     <rb.Col className="d-flex align-items-center justify-content-end">
-                      {valueToUnit(balance, unit)}
+                      {valueToUnit(balance, unit, redactBalances)}
                     </rb.Col>
                   </rb.Row>
                   <rb.Row className="w-100">
@@ -52,7 +52,7 @@ export default function DisplayAccounts({ accounts, unit, ...props }) {
                         {labels && <span className="badge bg-info">{labels}</span>}
                       </rb.Col>
                       <rb.Col className="d-flex align-items-center justify-content-end">
-                        {valueToUnit(amount, unit)}
+                        {valueToUnit(amount, unit, redactBalances)}
                       </rb.Col>
                     </rb.Row>))}
                 </article>

--- a/src/components/DisplayAccounts.jsx
+++ b/src/components/DisplayAccounts.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import { titleize, valueToUnit } from '../utils'
 
-export default function DisplayAccounts({ accounts, unit, redactBalances, ...props }) {
+export default function DisplayAccounts({ accounts, unit, showBalances, ...props }) {
   return (
     <rb.Accordion {...props}>
       {Object.values(accounts).map(({ account, account_balance: balance, branches }) => (
@@ -14,7 +14,7 @@ export default function DisplayAccounts({ accounts, unit, redactBalances, ...pro
                 <h5 className="mb-0">Account {account}</h5>
               </rb.Col>
               <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-                {valueToUnit(balance, unit, redactBalances)}
+                {valueToUnit(balance, unit, showBalances)}
               </rb.Col>
             </rb.Row>
           </rb.Accordion.Header>
@@ -30,7 +30,7 @@ export default function DisplayAccounts({ accounts, unit, redactBalances, ...pro
                       <h6>{titleize(type)}</h6>
                     </rb.Col>
                     <rb.Col className="d-flex align-items-center justify-content-end">
-                      {valueToUnit(balance, unit, redactBalances)}
+                      {valueToUnit(balance, unit, showBalances)}
                     </rb.Col>
                   </rb.Row>
                   <rb.Row className="w-100">
@@ -52,7 +52,7 @@ export default function DisplayAccounts({ accounts, unit, redactBalances, ...pro
                         {labels && <span className="badge bg-info">{labels}</span>}
                       </rb.Col>
                       <rb.Col className="d-flex align-items-center justify-content-end">
-                        {valueToUnit(amount, unit, redactBalances)}
+                        {valueToUnit(amount, unit, showBalances)}
                       </rb.Col>
                     </rb.Row>))}
                 </article>

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as rb from 'react-bootstrap'
 import { displayDate, valueToUnit } from '../utils'
 
-export default function DisplayUTXOs({ utxos, unit, ...props}) {
+export default function DisplayUTXOs({ utxos, unit, redactBalances, ...props}) {
   return (
     <rb.ListGroup variant="flush" {...props}>
       {utxos.map(utxo => (
@@ -12,7 +12,7 @@ export default function DisplayUTXOs({ utxos, unit, ...props}) {
               <code className="text-break">{utxo.address}</code>
             </rb.Col>
             <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-              {valueToUnit(utxo.value, unit)}
+              {valueToUnit(utxo.value, unit, redactBalances)}
             </rb.Col>
           </rb.Row>
           <rb.Row className="w-100 mt-1">

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as rb from 'react-bootstrap'
 import { displayDate, valueToUnit } from '../utils'
 
-export default function DisplayUTXOs({ utxos, unit, redactBalances, ...props}) {
+export default function DisplayUTXOs({ utxos, unit, showBalances, ...props}) {
   return (
     <rb.ListGroup variant="flush" {...props}>
       {utxos.map(utxo => (
@@ -12,7 +12,7 @@ export default function DisplayUTXOs({ utxos, unit, redactBalances, ...props}) {
               <code className="text-break">{utxo.address}</code>
             </rb.Col>
             <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-              {valueToUnit(utxo.value, unit, redactBalances)}
+              {valueToUnit(utxo.value, unit, showBalances)}
             </rb.Col>
           </rb.Row>
           <rb.Row className="w-100 mt-1">

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,11 @@ export const btcToSats = value => Math.round(parseFloat(value) * 100000000)
 
 export const satsToBtc = value => parseInt(value, 10) / 100000000
 
-export const valueToUnit = (value, unit) => {
+export const valueToUnit = (value, unit, redactValue = false) => {
+  if (redactValue) {
+    return `*** ${unit}`
+  }
+
   const isSats = value === parseInt(value)
   const isBTC = !isSats && typeof(value) === 'string' && value.indexOf('.') > -1
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,8 +28,8 @@ export const btcToSats = value => Math.round(parseFloat(value) * 100000000)
 
 export const satsToBtc = value => parseInt(value, 10) / 100000000
 
-export const valueToUnit = (value, unit, redactValue = false) => {
-  if (redactValue) {
+export const valueToUnit = (value, unit, showValue = true) => {
+  if (!showValue) {
     return `*** ${unit}`
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ export const btcToSats = value => Math.round(parseFloat(value) * 100000000)
 
 export const satsToBtc = value => parseInt(value, 10) / 100000000
 
-export const valueToUnit = (value, unit, showValue = true) => {
+export const valueToUnit = (value, unit, showValue = false) => {
   if (!showValue) {
     return `*** ${unit}`
   }


### PR DESCRIPTION
Adds a simple switch to show / hide wallet balances on the main page.

Hiding sensitive information such as balances is one of the best practices [mentioned in the Bitcoin design guidelines](https://bitcoin.design/guide/onboarding/protecting-a-wallet/#quickly-hiding-balances). 


Nothing fancy, maybe we should make it possible to hide balances app-wide in the future but for now I think this might be good enough.


![Screen_Recording_2022-01-14_at_11 41 41](https://user-images.githubusercontent.com/10026790/149502957-6e2aadeb-4b76-4e15-bed1-08e03141adb7.gif)
