### PR TITLE
feat: add settings screen

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -158,12 +158,12 @@ export default function App() {
                 <rb.Offcanvas.Body>{nav}</rb.Offcanvas.Body>
               </rb.Navbar.Offcanvas>
               {currentWallet && (
-                <rb.Nav className="ms-sm-auto ms-lg-0 d-block order-sm-0">
-                  <Link to="/wallet" className="nav-link d-inline-block">
+                <rb.Nav className="ms-sm-auto ms-lg-0 d-inline-flex flex-row order-sm-0">
+                  <Link to="/wallet" className="px-2 nav-link d-inline-block">
                     {walletDisplayName(currentWallet.name)}
                   </Link>
                   <rb.Navbar.Text> · </rb.Navbar.Text>
-                  <Link to="/earn" className="nav-link d-inline-flex align-items-center">
+                  <Link to="/earn" className="px-2 nav-link d-inline-flex align-items-center">
                     Earn
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -181,22 +181,38 @@ export default function App() {
                     </svg>
                   </Link>
                   {coinjoinInProcess && (
-                    <rb.Navbar.Text>
-                      {' '}
-                      · Joining
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1.5rem"
-                        height="1.5rem"
-                        fill="currentColor"
-                        className="ms-2"
-                        viewBox="0 0 16 16"
-                      >
-                        <path d="M8 9.5a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" />
-                        <path d="M9.5 2c-.9 0-1.75.216-2.501.6A5 5 0 0 1 13 7.5a6.5 6.5 0 1 1-13 0 .5.5 0 0 1 1 0 5.5 5.5 0 0 0 8.001 4.9A5 5 0 0 1 3 7.5a6.5 6.5 0 0 1 13 0 .5.5 0 0 1-1 0A5.5 5.5 0 0 0 9.5 2zM8 3.5a4 4 0 1 0 0 8 4 4 0 0 0 0-8z" />
-                      </svg>
-                    </rb.Navbar.Text>
+                    <>
+                      <rb.Navbar.Text> · </rb.Navbar.Text>
+                      <rb.Navbar.Text className="px-2">
+                        Joining
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="1.5rem"
+                          height="1.5rem"
+                          fill="currentColor"
+                          className="ms-2"
+                          viewBox="0 0 16 16"
+                        >
+                          <path d="M8 9.5a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" />
+                          <path d="M9.5 2c-.9 0-1.75.216-2.501.6A5 5 0 0 1 13 7.5a6.5 6.5 0 1 1-13 0 .5.5 0 0 1 1 0 5.5 5.5 0 0 0 8.001 4.9A5 5 0 0 1 3 7.5a6.5 6.5 0 0 1 13 0 .5.5 0 0 1-1 0A5.5 5.5 0 0 0 9.5 2zM8 3.5a4 4 0 1 0 0 8 4 4 0 0 0 0-8z" />
+                        </svg>
+                      </rb.Navbar.Text>
+                    </>
                   )}
+                  <rb.Navbar.Text> · </rb.Navbar.Text>
+                  <Link to="/settings" className="px-2 nav-link d-inline-flex align-items-center">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="1rem"
+                      height="1rem"
+                      fill="currentColor"
+                      className="ms-0"
+                      viewBox="0 0 16 16"
+                    >
+                      <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z" />
+                      <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z" />
+                    </svg>
+                  </Link>
                 </rb.Nav>
               )}
             </>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -7,6 +7,7 @@ import Send from './Send'
 import Earn from './Earn'
 import Receive from './Receive'
 import CurrentWallet from './CurrentWallet'
+import Settings from './Settings'
 import { getSession, setSession, clearSession } from '../session'
 import { walletDisplayName } from '../utils'
 
@@ -247,6 +248,7 @@ export default function App() {
                   }
                 />
                 <Route path="receive" element={<Receive currentWallet={currentWallet} />} />
+                <Route path="settings" element={<Settings currentWallet={currentWallet} />} />
               </>
             )}
           </Routes>

