### PR TITLE
fix: initialize local storage with default values

### DIFF
--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -1,10 +1,9 @@
 import React, { createContext, useReducer, useEffect, useContext } from 'react'
 import { BTC } from '../utils'
 
-const localStorageKey = 'jm-settings'
+const localStorageKey = window.JM.SETTINGS_STORE_KEY
 
 const initialSettings = {
-  theme: 'light',
   showBalance: false,
   unit: BTC,
 }

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -4,6 +4,7 @@ import { BTC } from '../utils'
 const localStorageKey = 'jm-settings'
 
 const initialSettings = {
+  theme: 'light',
   showBalance: false,
   unit: BTC,
 }
@@ -22,7 +23,7 @@ const settingsReducer = (oldSettings, action) => {
 const SettingsProvider = ({ children }) => {
   const [settings, dispatch] = useReducer(
     settingsReducer,
-    JSON.parse(window.localStorage.getItem(localStorageKey)) || initialSettings
+    Object.assign({}, initialSettings, JSON.parse(window.localStorage.getItem(localStorageKey)))
   )
 
   useEffect(() => {


### PR DESCRIPTION
Always take default values into account when initializing the settings for the first time, as it might already contain some values (e.g. from `prefers-color-scheme` handling)

Fixes #32.