### PR TITLE
fix: display amount of addresses correctly

### DIFF
--- a/src/components/DisplayAccounts.jsx
+++ b/src/components/DisplayAccounts.jsx
@@ -59,7 +59,7 @@ export default function DisplayAccounts({ accounts, ...props }) {
                         {labels && <span className="badge bg-info">{labels}</span>}
                       </rb.Col>
                       <rb.Col className="d-flex align-items-center justify-content-end">
-                        <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />
+                        <Balance value={amount} unit={settings.unit} showBalance={settings.showBalance} />
                       </rb.Col>
                     </rb.Row>
                   ))}


### PR DESCRIPTION
Quick fix to display the correct amount per address.

Small bug seems to have been introduced while refactoring that will led to the balance of addresses always end up displaying the whole account balance.