### PR TITLE
feat: do not autocomplete password when creating wallet

### DIFF
--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -96,7 +96,13 @@ export default function CreateWallet({ currentWallet, startWallet }) {
         </rb.Form.Group>
         <rb.Form.Group className="mb-3" controlId="password">
           <rb.Form.Label>Password</rb.Form.Label>
-          <rb.Form.Control name="password" type="password" style={{ maxWidth: '20em' }} required />
+          <rb.Form.Control
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            style={{ maxWidth: '20em' }}
+            required
+          />
           <rb.Form.Control.Feedback type="invalid">Please set a password.</rb.Form.Control.Feedback>
         </rb.Form.Group>
         <rb.Button variant="dark" type="submit" disabled={isCreating}>


### PR DESCRIPTION
There are some pros and cons for password auto-completion, however on the create wallet page it should propably not prefill with an existing password - what do you think? 
Most modern browsers will optionally open a dialog to choose from.

Before:
![image](https://user-images.githubusercontent.com/3358649/152019555-efe43db7-3e0f-4c64-8b24-259121f9a216.png)

After:
![image](https://user-images.githubusercontent.com/3358649/152019249-3a360931-7877-4c5c-b4cf-b48cd4b86bcf.png)


See [info about autocomplete attribute and login fields from Mozilla](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields)