### PR TITLE
feat: ability for reverse proxy to enforce own auth scheme

### DIFF
--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -4,10 +4,24 @@
  * This is not aiming to be feature-complete.
  *
  * See OpenAPI spec: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/api/wallet-rpc.yaml
+ *
+ * Because we forward all requests through a proxy, additional functionality
+ * can be provided. One adaptation is to send the Authorization header as
+ * 'x-jm-authorization' so that the reverse proxy can apply its own
+ * authentication mechanism.
  */
 
+/**
+ * Construct a bearer authorization header object for the given token.
+ *
+ * The 'x-jm-authorization' header is used as 'Authorization' header for
+ * requests to jmwalletd by the reverse proxy.
+ *
+ * @param {string} token the bearer token
+ * @returns an object containing the authorization header
+ */
 const Authorization = (token) => {
-  return { Authorization: `Bearer ${token}` }
+  return { 'x-jm-authorization': `Bearer ${token}` }
 }
 
 const getSession = async ({ signal }) => {

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -14,7 +14,7 @@
 /**
  * Construct a bearer authorization header object for the given token.
  *
- * The 'x-jm-authorization' header is used as 'Authorization' header for
+ * The 'x-jm-authorization' header is forwarded as 'Authorization' header in
  * requests to jmwalletd by the reverse proxy.
  *
  * @param {string} token the bearer token

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -8,6 +8,11 @@ module.exports = (app) => {
       changeOrigin: true,
       secure: false,
       ws: false,
+      onProxyReq: (proxyReq, req, res) => {
+        if (req.headers['x-jm-authorization']) {
+          proxyReq.setHeader('authorization', req.headers['x-jm-authorization'])
+        }
+      },
     })
   )
   app.use(

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -10,7 +10,7 @@ module.exports = (app) => {
       ws: false,
       onProxyReq: (proxyReq, req, res) => {
         if (req.headers['x-jm-authorization']) {
-          proxyReq.setHeader('authorization', req.headers['x-jm-authorization'])
+          proxyReq.setHeader('Authorization', req.headers['x-jm-authorization'])
         }
       },
     })


### PR DESCRIPTION
A reverse proxy must be used in order to use this application. Since such a proxy might want to enforce it's own authentication mechanism, a small adaption is needed how requests to `jmwalletd` are constructed and forwarded.

This change includes sending the bearer token via a header named `x-jm-authorization` instead of `Authorization` in order for the reverse proxy to use the `Authorization` header for it's own purposes.

From this change onward, any reverse proxy that wants to deliver this application must forward the  `x-jm-authorization` header as `Authorization` header to `jmwalletd`. No other changes are needed for the development environment.