### PR TITLE
Specter Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@
 .env.production.local
 
 npm-debug.log*
+
+# python stuff
+.env
+joinmarketwebui/static
+__pycache__

--- a/README.md
+++ b/README.md
@@ -128,3 +128,18 @@ npm install && npm start
 ## 👨‍💻 Developing
 
 See [DEVELOPING.md](DEVELOPING.md) for developer docs.
+
+## Specter integration
+
+
+```
+npm run build
+virtualenv --python=python3 .env
+# . ./.env/bin/activate
+# pip3 install -r requirements.txt --pre
+. ../specter-desktop/.env/bin/activate
+python3 -m cryptoadvance.specter server --config DevelopmentConfig --debug
+# open browser https://localhost:25441
+# choose service --> Joinmarket Webui
+```
+

--- a/joinmarketwebui/controller.py
+++ b/joinmarketwebui/controller.py
@@ -1,0 +1,37 @@
+import logging
+from flask import Flask, Response, redirect, render_template, request, url_for, flash
+from flask_login import login_required
+
+
+from cryptoadvance.specter.util.common import str2bool
+from cryptoadvance.specter.services.controller import user_secret_decrypted_required
+from .service import JoinmarketwebuiService
+
+
+from flask import Flask, send_from_directory, request
+from flask_cors import CORS
+import os
+import requests
+
+
+"""
+    Empty placeholder just so the dummyservice/static folder can be wired up to retrieve its img
+"""
+
+logger = logging.getLogger(__name__)
+
+joinmarketwebui_enpoint = JoinmarketwebuiService.blueprint
+CORS()
+
+@joinmarketwebui_enpoint.route("/index.html")
+def index():
+
+    embed = str2bool(request.args.get('embed'))
+    if not embed:
+        return render_template(
+            "joinmarketwebui/index.html", embed = True
+        )
+    else:
+        return render_template(
+            "joinmarketwebui/index_embedded.jinja", emded=False
+        )

--- a/joinmarketwebui/service.py
+++ b/joinmarketwebui/service.py
@@ -1,0 +1,15 @@
+from cryptoadvance.specter.services.service import Service, devstatus_alpha
+
+
+class JoinmarketwebuiService(Service):
+    id = "joinmarketwebui"
+    name = "Joinmarket WebUI"
+    icon = "mstile-310x310.png"
+    logo = "mstile-70x70.png"
+    desc = "A WebUI for joinmarket."
+    has_blueprint = True
+    blueprint_module = "joinmarketwebui.controller"
+    devstatus = devstatus_alpha
+
+    # TODO: As more Services are integrated, we'll want more robust categorization and sorting logic
+    sort_priority = 2

--- a/joinmarketwebui/templates/joinmarketwebui/index.html
+++ b/joinmarketwebui/templates/joinmarketwebui/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/svc/joinmarketwebui/static/apple-touch-icon.png">
+    <link rel="icon" href="/svc/joinmarketwebui/static/favicon.svg">
+    <link rel="manifest" href="/svc/joinmarketwebui/static/site.webmanifest">
+    <link rel="mask-icon" href="/svc/joinmarketwebui/static/safari-pinned-tab.svg" color="#000000">
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="theme-color" content="#ffffff">
+    <title>JoinMarket</title>
+    <script>window.JM = { SETTINGS_STORE_KEY: "jm-settings", THEMES: ["light", "dark"], THEME_ROOT_ATTR: "data-theme" }; const settings = JSON.parse(window.localStorage.getItem(JM.SETTINGS_STORE_KEY) || "{}"), userColorMode = settings.theme, systemColorMode = window.matchMedia("(prefers-color-scheme: dark)").matches ? JM.THEMES[1] : JM.THEMES[0], initialColorMode = JM.THEMES.includes(userColorMode) ? userColorMode : systemColorMode; if (!userColorMode) { const e = Object.assign(settings, { theme: initialColorMode }); window.localStorage.setItem(JM.SETTINGS_STORE_KEY, JSON.stringify(e)) } document.documentElement.setAttribute(JM.THEME_ROOT_ATTR, initialColorMode)</script>
+    <script defer="defer" src="/svc/joinmarketwebui/static/js/main.4e04ed91.js"></script>
+    <link href="/svc/joinmarketwebui/static/css/main.f8568812.css" rel="stylesheet">
+</head>
+
+<body><noscript>You need to enable JavaScript to run this app.</noscript>
+    <div>
+        <a style="color: #e21358;" href="?embed={% if embed %}true{% else %}false{% endif %}">Click here to (un)embed</a>
+    </div>
+    <div id="root"></div>
+</body>
+
+</html>

--- a/joinmarketwebui/templates/joinmarketwebui/index.jinja
+++ b/joinmarketwebui/templates/joinmarketwebui/index.jinja
@@ -1,0 +1,1 @@
+{% include 'joinmarketwebui/index.html' %}

--- a/joinmarketwebui/templates/joinmarketwebui/index_embedded.jinja
+++ b/joinmarketwebui/templates/joinmarketwebui/index_embedded.jinja
@@ -1,0 +1,7 @@
+
+{% extends "base.jinja" %}
+
+{% block main %}
+{% include "joinmarketwebui/index.jinja" %}
+
+{% endblock %}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=16.0.0",
     "npm": ">=7.0.0"
   },
-  "homepage": ".",
+  "homepage": "/svc/joinmarketwebui",
   "devDependencies": {
     "@ibunker/bitcoin-react": "^0.1.13-cd",
     "@popperjs/core": "^2.11.2",
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "rm -rf joinmarketwebui/static && react-scripts build && mv build joinmarketwebui/static && mv joinmarketwebui/static/static/* joinmarketwebui/static",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "postinstall": "husky install",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+cryptoadvance.specter==1.8.1


### PR DESCRIPTION
With our newest `v1.8.x` release there is the possibility to integrate via extensions. Components which are client-only are specifically easy to integrate. I spend about 2h creating this. I don't had a joinmarket-dev-env running so this might even not work at all and i'm also not very familiar with react.

Here is a gif showing how it looks like. In the `README.md` at the very bottom, it's described how to get it to run.

![joinmwebui-specter](https://user-images.githubusercontent.com/117085/152546239-ac8f833d-b977-4f4b-bda4-bf6e7a774951.gif)

What do you think about such an integration? Would it be interesting to collaborate here?
