### PR TITLE
feat: make balance hideable on click

### DIFF
--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { Link } from 'react-router-dom'
-import { useSettings } from '../context/SettingsContext'
+import { useSettings, useSettingsDispatch } from '../context/SettingsContext'
 import { useCurrentWallet, useCurrentWalletInfo, useSetCurrentWalletInfo } from '../context/WalletContext'
 import Balance from './Balance'
 import Sprite from './Sprite'
@@ -62,6 +62,7 @@ const PrivacyLevel = ({ numAccounts, level, balance }) => {
 
 export default function CurrentWalletMagic() {
   const settings = useSettings()
+  const settingsDispatch = useSettingsDispatch()
   const wallet = useCurrentWallet()
   const walletInfo = useCurrentWalletInfo()
   const setWalletInfo = useSetCurrentWalletInfo()
@@ -109,7 +110,10 @@ export default function CurrentWalletMagic() {
       {!isLoading && wallet && walletInfo && (
         <rb.Row className="justify-content-center">
           <rb.Col xs={10} sm={8} md={6} lg={4}>
-            <rb.Row>
+            <rb.Row
+              onClick={() => settingsDispatch({ showBalance: !settings.showBalance })}
+              style={{ cursor: 'pointer' }}
+            >
               <WalletHeader
                 name={wallet.name}
                 balance={walletInfo.total_balance}


### PR DESCRIPTION
Let's the user hide the balance by clicking on it on the main wallet screen.

Initially, the balance is hidden. Having to go to the settings screen to show it might be a bit cumbersome. Clicking on the balance (on the main wallet page only) lets the user reveal the balance more easily. This is also what the [bitcoin design guidelines](https://bitcoin.design/guide/onboarding/protecting-a-wallet/#quickly-hiding-balances) recommend.

https://user-images.githubusercontent.com/10026790/154489584-23bddf00-acb1-4cf7-9d3f-284482f3ec39.mov


