### PR TITLE
feat: add connection indicator to footer

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -116,7 +116,8 @@ export default function App() {
         <rb.Container>
           {connectionError ? (
             <div class="d-flex justify-content-center">
-              <span class="text-danger mx-1">•</span>Disconnected
+              <span class="text-danger mx-1">•</span>
+              <span className="text-secondary">Disconnected</span>
             </div>
           ) : (
             <div class="d-flex justify-content-center">

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -113,47 +113,58 @@ export default function App() {
         )}
       </rb.Container>
       <rb.Nav as="footer" className="border-top py-2">
-        <rb.Container className="d-flex justify-content-center">
-          <rb.Nav.Item>
-            <a
-              href="https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/docs"
-              target="_blank"
-              rel="noreferrer"
-              className="nav-link text-secondary"
-            >
-              Docs
-            </a>
-          </rb.Nav.Item>
-          <rb.Nav.Item>
-            <a
-              href="https://github.com/JoinMarket-Org/joinmarket-clientserver#wallet-features"
-              target="_blank"
-              rel="noreferrer"
-              className="nav-link text-secondary"
-            >
-              Features
-            </a>
-          </rb.Nav.Item>
-          <rb.Nav.Item>
-            <a
-              href="https://github.com/JoinMarket-Org/joinmarket-clientserver"
-              target="_blank"
-              rel="noreferrer"
-              className="nav-link text-secondary"
-            >
-              GitHub
-            </a>
-          </rb.Nav.Item>
-          <rb.Nav.Item>
-            <a
-              href="https://twitter.com/joinmarket"
-              target="_blank"
-              rel="noreferrer"
-              className="nav-link text-secondary"
-            >
-              Twitter
-            </a>
-          </rb.Nav.Item>
+        <rb.Container>
+          {connectionError ? (
+            <div class="d-flex justify-content-center">
+              <span class="text-danger mx-1">•</span>Disconnected
+            </div>
+          ) : (
+            <div class="d-flex justify-content-center">
+              <span class="text-success mx-1">•</span>Connected
+            </div>
+          )}
+          <div class="d-flex justify-content-center">
+            <rb.Nav.Item>
+              <a
+                href="https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/docs"
+                target="_blank"
+                rel="noreferrer"
+                className="nav-link text-secondary"
+              >
+                Docs
+              </a>
+            </rb.Nav.Item>
+            <rb.Nav.Item>
+              <a
+                href="https://github.com/JoinMarket-Org/joinmarket-clientserver#wallet-features"
+                target="_blank"
+                rel="noreferrer"
+                className="nav-link text-secondary"
+              >
+                Features
+              </a>
+            </rb.Nav.Item>
+            <rb.Nav.Item>
+              <a
+                href="https://github.com/JoinMarket-Org/joinmarket-clientserver"
+                target="_blank"
+                rel="noreferrer"
+                className="nav-link text-secondary"
+              >
+                GitHub
+              </a>
+            </rb.Nav.Item>
+            <rb.Nav.Item>
+              <a
+                href="https://twitter.com/joinmarket"
+                target="_blank"
+                rel="noreferrer"
+                className="nav-link text-secondary"
+              >
+                Twitter
+              </a>
+            </rb.Nav.Item>
+          </div>
         </rb.Container>
       </rb.Nav>
     </>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -120,7 +120,8 @@ export default function App() {
             </div>
           ) : (
             <div class="d-flex justify-content-center">
-              <span class="text-success mx-1">•</span>Connected
+              <span class="text-success mx-1">•</span>
+              <span className="text-secondary">Connected</span>
             </div>
           )}
           <div class="d-flex justify-content-center">

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -120,7 +120,7 @@ export default function App() {
               <span className="text-secondary">Disconnected</span>
             </div>
           ) : (
-            <div class="d-flex justify-content-center">
+            <div class="d-flex justify-content-center pt-2">
               <span class="text-success mx-1">•</span>
               <span className="text-secondary">Connected</span>
             </div>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -115,7 +115,7 @@ export default function App() {
       <rb.Nav as="footer" className="border-top py-2">
         <rb.Container>
           {connectionError ? (
-            <div class="d-flex justify-content-center">
+            <div class="d-flex justify-content-center pt-2">
               <span class="text-danger mx-1">•</span>
               <span className="text-secondary">Disconnected</span>
             </div>


### PR DESCRIPTION
As talked about in issue #28 I added a connection indicator to the footer. It is a simple 'Connected' or 'Disconnected' message with a red or green dot beside it. It uses the state `connectionError` as a conditional.

Here is how it looks:

![image](https://user-images.githubusercontent.com/85003930/152667008-fc67bb0f-88f0-45e8-9581-01e651d07bc7.png)

![image](https://user-images.githubusercontent.com/85003930/152667014-383cc1ba-d228-40c6-873b-d0de217f6708.png)

I can make changes if anyone has any feedback.

Thanks

Closes #28 