### PR TITLE
fix: enable fetching manifest with credentials

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg">
-    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest">
+    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" crossorigin="use-credentials">
     <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#000000">
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="msapplication-TileColor" content="#ffffff">


### PR DESCRIPTION
With this change the `site.webmanifest` file can be fetched on a server with an auth mechanism enabled.

From [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_webmanifest_with_credentials):
> The use-credentials value must be used when fetching a [manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) that requires credentials, even if the file is from the same origin.

For more on why this is needed on `rel="manifest"` see [here](https://github.com/w3c/manifest/issues/535#issuecomment-435739223).