### PR TITLE
fix: change navbar collapse to offcanvas

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -122,6 +122,7 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
 
   return (
     <rb.Navbar
+      id="mainNav"
       bg={settings.theme === 'light' ? 'white' : 'dark'}
       sticky="top"
       expand="md"

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -142,20 +142,33 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
           <>
             {!currentWallet ? (
               <>
-                <Link to="/" className="navbar-brand nav-link d-flex align-items-center" style={{ height: height }}>
+                <Link
+                  to="/"
+                  className="navbar-brand nav-link d-flex align-items-center ps-0 ps-sm-2 ps-xl-0"
+                  style={{ height: height }}
+                >
                   <Sprite symbol="logo" width="30" height="30" className="d-inline-block align-top" />
                   <span className="ms-2">JoinMarket</span>
                 </Link>
                 <rb.Navbar.Toggle className="border-0" />
-                <rb.Navbar.Collapse>
-                  <rb.Nav className="ms-auto">
-                    <rb.Nav.Item>
-                      <Link to="/create-wallet" onClick={() => isExpanded && setIsExpanded(false)} className="nav-link">
-                        Create Wallet
-                      </Link>
-                    </rb.Nav.Item>
-                  </rb.Nav>
-                </rb.Navbar.Collapse>
+                <rb.Navbar.Offcanvas className={`navbar-${settings.theme}`} placement="end">
+                  <rb.Offcanvas.Header>
+                    <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
+                  </rb.Offcanvas.Header>
+                  <rb.Offcanvas.Body>
+                    <rb.Nav className="ms-auto">
+                      <rb.Nav.Item>
+                        <Link
+                          to="/create-wallet"
+                          onClick={() => isExpanded && setIsExpanded(false)}
+                          className="nav-link"
+                        >
+                          Create Wallet
+                        </Link>
+                      </rb.Nav.Item>
+                    </rb.Nav>
+                  </rb.Offcanvas.Body>
+                </rb.Navbar.Offcanvas>
               </>
             ) : (
               <>
@@ -181,15 +194,9 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
                 </rb.Nav>
                 <rb.Navbar.Toggle className="border-0" />
                 <rb.Navbar.Offcanvas className={`navbar-${settings.theme}`} placement="end">
-                  {settings.theme === 'dark' ? (
-                    <rb.Offcanvas.Header closeButton closeVariant="white">
-                      <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
-                    </rb.Offcanvas.Header>
-                  ) : (
-                    <rb.Offcanvas.Header closeButton>
-                      <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
-                    </rb.Offcanvas.Header>
-                  )}
+                  <rb.Offcanvas.Header>
+                    <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
+                  </rb.Offcanvas.Header>
                   <rb.Offcanvas.Body>
                     <CenterNav makerRunning={makerRunning} onClick={() => setIsExpanded(!isExpanded)} />
                     <TrailingNav coinjoinInProcess={coinjoinInProcess} onClick={() => setIsExpanded(!isExpanded)} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -150,7 +150,11 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
                   <Sprite symbol="logo" width="30" height="30" className="d-inline-block align-top" />
                   <span className="ms-2">JoinMarket</span>
                 </Link>
-                <rb.Navbar.Toggle className="border-0" />
+                <div className="d-flex d-md-none align-items-center">
+                  <rb.Navbar.Toggle id="mainNavToggle">
+                    <span>Menu</span>
+                  </rb.Navbar.Toggle>
+                </div>
                 <rb.Navbar.Offcanvas className={`navbar-${settings.theme}`} placement="end">
                   <rb.Offcanvas.Header>
                     <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
@@ -192,7 +196,11 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
                     </NavLink>
                   </rb.Nav.Item>
                 </rb.Nav>
-                <rb.Navbar.Toggle className="border-0" />
+                <div className="d-flex d-md-none align-items-center">
+                  <rb.Navbar.Toggle id="mainNavToggle">
+                    <span>Menu</span>
+                  </rb.Navbar.Toggle>
+                </div>
                 <rb.Navbar.Offcanvas className={`navbar-${settings.theme}`} placement="end">
                   <rb.Offcanvas.Header>
                     <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -93,7 +93,8 @@ const TrailingNav = ({ coinjoinInProcess, onClick }) => {
             'nav-link d-flex align-items-center justify-content-center px-0' + (isActive ? ' active' : '')
           }
         >
-          <Sprite symbol="gear" width="30" height="30" />
+          <Sprite symbol="gear" width="30" height="30" className="d-none d-md-inline-block" />
+          <span className="d-inline-block d-md-none">Settings</span>
         </NavLink>
       </rb.Nav.Item>
       <rb.Nav.Item className="d-flex align-items-stretch">
@@ -104,7 +105,8 @@ const TrailingNav = ({ coinjoinInProcess, onClick }) => {
             'nav-link d-flex align-items-center justify-content-center px-0' + (isActive ? ' active' : '')
           }
         >
-          <Sprite symbol="grid" width="30" height="30" />
+          <Sprite symbol="grid" width="30" height="30" className="d-none d-md-inline-block" />
+          <span className="d-inline-block d-md-none">Wallets</span>
         </NavLink>
       </rb.Nav.Item>
     </rb.Nav>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -31,6 +31,86 @@ const ActivityIndicator = ({ isOn }) => {
   return <span className={`activity-indicator ${isOn ? 'activity-indicator-on' : 'activity-indicator-off'}`} />
 }
 
+const CenterNav = ({ makerRunning, onClick }) => {
+  return (
+    <rb.Nav className="justify-content-center align-items-stretch">
+      <rb.Nav.Item className="d-flex align-items-stretch">
+        <NavLink
+          to="/send"
+          onClick={onClick}
+          className={({ isActive }) =>
+            'center-nav-link nav-link d-flex align-items-center justify-content-center' + (isActive ? ' active' : '')
+          }
+        >
+          Send
+        </NavLink>
+      </rb.Nav.Item>
+      <rb.Nav.Item className="d-flex align-items-stretch">
+        <NavLink
+          to="/receive"
+          onClick={onClick}
+          className={({ isActive }) =>
+            'center-nav-link nav-link d-flex align-items-center justify-content-center' + (isActive ? ' active' : '')
+          }
+        >
+          Receive
+        </NavLink>
+      </rb.Nav.Item>
+      <rb.Nav.Item className="d-flex align-items-stretch">
+        <NavLink
+          to="/earn"
+          onClick={onClick}
+          className={({ isActive }) =>
+            'center-nav-link nav-link d-flex align-items-center justify-content-center' + (isActive ? ' active' : '')
+          }
+        >
+          <div className="d-flex align-items-start">
+            Earn
+            <ActivityIndicator isOn={makerRunning} />
+          </div>
+        </NavLink>
+      </rb.Nav.Item>
+    </rb.Nav>
+  )
+}
+
+const TrailingNav = ({ coinjoinInProcess, onClick }) => {
+  return (
+    <rb.Nav className="justify-content-center align-items-stretch">
+      {coinjoinInProcess && (
+        <rb.Nav.Item className="d-flex align-items-center justify-content-center pe-2">
+          <div className="d-flex align-items-center px-0">
+            <rb.Navbar.Text>Joining</rb.Navbar.Text>
+            <Sprite symbol="joining" width="30" height="30" className="p-1 navbar-text" />
+          </div>
+        </rb.Nav.Item>
+      )}
+      <rb.Nav.Item className="d-flex align-items-stretch">
+        <NavLink
+          to="/settings"
+          onClick={onClick}
+          className={({ isActive }) =>
+            'nav-link d-flex align-items-center justify-content-center px-0' + (isActive ? ' active' : '')
+          }
+        >
+          <Sprite symbol="gear" width="30" height="30" />
+        </NavLink>
+      </rb.Nav.Item>
+      <rb.Nav.Item className="d-flex align-items-stretch">
+        <NavLink
+          to="/"
+          onClick={onClick}
+          className={({ isActive }) =>
+            'nav-link d-flex align-items-center justify-content-center px-0' + (isActive ? ' active' : '')
+          }
+        >
+          <Sprite symbol="grid" width="30" height="30" />
+        </NavLink>
+      </rb.Nav.Item>
+    </rb.Nav>
+  )
+}
+
 export default function Navbar({ connectionError, makerRunning, coinjoinInProcess }) {
   const settings = useSettings()
   const currentWallet = useCurrentWallet()
@@ -97,81 +177,29 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
                   </rb.Nav.Item>
                 </rb.Nav>
                 <rb.Navbar.Toggle className="border-0" />
-                <rb.Navbar.Collapse className="flex-1 flex-grow-0 align-items-stretch">
-                  <rb.Nav className="justify-content-center align-items-stretch">
-                    <rb.Nav.Item className="d-flex align-items-stretch">
-                      <NavLink
-                        to="/send"
-                        onClick={() => isExpanded && setIsExpanded(false)}
-                        className={({ isActive }) =>
-                          'center-nav-link nav-link d-flex align-items-center justify-content-center' +
-                          (isActive ? ' active' : '')
-                        }
-                      >
-                        Send
-                      </NavLink>
-                    </rb.Nav.Item>
-                    <rb.Nav.Item className="d-flex align-items-stretch">
-                      <NavLink
-                        to="/receive"
-                        onClick={() => isExpanded && setIsExpanded(false)}
-                        className={({ isActive }) =>
-                          'center-nav-link nav-link d-flex align-items-center justify-content-center' +
-                          (isActive ? ' active' : '')
-                        }
-                      >
-                        Receive
-                      </NavLink>
-                    </rb.Nav.Item>
-                    <rb.Nav.Item className="d-flex align-items-stretch">
-                      <NavLink
-                        to="/earn"
-                        onClick={() => isExpanded && setIsExpanded(false)}
-                        className={({ isActive }) =>
-                          'center-nav-link  nav-link d-flex align-items-center justify-content-center' +
-                          (isActive ? ' active' : '')
-                        }
-                      >
-                        <div className="d-flex align-items-start">
-                          Earn
-                          <ActivityIndicator isOn={makerRunning} />
-                        </div>
-                      </NavLink>
-                    </rb.Nav.Item>
-                  </rb.Nav>
-                </rb.Navbar.Collapse>
-                <rb.Navbar.Collapse className="flex-1">
-                  <span className="ms-auto">
-                    <rb.Nav className="align-items-center">
-                      {coinjoinInProcess && (
-                        <rb.Nav.Item className="d-flex align-items-center pe-2">
-                          <>
-                            <rb.Navbar.Text>Joining</rb.Navbar.Text>
-                            <Sprite symbol="joining" width="30" height="30" className="text-secondary p-1" />
-                          </>
-                        </rb.Nav.Item>
-                      )}
-                      <rb.Nav.Item className="d-flex">
-                        <NavLink
-                          to="/settings"
-                          onClick={() => isExpanded && setIsExpanded(false)}
-                          className={({ isActive }) => 'nav-link px-0' + (isActive ? ' active' : '')}
-                        >
-                          <Sprite symbol="gear" width="30" height="30" />
-                        </NavLink>
-                      </rb.Nav.Item>
-                      <rb.Nav.Item className="d-flex">
-                        <NavLink
-                          to="/"
-                          onClick={() => isExpanded && setIsExpanded(false)}
-                          className={({ isActive }) => 'nav-link px-0' + (isActive ? ' active' : '')}
-                        >
-                          <Sprite symbol="grid" width="30" height="30" />
-                        </NavLink>
-                      </rb.Nav.Item>
-                    </rb.Nav>
-                  </span>
-                </rb.Navbar.Collapse>
+                <rb.Navbar.Offcanvas className={`navbar-${settings.theme}`} placement="end">
+                  {settings.theme === 'dark' ? (
+                    <rb.Offcanvas.Header closeButton closeVariant="white">
+                      <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
+                    </rb.Offcanvas.Header>
+                  ) : (
+                    <rb.Offcanvas.Header closeButton>
+                      <rb.Offcanvas.Title>JoinMarket Web UI</rb.Offcanvas.Title>
+                    </rb.Offcanvas.Header>
+                  )}
+                  <rb.Offcanvas.Body>
+                    <CenterNav makerRunning={makerRunning} onClick={() => setIsExpanded(!isExpanded)} />
+                    <TrailingNav coinjoinInProcess={coinjoinInProcess} onClick={() => setIsExpanded(!isExpanded)} />
+                  </rb.Offcanvas.Body>
+                </rb.Navbar.Offcanvas>
+                <rb.Container className="d-none d-md-flex flex-1 flex-grow-0 align-items-stretch">
+                  <CenterNav makerRunning={makerRunning} />
+                </rb.Container>
+                <rb.Container className="d-none d-md-flex flex-1 align-items-stretch">
+                  <div className="ms-auto d-flex align-items-stretch">
+                    <TrailingNav coinjoinInProcess={coinjoinInProcess} />
+                  </div>
+                </rb.Container>
               </>
             )}
           </>

--- a/src/components/Sprite.jsx
+++ b/src/components/Sprite.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function Sprite({ symbol, className, ...props }) {
   return (
-    <svg role="img" className={`d-inline-block sprite sprite-${symbol} ${className}`} {...props}>
+    <svg role="img" className={`d-inline-block sprite sprite-${symbol}${className ? ` ${className}` : ''}`} {...props}>
       <use href={`${process.env.PUBLIC_URL}/sprite.svg#${symbol}`}></use>
     </svg>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -249,6 +249,11 @@ main {
     padding: 12px 0 10px 0 !important;
     border-bottom: 2px solid black;
   }
+
+  .offcanvas,
+  .offcanvas-backdrop {
+    display: none;
+  }
 }
 
 .activity-indicator {

--- a/src/index.css
+++ b/src/index.css
@@ -211,6 +211,68 @@ body,
   height: 76px;
 }
 
+#mainNavToggle {
+  --line-thickness: 2px;
+  --transition-easing: ease-in-out;
+  --transition-duration: 0.25s;
+  --button-width: 40px;
+  --button-height: 40px;
+  --button-padding: 7px;
+  --icon-size: 1.5rem;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 var(--button-width);
+  height: var(--button-height);
+  border: 0;
+  padding: var(--button-padding);
+  box-shadow: none;
+  color: inherit;
+}
+
+#mainNavToggle span {
+  position: relative;
+  display: inline-block;
+  width: calc(var(--button-width) - var(--button-padding) * 2);
+  height: calc(var(--button-height) - (var(--button-padding) * 2) - (var(--line-thickness) * 4));
+  border-top: var(--line-thickness) solid;
+  border-bottom: var(--line-thickness) solid;
+  border-color: currentColor !important;
+  font-size: 0;
+  transition: all var(--transition-duration) var(--transition-easing);
+}
+
+#mainNavToggle span:before,
+#mainNavToggle span:after {
+  position: absolute;
+  display: block;
+  content: '';
+  width: 100%;
+  height: var(--line-thickness);
+  top: 50%;
+  left: 50%;
+  background: currentColor;
+  transform: translate(-50%, -50%);
+  transition: transform var(--transition-duration) var(--transition-easing);
+}
+
+#mainNavToggle:hover span {
+  /* color: var(--btcpay-header-text); */
+}
+
+#mainNavToggle:not(.collapsed) span {
+  border-color: transparent !important;
+}
+
+#mainNavToggle:not(.collapsed) span:before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+#mainNavToggle:not(.collapsed) span:after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
 main {
   flex: 1;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -202,6 +202,15 @@ body,
   flex-direction: column;
 }
 
+#mainNav {
+  z-index: 1050;
+}
+
+#mainNav,
+.offcanvas-header {
+  height: 76px;
+}
+
 main {
   flex: 1;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -225,7 +225,7 @@ main {
 
 /* Start Navbar Styles */
 
-.center-nav-link {
+#mainNav .nav-link {
   font-weight: 600 !important;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -257,10 +257,6 @@ body,
   transition: transform var(--transition-duration) var(--transition-easing);
 }
 
-#mainNavToggle:hover span {
-  /* color: var(--btcpay-header-text); */
-}
-
 #mainNavToggle:not(.collapsed) span {
   border-color: transparent !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -332,3 +332,7 @@ main {
 :root[data-theme='dark'] code {
   color: var(--bs-gray-300);
 }
+
+:root[data-theme='dark'] .offcanvas {
+  background-color: var(--bs-gray-900);
+}


### PR DESCRIPTION
Changes the mobile version of the navbar from a [collapse](https://getbootstrap.com/docs/5.0/components/collapse/) to an [offcanvas](https://getbootstrap.com/docs/5.0/components/offcanvas/) drawer.

It would be nice to show the offcanvas drawer under the navbar somehow but I couldn't find a good way of doing that (except maybe hardcoding a margin but not sure how good that would be).