### PR TITLE
fix: hidden balance icon alignment and size

### DIFF
--- a/src/components/Balance.jsx
+++ b/src/components/Balance.jsx
@@ -26,8 +26,8 @@ export default function Balance({ value, unit, showBalance = false }) {
       <span className={styles['balance-wrapper']}>
         <span className={styles['balance']}>
           <span className={styles['text']}>*****</span>
-          <span className="text-muted">
-            <Sprite symbol="hide" width="20px" height="20px" className="ps-1" />
+          <span className="text-muted d-inline-flex align-items-center">
+            <Sprite symbol="hide" width="1.2em" height="1.2em" className="ps-1" />
           </span>
         </span>
       </span>


### PR DESCRIPTION
Properly centers the "hidden" icon and size it relative to the current active font size.

This is important for when balances are shown in larger font such as in the "privacy level screen" in #51.