### PR TITLE
Change accounts to privacy levels

### DIFF
--- a/src/components/DisplayAccountUTXOs.jsx
+++ b/src/components/DisplayAccountUTXOs.jsx
@@ -21,7 +21,7 @@ export default function DisplayAccountUTXOs({ utxos, ...props }) {
       {Object.entries(byAccount(utxos)).map(([account, utxos]) => (
         <rb.Accordion.Item key={account} eventKey={account}>
           <rb.Accordion.Header className="head">
-            <h5 className="mb-0">Account {account}</h5>
+            <h5 className="mb-0">Privacy Level {account}</h5>
           </rb.Accordion.Header>
           <rb.Accordion.Body>
             <DisplayUTXOs utxos={utxos} unit={settings.unit} showBalances={settings.showBalance} />

--- a/src/components/DisplayAccounts.jsx
+++ b/src/components/DisplayAccounts.jsx
@@ -15,7 +15,7 @@ export default function DisplayAccounts({ accounts, ...props }) {
           <rb.Accordion.Header>
             <rb.Row className="w-100">
               <rb.Col>
-                <h5 className="mb-0">Account {account}</h5>
+                <h5 className="mb-0">Privacy Level {account}</h5>
               </rb.Col>
               <rb.Col className="d-flex align-items-center justify-content-end pe-5">
                 <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -64,7 +64,7 @@ const Receive = ({ currentWallet }) => {
         </div>
       )}
       <rb.Form.Group className="mb-3" controlId="account">
-        <rb.Form.Label>Account</rb.Form.Label>
+        <rb.Form.Label>Privacy Level</rb.Form.Label>
         <rb.Form.Select
           defaultValue={account}
           onChange={(e) => setAccount(parseInt(e.target.value, 10))}
@@ -74,7 +74,7 @@ const Receive = ({ currentWallet }) => {
         >
           {ACCOUNTS.map((val) => (
             <option key={val} value={val}>
-              Account {val}
+              Privacy Level {val}
             </option>
           ))}
         </rb.Form.Select>

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -100,7 +100,7 @@ export default function Payment({ currentWallet }) {
         <rb.Form.Control.Feedback type="invalid">Please provide a receiving address.</rb.Form.Control.Feedback>
       </rb.Form.Group>
       <rb.Form.Group className="mb-3" controlId="account">
-        <rb.Form.Label>Account</rb.Form.Label>
+        <rb.Form.Label>Privacy Level</rb.Form.Label>
         <rb.Form.Select
           defaultValue={account}
           onChange={(e) => setAccount(parseInt(e.target.value, 10))}
@@ -109,7 +109,7 @@ export default function Payment({ currentWallet }) {
         >
           {ACCOUNTS.map((val) => (
             <option key={val} value={val}>
-              Account {val}
+              Privacy Level {val}
             </option>
           ))}
         </rb.Form.Select>


### PR DESCRIPTION
This was suggested in issue #69, I have changed the UI references to Accounts to Privacy Levels. I think this looks really good and drives home the meaning to the users better.

![image](https://user-images.githubusercontent.com/85003930/153272483-2afc857f-41ad-4fb1-af01-46f6762a785d.png)
![image](https://user-images.githubusercontent.com/85003930/153272519-87ee02db-8dd1-43ef-acb8-a5bfc6f40b4e.png)

Please let me know if I have missed any other references to the Account. Thanks!