### PR TITLE
fix: condition check during wallet confirmation

### DIFF
--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -151,7 +151,7 @@ export default function CreateWallet({ startWallet }) {
   }
 
   const walletConfirmed = () => {
-    if (createWallet.name && createdWallet.token) {
+    if (createdWallet.name && createdWallet.token) {
       startWallet(createdWallet.name, createdWallet.token)
       navigate('/wallet')
     } else {


### PR DESCRIPTION
Noticed this during testing the docker setup. 
The checked `name` property is actually from the function `createWallet` rather than the reference to variable `createdWallet`.
Seems to invoke an error in the packaged application but does not show up during development.