### PR TITLE
fix: navbar padding

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -182,7 +182,7 @@ export default function Navbar({ connectionError, makerRunning, coinjoinInProces
                       to="/wallet"
                       style={{ height: height }}
                       className={({ isActive }) =>
-                        'center-nav-link nav-link d-flex align-items-center' + (isActive ? ' active' : '')
+                        'leading-nav-link nav-link d-flex align-items-center' + (isActive ? ' active' : '')
                       }
                     >
                       <>

--- a/src/index.css
+++ b/src/index.css
@@ -300,11 +300,20 @@ main {
 
   .center-nav-link {
     min-width: 80px;
-    padding: auto 0 12px 0 !important;
+    padding: 8px 0 !important;
   }
 
   .center-nav-link.active {
-    padding: 12px 0 10px 0 !important;
+    padding: 8px 0 6px 0 !important;
+    border-bottom: 2px solid black;
+  }
+
+  .leading-nav-link {
+    padding: 8px !important;
+  }
+
+  .leading-nav-link.active {
+    padding: 8px 8px 6px 8px !important;
     border-bottom: 2px solid black;
   }
 


### PR DESCRIPTION
Fixes inconsistent padding in the navbar which caused ugly jumping effects when switching from the non-active to the active state of the wallet preview in the navbar.

🎥 **Before:**

![Screen_Recording_2022-02-04_at_09 29 03](https://user-images.githubusercontent.com/10026790/152496687-cfeae541-8b6e-46e0-9c0d-645fde5b872d.gif)

🎥 **After:**

![Screen_Recording_2022-02-04_at_09 28 37](https://user-images.githubusercontent.com/10026790/152496678-7a14f8f9-9a41-402d-b47b-901535cefdf3.gif)

