### PR TITLE
fix: brighten loading indicator in dark theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -417,3 +417,8 @@ main {
 :root[data-theme='dark'] .offcanvas {
   background-color: var(--bs-gray-900);
 }
+
+:root[data-theme='dark'] .spinner-border {
+  border-color: var(--bs-white) !important;
+  border-right-color: transparent !important;
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3358649/152615131-53ea3a81-0a70-4b88-b8da-9a9f97a986da.png)


After:
![image](https://user-images.githubusercontent.com/3358649/152614861-5d98ff3d-4e95-4c18-b8be-6a58c9d0bf3b.png)