--- a/src/components/CurrentWallet.jsx
+++ b/src/components/CurrentWallet.jsx
@@ -3,29 +3,19 @@ import { useState, useEffect } from 'react'
 import * as rb from 'react-bootstrap'
 import DisplayAccounts from './DisplayAccounts'
 import DisplayAccountUTXOs from './DisplayAccountUTXOs'
-import { walletDisplayName, BTC, SATS } from '../utils'
+import { walletDisplayName } from '../utils'
 import DisplayUTXOs from './DisplayUTXOs'
 import Balance from './Balance'
+import { useSettings } from '../context/SettingsContext'
 
 export default function CurrentWallet({ currentWallet }) {
   const [walletInfo, setWalletInfo] = useState(null)
-  const [showBalances, setShowBalances] = useState(window.localStorage.getItem('jm-showBalances') === 'true')
-  const [unit, setUnit] = useState(window.localStorage.getItem('jm-unit') || BTC)
   const [fidelityBonds, setFidelityBonds] = useState(null)
   const [utxos, setUtxos] = useState(null)
   const [showUTXO, setShowUTXO] = useState(false)
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
-
-  const setAndPersistShowBalances = (showBalances) => {
-    setShowBalances(showBalances)
-    window.localStorage.setItem('jm-showBalances', showBalances)
-  }
-
-  const setAndPersistUnit = (unit) => {
-    setUnit(unit)
-    window.localStorage.setItem('jm-unit', unit)
-  }
+  const settings = useSettings()
 
   useEffect(() => {
     const abortCtrl = new AbortController()
@@ -73,32 +63,16 @@ export default function CurrentWallet({ currentWallet }) {
         </div>
       )}
       {walletInfo && walletInfo?.total_balance && (
-        <>
-          <p>
-            Total balance: <Balance value={walletInfo.total_balance} unit={unit} showBalance={showBalances} />
-          </p>
-          <rb.Form.Check
-            type="switch"
-            label="Show balances"
-            checked={showBalances}
-            onChange={(e) => setAndPersistShowBalances(e.target.checked)}
-          />
-          <rb.Form.Check
-            type="switch"
-            label={`Display amounts in ${SATS}`}
-            checked={unit === SATS}
-            onChange={(e) => setAndPersistUnit(e.target.checked ? SATS : BTC)}
-            className="mb-4"
-          />
-        </>
+        <p>
+          Total balance:{' '}
+          <Balance value={walletInfo.total_balance} unit={settings.unit} showBalance={settings.showBalance} />
+        </p>
       )}
-      {walletInfo && (
-        <DisplayAccounts accounts={walletInfo.accounts} unit={unit} showBalances={showBalances} className="mb-4" />
-      )}
+      {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} className="mb-4" />}
       {!!fidelityBonds?.length && (
         <div className="mt-5 mb-3 pe-3">
           <h5>Fidelity Bonds</h5>
-          <DisplayUTXOs utxos={fidelityBonds} unit={unit} showBalances={showBalances} className="pe-2" />
+          <DisplayUTXOs utxos={fidelityBonds} className="pe-2" />
         </div>
       )}
       {utxos && (
@@ -112,9 +86,7 @@ export default function CurrentWallet({ currentWallet }) {
           {showUTXO ? 'Hide UTXOs' : 'Show UTXOs'}
         </rb.Button>
       )}
-      {utxos && showUTXO && (
-        <DisplayAccountUTXOs utxos={utxos} unit={unit} showBalances={showBalances} className="mt-3" />
-      )}
+      {utxos && showUTXO && <DisplayAccountUTXOs utxos={utxos} className="mt-3" />}
     </div>
   )
 }

--- a/src/components/DisplayAccountUTXOs.jsx
+++ b/src/components/DisplayAccountUTXOs.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import * as rb from 'react-bootstrap'
 import DisplayUTXOs from './DisplayUTXOs'
