### PR TITLE
docs: Docker README improvements

### DIFF
--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -43,7 +43,7 @@ In order to incorporate the current contents of the master branch, simply rebuil
 docker image rm regtest_joinmarket:latest regtest_joinmarket2:latest
 
 # rebuilding the imags with contents of current master branch
-docker-compose build
+docker-compose build --no-cache
 ```
 
 ## Debugging

--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -1,7 +1,7 @@
-# Docker setup for running joinmarket in regtest mode
+# Docker setup for running JoinMarket in regtest mode
 
 This setup will help you set up a regtest environment quickly.
-It starts two JoinMarket container, hence not only API calls but also actual CoinJoin transactions can be tested.
+It starts two JoinMarket containers, hence not only API calls but also actual CoinJoin transactions can be tested.
 
 ## Commands
 


### PR DESCRIPTION
Minor typo fixes and an update for the rebuild command: I had to use the `--no-cache` option to get the current latest master version of JoinMarket, without it it was using the previous, cached version of their master.