### PR TITLE
refactor: collect api requests in single file

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -50,7 +50,7 @@ export default function App() {
     }
 
     const refreshSession = () => {
-      Api.session({ signal: abortCtrl.signal })
+      Api.getSession({ signal: abortCtrl.signal })
         .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.statusText))))
         .then((data) => {
           const { maker_running, coinjoin_in_process, wallet_name } = data

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -13,6 +13,7 @@ import Navbar from './Navbar'
 import { useSettings } from '../context/SettingsContext'
 import { useCurrentWallet, useSetCurrentWallet, useSetCurrentWalletInfo } from '../context/WalletContext'
 import { getSession, setSession, clearSession } from '../session'
+import * as Api from '../libs/JmWalletApi'
 
 export default function App() {
   const currentWallet = useCurrentWallet()
@@ -49,9 +50,7 @@ export default function App() {
     }
 
     const refreshSession = () => {
-      const opts = { signal: abortCtrl.signal }
-
-      fetch('/api/v1/session', opts)
+      Api.session({ signal: abortCtrl.signal })
         .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.statusText))))
         .then((data) => {
           const { maker_running, coinjoin_in_process, wallet_name } = data

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -125,7 +125,7 @@ export default function CreateWallet({ startWallet }) {
     setIsCreating(true)
 
     try {
-      const res = await Api.walletCreate({ walletname, password })
+      const res = await Api.postWalletCreate({ walletname, password })
 
       if (res.ok) {
         const { seedphrase, token, walletname: name } = await res.json()

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -5,6 +5,7 @@ import PageTitle from './PageTitle'
 import ToggleSwitch from './ToggleSwitch'
 import { serialize, walletDisplayName } from '../utils'
 import { useCurrentWallet } from '../context/WalletContext'
+import * as Api from '../libs/JmWalletApi'
 
 const WalletCreationForm = ({ createWallet, isCreating }) => {
   const [validated, setValidated] = useState(false)
@@ -124,15 +125,7 @@ export default function CreateWallet({ startWallet }) {
     setIsCreating(true)
 
     try {
-      const wallettype = 'sw-fb'
-      const res = await fetch(`/api/v1/wallet/create`, {
-        method: 'POST',
-        body: JSON.stringify({
-          password,
-          walletname,
-          wallettype,
-        }),
-      })
+      const res = await Api.walletCreate({ walletname, password })
 
       if (res.ok) {
         const { seedphrase, token, walletname: name } = await res.json()

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -118,18 +118,16 @@ export default function CreateWallet({ startWallet }) {
   const [isCreating, setIsCreating] = useState(false)
   const [createdWallet, setCreatedWallet] = useState(null)
 
-  const createWallet = async (name, password) => {
-    const walletname = name.endsWith('.jmdat') ? name : `${name}.jmdat`
-
+  const createWallet = async (walletName, password) => {
     setAlert(null)
     setIsCreating(true)
 
     try {
-      const res = await Api.postWalletCreate({ walletname, password })
+      const res = await Api.postWalletCreate({ walletName, password })
 
       if (res.ok) {
-        const { seedphrase, token, walletname: name } = await res.json()
-        setCreatedWallet({ name, seedphrase, password, token })
+        const { seedphrase, token, walletname: createdWalletName } = await res.json()
+        setCreatedWallet({ name: createdWalletName, seedphrase, password, token })
       } else {
         const { message } = await res.json()
         setAlert({ variant: 'danger', message })

--- a/src/components/CurrentWalletAdvanced.jsx
+++ b/src/components/CurrentWalletAdvanced.jsx
@@ -28,14 +28,14 @@ export default function CurrentWalletAdvanced() {
     setAlert(null)
     setIsLoading(true)
 
-    const loadingWallet = Api.walletDisplay({ walletname: name, token, signal: abortCtrl.signal })
+    const loadingWallet = Api.getWalletDisplay({ walletname: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
       .then((data) => setWalletInfo(data.walletinfo))
       .catch((err) => {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
 
-    const loadingUtxos = Api.walletUtxos({ walletname: name, token, signal: abortCtrl.signal })
+    const loadingUtxos = Api.getWalletUtxos({ walletname: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading UTXOs failed.'))))
       .then((data) => setUtxoData(data.utxos))
       .catch((err) => {

--- a/src/components/CurrentWalletAdvanced.jsx
+++ b/src/components/CurrentWalletAdvanced.jsx
@@ -28,14 +28,14 @@ export default function CurrentWalletAdvanced() {
     setAlert(null)
     setIsLoading(true)
 
-    const loadingWallet = Api.getWalletDisplay({ walletname: name, token, signal: abortCtrl.signal })
+    const loadingWallet = Api.getWalletDisplay({ walletName: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
       .then((data) => setWalletInfo(data.walletinfo))
       .catch((err) => {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
 
-    const loadingUtxos = Api.getWalletUtxos({ walletname: name, token, signal: abortCtrl.signal })
+    const loadingUtxos = Api.getWalletUtxos({ walletName: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading UTXOs failed.'))))
       .then((data) => setUtxoData(data.utxos))
       .catch((err) => {

--- a/src/components/CurrentWalletAdvanced.jsx
+++ b/src/components/CurrentWalletAdvanced.jsx
@@ -4,6 +4,7 @@ import DisplayAccounts from './DisplayAccounts'
 import DisplayAccountUTXOs from './DisplayAccountUTXOs'
 import DisplayUTXOs from './DisplayUTXOs'
 import { useCurrentWallet, useCurrentWalletInfo, useSetCurrentWalletInfo } from '../context/WalletContext'
+import * as Api from '../libs/JmWalletApi'
 
 export default function CurrentWalletAdvanced() {
   const currentWallet = useCurrentWallet()
@@ -18,10 +19,6 @@ export default function CurrentWalletAdvanced() {
   useEffect(() => {
     const abortCtrl = new AbortController()
     const { name, token } = currentWallet
-    const opts = {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: abortCtrl.signal,
-    }
 
     const setUtxoData = (utxos) => {
       setUtxos(utxos)
@@ -31,14 +28,14 @@ export default function CurrentWalletAdvanced() {
     setAlert(null)
     setIsLoading(true)
 
-    const loadingWallet = fetch(`/api/v1/wallet/${name}/display`, opts)
+    const loadingWallet = Api.walletDisplay({ walletname: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
       .then((data) => setWalletInfo(data.walletinfo))
       .catch((err) => {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
 
-    const loadingUtxos = fetch(`/api/v1/wallet/${name}/utxos`, opts)
+    const loadingUtxos = Api.walletUtxos({ walletname: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading UTXOs failed.'))))
       .then((data) => setUtxoData(data.utxos))
       .catch((err) => {

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -6,6 +6,7 @@ import { useCurrentWallet, useCurrentWalletInfo, useSetCurrentWalletInfo } from 
 import Balance from './Balance'
 import Sprite from './Sprite'
 import { walletDisplayName } from '../utils'
+import * as Api from '../libs/JmWalletApi'
 
 const WalletHeader = ({ name, balance, unit, showBalance }) => {
   return (
@@ -71,15 +72,11 @@ export default function CurrentWalletMagic() {
   useEffect(() => {
     const abortCtrl = new AbortController()
     const { name, token } = wallet
-    const opts = {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: abortCtrl.signal,
-    }
 
     setAlert(null)
     setIsLoading(true)
 
-    fetch(`/api/v1/wallet/${name}/display`, opts)
+    Api.walletDisplay({ walletname: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
       .then((data) => setWalletInfo(data.walletinfo))
       .catch((err) => {

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -76,7 +76,7 @@ export default function CurrentWalletMagic() {
     setAlert(null)
     setIsLoading(true)
 
-    Api.walletDisplay({ walletname: name, token, signal: abortCtrl.signal })
+    Api.getWalletDisplay({ walletname: name, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
       .then((data) => setWalletInfo(data.walletinfo))
       .catch((err) => {

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -71,12 +71,12 @@ export default function CurrentWalletMagic() {
 
   useEffect(() => {
     const abortCtrl = new AbortController()
-    const { name, token } = wallet
+    const { name: walletName, token } = wallet
 
     setAlert(null)
     setIsLoading(true)
 
-    Api.getWalletDisplay({ walletname: name, token, signal: abortCtrl.signal })
+    Api.getWalletDisplay({ walletName, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
       .then((data) => setWalletInfo(data.walletinfo))
       .catch((err) => {

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -43,7 +43,7 @@ export default function Earn({ currentWallet, makerRunning }) {
     setIsSending(true)
     setIsWaiting(false)
     try {
-      const res = await Api.makerStart(
+      const res = await Api.postMakerStart(
         { walletname: name, token },
         {
           cjfee_a,
@@ -81,7 +81,7 @@ export default function Earn({ currentWallet, makerRunning }) {
     setIsSending(true)
     setIsWaiting(false)
     try {
-      const res = await Api.makerStop({ walletname: name, token })
+      const res = await Api.getMakerStop({ walletname: name, token })
 
       if (res.ok) {
         // FIXME: Right now there is no response data to check if maker got stopped

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useEffect, useState } from 'react'
 import * as rb from 'react-bootstrap'
+import * as Api from '../libs/JmWalletApi'
 
 const OFFERTYPE_REL = 'sw0reloffer'
 const OFFERTYPE_ABS = 'sw0absoffer'
@@ -37,23 +38,20 @@ export default function Earn({ currentWallet, makerRunning }) {
 
   const startMakerService = async (cjfee_a, cjfee_r, ordertype, minsize) => {
     const { name, token } = currentWallet
-    const opts = {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      body: JSON.stringify({
-        txfee: 0,
-        cjfee_a,
-        cjfee_r,
-        ordertype,
-        minsize,
-      }),
-    }
 
     setAlert(null)
     setIsSending(true)
     setIsWaiting(false)
     try {
-      const res = await fetch(`/api/v1/wallet/${name}/maker/start`, opts)
+      const res = await Api.makerStart(
+        { walletname: name, token },
+        {
+          cjfee_a,
+          cjfee_r,
+          ordertype,
+          minsize,
+        }
+      )
 
       if (res.ok) {
         // FIXME: Right now there is no response data to check if maker got started
@@ -78,15 +76,12 @@ export default function Earn({ currentWallet, makerRunning }) {
 
   const stopMakerService = async () => {
     const { name, token } = currentWallet
-    const opts = {
-      headers: { Authorization: `Bearer ${token}` },
-    }
 
     setAlert(null)
     setIsSending(true)
     setIsWaiting(false)
     try {
-      const res = await fetch(`/api/v1/wallet/${name}/maker/stop`, opts)
+      const res = await Api.makerStop({ walletname: name, token })
 
       if (res.ok) {
         // FIXME: Right now there is no response data to check if maker got stopped

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -37,14 +37,14 @@ export default function Earn({ currentWallet, makerRunning }) {
   }
 
   const startMakerService = async (cjfee_a, cjfee_r, ordertype, minsize) => {
-    const { name, token } = currentWallet
+    const { name: walletName, token } = currentWallet
 
     setAlert(null)
     setIsSending(true)
     setIsWaiting(false)
     try {
       const res = await Api.postMakerStart(
-        { walletname: name, token },
+        { walletName, token },
         {
           cjfee_a,
           cjfee_r,
@@ -75,13 +75,13 @@ export default function Earn({ currentWallet, makerRunning }) {
   }, [makerRunning])
 
   const stopMakerService = async () => {
-    const { name, token } = currentWallet
+    const { name: walletName, token } = currentWallet
 
     setAlert(null)
     setIsSending(true)
     setIsWaiting(false)
     try {
-      const res = await Api.getMakerStop({ walletname: name, token })
+      const res = await Api.getMakerStop({ walletName, token })
 
       if (res.ok) {
         // FIXME: Right now there is no response data to check if maker got stopped

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -5,6 +5,7 @@ import { useLocation } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import { ACCOUNTS } from '../utils'
 import { useSettings } from '../context/SettingsContext'
+import * as Api from '../libs/JmWalletApi'
 
 const Receive = ({ currentWallet }) => {
   const location = useLocation()
@@ -21,14 +22,10 @@ const Receive = ({ currentWallet }) => {
     const abortCtrl = new AbortController()
     const fetchAddress = async (accountNr) => {
       const { name, token } = currentWallet
-      const opts = {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: abortCtrl.signal,
-      }
 
       setAlert(null)
       setIsLoading(true)
-      fetch(`/api/v1/wallet/${name}/address/new/${accountNr}`, opts)
+      Api.walletAddressNew({ walletname: name, accountNr, token, signal: abortCtrl.signal })
         .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading new address failed.'))))
         .then((data) => setAddress(data.address))
         .catch((err) => {

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -25,7 +25,7 @@ const Receive = ({ currentWallet }) => {
 
       setAlert(null)
       setIsLoading(true)
-      Api.walletAddressNew({ walletname: name, accountNr, token, signal: abortCtrl.signal })
+      Api.getAddressNew({ walletname: name, accountNr, token, signal: abortCtrl.signal })
         .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading new address failed.'))))
         .then((data) => setAddress(data.address))
         .catch((err) => {

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -21,11 +21,11 @@ const Receive = ({ currentWallet }) => {
   useEffect(() => {
     const abortCtrl = new AbortController()
     const fetchAddress = async (accountNr) => {
-      const { name, token } = currentWallet
+      const { name: walletName, token } = currentWallet
 
       setAlert(null)
       setIsLoading(true)
-      Api.getAddressNew({ walletname: name, accountNr, token, signal: abortCtrl.signal })
+      Api.getAddressNew({ walletName, accountNr, token, signal: abortCtrl.signal })
         .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading new address failed.'))))
         .then((data) => setAddress(data.address))
         .catch((err) => {

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -14,13 +14,13 @@ export default function Payment({ currentWallet }) {
   const [account, setAccount] = useState(parseInt(location.state?.account, 10) || 0)
 
   const sendPayment = async (account, destination, amount_sats) => {
-    const { name, token } = currentWallet
+    const { name: walletName, token } = currentWallet
 
     setAlert(null)
     setIsSending(true)
     let success = false
     try {
-      const res = await Api.postDirectSend({ walletname: name, token }, { account, destination, amount_sats })
+      const res = await Api.postDirectSend({ walletName, token }, { account, destination, amount_sats })
       if (res.ok) {
         const {
           txinfo: { outputs },
@@ -45,16 +45,13 @@ export default function Payment({ currentWallet }) {
   }
 
   const startCoinjoin = async (account, destination, amount_sats, counterparties) => {
-    const { name, token } = currentWallet
+    const { name: walletName, token } = currentWallet
 
     setAlert(null)
     setIsSending(true)
     let success = false
     try {
-      const res = await Api.postCoinjoin(
-        { walletname: name, token },
-        { account, destination, amount_sats, counterparties }
-      )
+      const res = await Api.postCoinjoin({ walletName, token }, { account, destination, amount_sats, counterparties })
       if (res.ok) {
         const data = await res.json()
         console.log(data)

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -20,7 +20,7 @@ export default function Payment({ currentWallet }) {
     setIsSending(true)
     let success = false
     try {
-      const res = await Api.takerDirectSend({ walletname: name, token }, { account, destination, amount_sats })
+      const res = await Api.postDirectSend({ walletname: name, token }, { account, destination, amount_sats })
       if (res.ok) {
         const {
           txinfo: { outputs },
@@ -51,7 +51,7 @@ export default function Payment({ currentWallet }) {
     setIsSending(true)
     let success = false
     try {
-      const res = await Api.takerCoinjoin(
+      const res = await Api.postCoinjoin(
         { walletname: name, token },
         { account, destination, amount_sats, counterparties }
       )

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import { serialize, ACCOUNTS } from '../utils'
+import * as Api from '../libs/JmWalletApi'
 
 export default function Payment({ currentWallet }) {
   const location = useLocation()
@@ -14,21 +15,12 @@ export default function Payment({ currentWallet }) {
 
   const sendPayment = async (account, destination, amount_sats) => {
     const { name, token } = currentWallet
-    const opts = {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      body: JSON.stringify({
-        mixdepth: String(account),
-        destination,
-        amount_sats,
-      }),
-    }
 
     setAlert(null)
     setIsSending(true)
     let success = false
     try {
-      const res = await fetch(`/api/v1/wallet/${name}/taker/direct-send`, opts)
+      const res = await Api.takerDirectSend({ walletname: name, token }, { account, destination, amount_sats })
       if (res.ok) {
         const {
           txinfo: { outputs },
@@ -54,22 +46,15 @@ export default function Payment({ currentWallet }) {
 
   const startCoinjoin = async (account, destination, amount_sats, counterparties) => {
     const { name, token } = currentWallet
-    const opts = {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
-      body: JSON.stringify({
-        mixdepth: String(account),
-        destination,
-        amount_sats,
-        counterparties,
-      }),
-    }
 
     setAlert(null)
     setIsSending(true)
     let success = false
     try {
-      const res = await fetch(`/api/v1/wallet/${name}/taker/coinjoin`, opts)
+      const res = await Api.takerCoinjoin(
+        { walletname: name, token },
+        { account, destination, amount_sats, counterparties }
+      )
       if (res.ok) {
         const data = await res.json()
         console.log(data)

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -25,7 +25,7 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
       setAlert(null)
       setIsUnlocking(true)
       try {
-        const res = await Api.walletUnlock({ walletname: walletName }, { password })
+        const res = await Api.postWalletUnlock({ walletname: walletName }, { password })
         if (res.ok) {
           const { walletname: name, token } = await res.json()
           startWallet(name, token)
@@ -58,7 +58,7 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
       setAlert(null)
       setIsLocking(true)
 
-      const res = await Api.walletLock({ walletname: name, token })
+      const res = await Api.getWalletLock({ walletname: name, token })
       if (res.ok) {
         const { walletname, already_locked } = await res.json()
         stopWallet()

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import { serialize, walletDisplayName } from '../utils'
+import * as Api from '../libs/JmWalletApi'
 
 export default function Wallet({ name, currentWallet, startWallet, stopWallet, setAlert, ...props }) {
   const [validated, setValidated] = useState(false)
@@ -24,11 +25,7 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
       setAlert(null)
       setIsUnlocking(true)
       try {
-        const opts = {
-          method: 'POST',
-          body: JSON.stringify({ password }),
-        }
-        const res = await fetch(`/api/v1/wallet/${walletName}/unlock`, opts)
+        const res = await Api.walletUnlock({ walletname: walletName }, { password })
         if (res.ok) {
           const { walletname: name, token } = await res.json()
           startWallet(name, token)
@@ -58,13 +55,10 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
 
     try {
       const { name, token } = currentWallet
-      const opts = {
-        headers: { Authorization: `Bearer ${token}` },
-      }
-
       setAlert(null)
       setIsLocking(true)
-      const res = await fetch(`/api/v1/wallet/${name}/lock`, opts)
+
+      const res = await Api.walletLock({ walletname: name, token })
       if (res.ok) {
         const { walletname, already_locked } = await res.json()
         stopWallet()

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -25,10 +25,10 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
       setAlert(null)
       setIsUnlocking(true)
       try {
-        const res = await Api.postWalletUnlock({ walletname: walletName }, { password })
+        const res = await Api.postWalletUnlock({ walletName }, { password })
         if (res.ok) {
-          const { walletname: name, token } = await res.json()
-          startWallet(name, token)
+          const { walletname: unlockedWalletName, token } = await res.json()
+          startWallet(unlockedWalletName, token)
           navigate('/wallet')
         } else {
           const { message } = await res.json()
@@ -54,17 +54,19 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
     }
 
     try {
-      const { name, token } = currentWallet
+      const { name: walletName, token } = currentWallet
       setAlert(null)
       setIsLocking(true)
 
-      const res = await Api.getWalletLock({ walletname: name, token })
+      const res = await Api.getWalletLock({ walletName, token })
       if (res.ok) {
-        const { walletname, already_locked } = await res.json()
+        const { walletname: lockedWalletName, already_locked } = await res.json()
         stopWallet()
         setAlert({
           variant: already_locked ? 'warning' : 'success',
-          message: `${walletDisplayName(walletname)} ${already_locked ? 'already locked' : 'locked succesfully'}.`,
+          message: `${walletDisplayName(lockedWalletName)} ${
+            already_locked ? 'already locked' : 'locked successfully'
+          }.`,
           dismissible: true,
         })
       } else {

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -23,7 +23,7 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
     const abortCtrl = new AbortController()
 
     setIsLoading(true)
-    Api.walletAll({ signal: abortCtrl.signal })
+    Api.getWalletAll({ signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallets failed.'))))
       .then((data) => {
         const { wallets = [] } = data

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -4,6 +4,7 @@ import * as rb from 'react-bootstrap'
 import Alert from './Alert'
 import Wallet from './Wallet'
 import { walletDisplayName } from '../utils'
+import * as Api from '../libs/JmWalletApi'
 
 export default function Wallets({ currentWallet, startWallet, stopWallet }) {
   const [walletList, setWalletList] = useState(null)
@@ -20,10 +21,9 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
 
   useEffect(() => {
     const abortCtrl = new AbortController()
-    const opts = { signal: abortCtrl.signal }
 
     setIsLoading(true)
-    fetch('/api/v1/wallet/all', opts)
+    Api.walletAll({ signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallets failed.'))))
       .then((data) => {
         const { wallets = [] } = data

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -61,8 +61,6 @@ const walletUnlock = async ({ walletname }, { password }) => {
 }
 
 const walletUtxos = async ({ walletname, token, signal }) => {
-  const wallettype = 'sw-fb'
-
   return await fetch(`/api/v1/wallet/${walletname}/utxos`, {
     headers: { ...Authorization(token) },
     signal,

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -14,8 +14,8 @@ const getSession = async ({ signal }) => {
   return await fetch(`/api/v1/session`, { signal })
 }
 
-const getAddressNew = async ({ walletname, token, accountNr, signal }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/address/new/${accountNr}`, {
+const getAddressNew = async ({ walletName, token, accountNr, signal }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/address/new/${accountNr}`, {
     headers: { ...Authorization(token) },
     signal,
   })
@@ -27,21 +27,21 @@ const getWalletAll = async ({ signal }) => {
   })
 }
 
-const postWalletCreate = async ({ walletname, password }) => {
-  const wallettype = 'sw-fb'
+const postWalletCreate = async ({ walletName: name, password }) => {
+  const walletname = name.endsWith('.jmdat') ? name : `${name}.jmdat`
 
   return await fetch(`/api/v1/wallet/create`, {
     method: 'POST',
     body: JSON.stringify({
-      password,
+      wallettype: 'sw-fb',
       walletname,
-      wallettype,
+      password,
     }),
   })
 }
 
-const getWalletDisplay = async ({ walletname, token, signal }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/display`, {
+const getWalletDisplay = async ({ walletName, token, signal }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/display`, {
     headers: { ...Authorization(token) },
     signal,
   })
@@ -53,28 +53,28 @@ const getWalletDisplay = async ({ walletname, token, signal }) => {
  *
  * Note: Performs a non-idempotent GET request.
  */
-const getWalletLock = async ({ walletname, token }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/lock`, {
+const getWalletLock = async ({ walletName, token }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/lock`, {
     headers: { ...Authorization(token) },
   })
 }
 
-const postWalletUnlock = async ({ walletname }, { password }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/unlock`, {
+const postWalletUnlock = async ({ walletName }, { password }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/unlock`, {
     method: 'POST',
     body: JSON.stringify({ password }),
   })
 }
 
-const getWalletUtxos = async ({ walletname, token, signal }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/utxos`, {
+const getWalletUtxos = async ({ walletName, token, signal }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/utxos`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
-const postMakerStart = async ({ walletname, token, signal }, { cjfee_a, cjfee_r, ordertype, minsize }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/maker/start`, {
+const postMakerStart = async ({ walletName, token, signal }, { cjfee_a, cjfee_r, ordertype, minsize }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/maker/start`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     signal,
@@ -93,14 +93,14 @@ const postMakerStart = async ({ walletname, token, signal }, { cjfee_a, cjfee_r,
  *
  * Note: Performs a non-idempotent GET request.
  */
-const getMakerStop = async ({ walletname, token }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/maker/stop`, {
+const getMakerStop = async ({ walletName, token }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/maker/stop`, {
     headers: { ...Authorization(token) },
   })
 }
 
-const postDirectSend = async ({ walletname, token }, { account, destination, amount_sats }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/taker/direct-send`, {
+const postDirectSend = async ({ walletName, token }, { account, destination, amount_sats }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/taker/direct-send`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     body: JSON.stringify({
@@ -111,8 +111,8 @@ const postDirectSend = async ({ walletname, token }, { account, destination, amo
   })
 }
 
-const postCoinjoin = async ({ walletname, token }, { account, destination, amount_sats, counterparties }) => {
-  return await fetch(`/api/v1/wallet/${walletname}/taker/coinjoin`, {
+const postCoinjoin = async ({ walletName, token }, { account, destination, amount_sats, counterparties }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/taker/coinjoin`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     body: JSON.stringify({

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -1,0 +1,131 @@
+/**
+ * Simple collection of all api requests to jmwalletd.
+ *
+ * It is not tried to be feature-complete, but to represent only what is really used.
+ *
+ * See OpenAPI spec: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/api/wallet-rpc.yaml
+ */
+
+const Authorization = (token) => {
+  return { Authorization: `Bearer ${token}` }
+}
+
+const session = async ({ signal }) => {
+  return await fetch(`/api/v1/session`, { signal })
+}
+
+const walletAddressNew = async ({ walletname, token, accountNr, signal }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/address/new/${accountNr}`, {
+    headers: { ...Authorization(token) },
+    signal,
+  })
+}
+
+const walletAll = async ({ signal }) => {
+  return await fetch(`/api/v1/wallet/all`, {
+    signal,
+  })
+}
+
+const walletCreate = async ({ walletname, password }) => {
+  const wallettype = 'sw-fb'
+
+  return await fetch(`/api/v1/wallet/create`, {
+    method: 'POST',
+    body: JSON.stringify({
+      password,
+      walletname,
+      wallettype,
+    }),
+  })
+}
+
+const walletDisplay = async ({ walletname, token, signal }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/display`, {
+    headers: { ...Authorization(token) },
+    signal,
+  })
+}
+
+const walletLock = async ({ walletname, token }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/lock`, {
+    headers: { ...Authorization(token) },
+  })
+}
+
+const walletUnlock = async ({ walletname }, { password }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/unlock`, {
+    method: 'POST',
+    body: JSON.stringify({ password }),
+  })
+}
+
+const walletUtxos = async ({ walletname, token, signal }) => {
+  const wallettype = 'sw-fb'
+
+  return await fetch(`/api/v1/wallet/${walletname}/utxos`, {
+    headers: { ...Authorization(token) },
+    signal,
+  })
+}
+
+const makerStart = async ({ walletname, token, signal }, { cjfee_a, cjfee_r, ordertype, minsize }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/maker/start`, {
+    method: 'POST',
+    headers: { ...Authorization(token) },
+    signal,
+    body: JSON.stringify({
+      txfee: 0,
+      cjfee_a,
+      cjfee_r,
+      ordertype,
+      minsize,
+    }),
+  })
+}
+
+const makerStop = async ({ walletname, token }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/maker/stop`, {
+    headers: { ...Authorization(token) },
+  })
+}
+
+const takerDirectSend = async ({ walletname, token }, { account, destination, amount_sats }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/taker/direct-send`, {
+    method: 'POST',
+    headers: { ...Authorization(token) },
+    body: JSON.stringify({
+      mixdepth: String(account),
+      destination,
+      amount_sats,
+    }),
+  })
+}
+
+const takerCoinjoin = async ({ walletname, token }, { account, destination, amount_sats, counterparties }) => {
+  return await fetch(`/api/v1/wallet/${walletname}/taker/coinjoin`, {
+    method: 'POST',
+    headers: { ...Authorization(token) },
+    body: JSON.stringify({
+      mixdepth: String(account),
+      destination,
+      amount_sats,
+      counterparties,
+    }),
+  })
+}
+
+export {
+  makerStart,
+  makerStop,
+  session,
+  takerDirectSend,
+  takerCoinjoin,
+  walletAddressNew,
+  walletAll,
+  walletCreate,
+  walletDisplay,
+  walletLock,
+  walletUnlock,
+  walletUtxos,
+}

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -1,7 +1,7 @@
 /**
- * Simple collection of all api requests to jmwalletd.
+ * Simple collection of api requests to jmwalletd.
  *
- * It is not tried to be feature-complete, but to represent only what is really used.
+ * This is not aiming to be feature-complete.
  *
  * See OpenAPI spec: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/api/wallet-rpc.yaml
  */
@@ -10,24 +10,24 @@ const Authorization = (token) => {
   return { Authorization: `Bearer ${token}` }
 }
 
-const session = async ({ signal }) => {
+const getSession = async ({ signal }) => {
   return await fetch(`/api/v1/session`, { signal })
 }
 
-const walletAddressNew = async ({ walletname, token, accountNr, signal }) => {
+const getAddressNew = async ({ walletname, token, accountNr, signal }) => {
   return await fetch(`/api/v1/wallet/${walletname}/address/new/${accountNr}`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
-const walletAll = async ({ signal }) => {
+const getWalletAll = async ({ signal }) => {
   return await fetch(`/api/v1/wallet/all`, {
     signal,
   })
 }
 
-const walletCreate = async ({ walletname, password }) => {
+const postWalletCreate = async ({ walletname, password }) => {
   const wallettype = 'sw-fb'
 
   return await fetch(`/api/v1/wallet/create`, {
@@ -40,34 +40,40 @@ const walletCreate = async ({ walletname, password }) => {
   })
 }
 
-const walletDisplay = async ({ walletname, token, signal }) => {
+const getWalletDisplay = async ({ walletname, token, signal }) => {
   return await fetch(`/api/v1/wallet/${walletname}/display`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
-const walletLock = async ({ walletname, token }) => {
+/**
+ * Block access to a currently decrypted wallet.
+ * After this (authenticated) action, the wallet will not be readable or writeable.
+ *
+ * Note: Performs a non-idempotent GET request.
+ */
+const getWalletLock = async ({ walletname, token }) => {
   return await fetch(`/api/v1/wallet/${walletname}/lock`, {
     headers: { ...Authorization(token) },
   })
 }
 
-const walletUnlock = async ({ walletname }, { password }) => {
+const postWalletUnlock = async ({ walletname }, { password }) => {
   return await fetch(`/api/v1/wallet/${walletname}/unlock`, {
     method: 'POST',
     body: JSON.stringify({ password }),
   })
 }
 
-const walletUtxos = async ({ walletname, token, signal }) => {
+const getWalletUtxos = async ({ walletname, token, signal }) => {
   return await fetch(`/api/v1/wallet/${walletname}/utxos`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
-const makerStart = async ({ walletname, token, signal }, { cjfee_a, cjfee_r, ordertype, minsize }) => {
+const postMakerStart = async ({ walletname, token, signal }, { cjfee_a, cjfee_r, ordertype, minsize }) => {
   return await fetch(`/api/v1/wallet/${walletname}/maker/start`, {
     method: 'POST',
     headers: { ...Authorization(token) },
@@ -82,13 +88,18 @@ const makerStart = async ({ walletname, token, signal }, { cjfee_a, cjfee_r, ord
   })
 }
 
-const makerStop = async ({ walletname, token }) => {
+/**
+ * Stop the yield generator service.
+ *
+ * Note: Performs a non-idempotent GET request.
+ */
+const getMakerStop = async ({ walletname, token }) => {
   return await fetch(`/api/v1/wallet/${walletname}/maker/stop`, {
     headers: { ...Authorization(token) },
   })
 }
 
-const takerDirectSend = async ({ walletname, token }, { account, destination, amount_sats }) => {
+const postDirectSend = async ({ walletname, token }, { account, destination, amount_sats }) => {
   return await fetch(`/api/v1/wallet/${walletname}/taker/direct-send`, {
     method: 'POST',
     headers: { ...Authorization(token) },
@@ -100,7 +111,7 @@ const takerDirectSend = async ({ walletname, token }, { account, destination, am
   })
 }
 
-const takerCoinjoin = async ({ walletname, token }, { account, destination, amount_sats, counterparties }) => {
+const postCoinjoin = async ({ walletname, token }, { account, destination, amount_sats, counterparties }) => {
   return await fetch(`/api/v1/wallet/${walletname}/taker/coinjoin`, {
     method: 'POST',
     headers: { ...Authorization(token) },
@@ -114,16 +125,16 @@ const takerCoinjoin = async ({ walletname, token }, { account, destination, amou
 }
 
 export {
-  makerStart,
-  makerStop,
-  session,
-  takerDirectSend,
-  takerCoinjoin,
-  walletAddressNew,
-  walletAll,
-  walletCreate,
-  walletDisplay,
-  walletLock,
-  walletUnlock,
-  walletUtxos,
+  postMakerStart,
+  getMakerStop,
+  getSession,
+  postDirectSend,
+  postCoinjoin,
+  getAddressNew,
+  getWalletAll,
+  postWalletCreate,
+  getWalletDisplay,
+  getWalletLock,
+  postWalletUnlock,
+  getWalletUtxos,
 }


### PR DESCRIPTION
This change really just moves all `fetch` calls to a single file `libs/JmWalletApi.js`.
It does not aim to be feature-complete, nor does it add any feature, increase configurability or something else.
So this can definitely be improved in the future, but is out of scope for now.

I'd need feedback on the method naming (e.g. just `walletAddressNew`) and params, as I did not include `signal` param in every call (because it has not been used in specific requests) and conversion between `name` and `walletname` feels also a bit cumbersome.


Closes #60 