### PR TITLE
fix warnings during build

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Route, Routes, Navigate } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import Wallets from './Wallets'

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -155,7 +155,7 @@ export default function App() {
               <a
                 href="https://github.com/JoinMarket-Org/joinmarket-clientserver/tree/master/docs"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="nav-link text-secondary"
               >
                 Docs
@@ -165,7 +165,7 @@ export default function App() {
               <a
                 href="https://github.com/JoinMarket-Org/joinmarket-clientserver#wallet-features"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="nav-link text-secondary"
               >
                 Features
@@ -175,7 +175,7 @@ export default function App() {
               <a
                 href="https://github.com/JoinMarket-Org/joinmarket-clientserver"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="nav-link text-secondary"
               >
                 GitHub
@@ -185,7 +185,7 @@ export default function App() {
               <a
                 href="https://twitter.com/joinmarket"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="nav-link text-secondary"
               >
                 Twitter

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -52,7 +52,7 @@ export default function Onboarding() {
           <a
             href="https://github.com/joinmarket-webui/joinmarket-webui/issues"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="link-secondary"
           >
             report an issue


### PR DESCRIPTION
There were several warnings originating from two causes:


```
./src/components/App.jsx
  Line 93:12:   'React' must be in scope when using JSX  react/react-in-jsx-scope
```
Fix: Import `React` in `App.jsx`

```
./src/components/App.jsx
./src/components/Onboarding.jsx
  Line 187:17:  Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener  react/jsx-no-target-blank
```
Fix: Add `noopener` to all links with `target="_blank"`