+import { useSettings } from '../context/SettingsContext'
 
 const byAccount = (utxos) => {
   const ret = utxos.reduce((res, utxo) => {
@@ -12,7 +13,9 @@ const byAccount = (utxos) => {
   return ret
 }
 
-export default function DisplayAccountUTXOs({ utxos, unit, showBalances, ...props }) {
+export default function DisplayAccountUTXOs({ utxos, ...props }) {
+  const settings = useSettings()
+
   return (
     <rb.Accordion {...props}>
       {Object.entries(byAccount(utxos)).map(([account, utxos]) => (
@@ -21,7 +24,7 @@ export default function DisplayAccountUTXOs({ utxos, unit, showBalances, ...prop
             <h5 className="mb-0">Account {account}</h5>
           </rb.Accordion.Header>
           <rb.Accordion.Body>
-            <DisplayUTXOs utxos={utxos} unit={unit} showBalances={showBalances} />
+            <DisplayUTXOs utxos={utxos} unit={settings.unit} showBalances={settings.showBalance} />
           </rb.Accordion.Body>
         </rb.Accordion.Item>
       ))}

--- a/src/components/DisplayAccounts.jsx
+++ b/src/components/DisplayAccounts.jsx
@@ -3,8 +3,11 @@ import { Link } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import { titleize } from '../utils'
 import Balance from './Balance'
+import { useSettings } from '../context/SettingsContext'
 
-export default function DisplayAccounts({ accounts, unit, showBalances, ...props }) {
+export default function DisplayAccounts({ accounts, ...props }) {
+  const settings = useSettings()
+
   return (
     <rb.Accordion {...props}>
       {Object.values(accounts).map(({ account, account_balance: balance, branches }) => (
@@ -15,7 +18,7 @@ export default function DisplayAccounts({ accounts, unit, showBalances, ...props
                 <h5 className="mb-0">Account {account}</h5>
               </rb.Col>
               <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-                <Balance value={balance} unit={unit} showBalance={showBalances} />
+                <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />
               </rb.Col>
             </rb.Row>
           </rb.Accordion.Header>
@@ -35,7 +38,7 @@ export default function DisplayAccounts({ accounts, unit, showBalances, ...props
                       <h6>{titleize(type)}</h6>
                     </rb.Col>
                     <rb.Col className="d-flex align-items-center justify-content-end">
-                      <Balance value={balance} unit={unit} showBalance={showBalances} />
+                      <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />
                     </rb.Col>
                   </rb.Row>
                   <rb.Row className="w-100">
@@ -56,7 +59,7 @@ export default function DisplayAccounts({ accounts, unit, showBalances, ...props
                         {labels && <span className="badge bg-info">{labels}</span>}
                       </rb.Col>
                       <rb.Col className="d-flex align-items-center justify-content-end">
-                        <Balance value={balance} unit={unit} showBalance={showBalances} />
+                        <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />
                       </rb.Col>
                     </rb.Row>
                   ))}

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -2,8 +2,11 @@ import React from 'react'
 import * as rb from 'react-bootstrap'
 import { displayDate } from '../utils'
 import Balance from './Balance'
+import { useSettings } from '../context/SettingsContext'
 
-export default function DisplayUTXOs({ utxos, unit, showBalances, ...props }) {
+export default function DisplayUTXOs({ utxos, ...props }) {
+  const settings = useSettings()
+
   return (
     <rb.ListGroup variant="flush" {...props}>
       {utxos.map((utxo) => (
@@ -13,7 +16,7 @@ export default function DisplayUTXOs({ utxos, unit, showBalances, ...props }) {
               <code className="text-break">{utxo.address}</code>
             </rb.Col>
             <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-              <Balance value={utxo.value} unit={unit} showBalance={showBalances} />
+              <Balance value={utxo.value} unit={settings.unit} showBalance={settings.showBalance} />
             </rb.Col>
           </rb.Row>
           <rb.Row className="w-100 mt-1">

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import * as rb from 'react-bootstrap'
+import { useSettings, useSettingsDispatch } from '../context/SettingsContext'
+import { SATS, BTC } from '../utils'
+
+export default function Settings({ currentWallet }) {
+  const settings = useSettings()
+  const settingsDispatch = useSettingsDispatch()
+
+  return (
+    <div>
+      <h1>Settings</h1>
+      <rb.Form.Check
+        type="switch"
+        label="Show balances"
+        checked={settings.showBalance}
+        onChange={(e) => settingsDispatch({ showBalance: e.target.checked })}
+      />
+      <rb.Form.Check
+        type="switch"
+        label={`Display amounts in ${SATS}`}
+        checked={settings.unit === SATS}
+        onChange={(e) => settingsDispatch({ unit: e.target.checked ? SATS : BTC })}
+        className="mb-4"
+      />
+    </div>
+  )
+}

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -1,0 +1,51 @@
+import React, { createContext, useReducer, useEffect, useContext } from 'react'
+import { BTC } from '../utils'
+
+const localStorageKey = 'jm-settings'
+
+const initialSettings = {
+  showBalance: false,
+  unit: BTC,
+}
+
+const SettingsContext = createContext()
+
+const settingsReducer = (oldSettings, action) => {
+  const { ...newSettings } = action
+
+  return {
+    ...oldSettings,
+    ...newSettings,
+  }
+}
+
+const SettingsProvider = ({ children }) => {
+  const [settings, dispatch] = useReducer(
+    settingsReducer,
+    JSON.parse(window.localStorage.getItem(localStorageKey)) || initialSettings
+  )
+
+  useEffect(() => {
+    window.localStorage.setItem(localStorageKey, JSON.stringify(settings))
+  }, [settings])
+
+  return <SettingsContext.Provider value={{ settings, dispatch }}>{children}</SettingsContext.Provider>
+}
+
+const useSettings = () => {
+  const context = useContext(SettingsContext)
+  if (context === undefined) {
+    throw new Error('useSettings must be used within a SettingsProvider')
+  }
+  return context.settings
+}
+
+const useSettingsDispatch = () => {
+  const context = useContext(SettingsContext)
+  if (context === undefined) {
+    throw new Error('useSettingsDispatch must be used within a SettingsProvider')
+  }
+  return context.dispatch
+}
+
+export { SettingsProvider, useSettings, useSettingsDispatch }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter } from 'react-router-dom'
 import App from './components/App'
+import { SettingsProvider } from './context/SettingsContext'
 import reportWebVitals from './reportWebVitals'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import '@ibunker/bitcoin-react/dist/index.css'
@@ -9,7 +10,9 @@ import './index.css'
 
 ReactDOM.render(
   <BrowserRouter>
-    <App />
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
   </BrowserRouter>,
   document.getElementById('root')
 )


### PR DESCRIPTION
Adds a simple settings screen and moves the "show balance" and "display amounts in sats" switches there. Nothing fancy yet because I wanted to keep the pull request as small as possible. We can do UI improvements later.

The main addition is a [React Context](https://reactjs.org/docs/context.html) that persists settings in local storage and keeps those settings in sync across the app. 

## Read Settings in a Component

``` js
import { useSettings } from '../context/SettingsContext'

/* later in the component */

const settings = useSettings() // e.g. { unit: "sats", showBalance: false }

<p>Unit: {settings.unit}</p> // read settings; when they change this component will be re-rendered
```

## Update Settings from a Component

``` js
import { useSettingsDispatch } from '../context/SettingsContext'

/* later in the component */

const settingsDispatch = useSettingsDispatch()

settingsDispatch({ unit: "BTC" }) // update that value of the settings; persists them in local storage and re-rendering all components that depend on them
```

Maybe we want to have more fine granular settings instead of having everything in one big JSON in local storage. Then we could have more control over what components get re-rendered when a single setting changes. But for now I feel like it is good enough.

## 📸 

![Screenshot 2022-01-27 at 16 57 07](https://user-images.githubusercontent.com/10026790/151395267-8cd8b964-05f4-448c-aa56-9d2998a5f9e2.png)
![Screenshot 2022-01-27 at 16 57 14](https://user-images.githubusercontent.com/10026790/151395273-f3c4bf42-967c-4dac-9c61-69d82d5f58d3.png)

