### PR TITLE
feat: update wallets page

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -119,11 +119,7 @@ export default function App() {
           <rb.Alert variant="danger">No connection to backend: {connectionError}.</rb.Alert>
         ) : (
           <Routes>
-            <Route
-              exact
-              path="/"
-              element={<Wallets currentWallet={currentWallet} startWallet={startWallet} stopWallet={stopWallet} />}
-            />
+            <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
             <Route
               path="create-wallet"
               element={<CreateWallet currentWallet={currentWallet} startWallet={startWallet} />}

--- a/src/components/PageTitle.jsx
+++ b/src/components/PageTitle.jsx
@@ -1,21 +1,23 @@
 import React from 'react'
 import Sprite from './Sprite'
 
-export default function PageTitle({ title, subtitle, success = false }) {
+export default function PageTitle({ title, subtitle, success = false, center = false }) {
   return (
-    <div className="mb-4">
+    <div className={`mb-4 ${center && 'text-center'}`}>
       {success && (
-        <div
-          className="d-flex align-items-center justify-content-center mb-2"
-          style={{
-            width: '3rem',
-            height: '3rem',
-            backgroundColor: 'rgba(39, 174, 96, 1)',
-            color: 'white',
-            borderRadius: '50%',
-          }}
-        >
-          <Sprite symbol="checkmark" width="24" height="30" />
+        <div className={`mb-2 ${center && 'd-flex align-items-center justify-content-center'}`}>
+          <div
+            className="d-flex align-items-center justify-content-center"
+            style={{
+              width: '3rem',
+              height: '3rem',
+              backgroundColor: 'rgba(39, 174, 96, 1)',
+              color: 'white',
+              borderRadius: '50%',
+            }}
+          >
+            <Sprite symbol="checkmark" width="24" height="30" />
+          </div>
         </div>
       )}
       <h2>{title}</h2>

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -109,101 +109,93 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
   const noneActive = !currentWallet
 
   return (
-    <rb.Row className="justify-content-center">
-      <rb.Col md={10} lg={8} xl={6}>
-        <rb.Card className="bg-transparent border-start-0 border-end-0 rounded-0" {...props}>
-          <rb.Card.Body>
-            <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
-              <div className="d-flex justify-content-between align-items-center flex-wrap">
-                <div>
-                  {isActive ? (
-                    <rb.Card.Title>
-                      <Link className="wallet-name" to="/wallet">
-                        {walletDisplayName(name)}
-                      </Link>
-                    </rb.Card.Title>
-                  ) : (
-                    <rb.Card.Title>{walletDisplayName(name)}</rb.Card.Title>
-                  )}
+    <rb.Card className="bg-transparent border-start-0 border-end-0 rounded-0" {...props}>
+      <rb.Card.Body>
+        <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
+          <div className="d-flex justify-content-between align-items-center flex-wrap">
+            <div>
+              {isActive ? (
+                <rb.Card.Title>
+                  <Link className="wallet-name" to="/wallet">
+                    {walletDisplayName(name)}
+                  </Link>
+                </rb.Card.Title>
+              ) : (
+                <rb.Card.Title>{walletDisplayName(name)}</rb.Card.Title>
+              )}
 
-                  {isActive ? (
-                    <span className="text-success">Active</span>
-                  ) : (
-                    <span className="text-muted">Inactive</span>
-                  )}
-                </div>
-                <div>
-                  {isActive ? (
-                    hasToken ? (
-                      <>
-                        <Link className="btn btn-outline-dark me-2" to="/wallet">
-                          Open
-                        </Link>
-                        <rb.FormControl type="hidden" name="action" value="lock" />
-                        <rb.Button variant="outline-dark" type="submit" disabled={isLocking}>
-                          {isLocking ? (
-                            <>
-                              <rb.Spinner
-                                as="span"
-                                animation="border"
-                                size="sm"
-                                role="status"
-                                aria-hidden="true"
-                                className="me-2"
-                              />
-                              Locking
-                            </>
-                          ) : (
-                            'Lock'
-                          )}
-                        </rb.Button>
-                      </>
-                    ) : (
-                      <rb.Alert variant="warning" className="mb-0">
-                        This wallet is active, but there is no token to interact with it. Please remove the lock file on
-                        the server.
-                      </rb.Alert>
-                    )
-                  ) : (
-                    noneActive && (
-                      <rb.InputGroup hasValidation={true}>
-                        <rb.FormControl
-                          type="password"
-                          placeholder="Password"
-                          name="password"
-                          disabled={isUnlocking}
-                          required
-                        />
-                        <rb.FormControl type="hidden" name="action" value="unlock" />
-                        <rb.Button variant="outline-dark" className="py-1 px-3" type="submit" disabled={isUnlocking}>
-                          {isUnlocking ? (
-                            <>
-                              <rb.Spinner
-                                as="span"
-                                animation="border"
-                                size="sm"
-                                role="status"
-                                aria-hidden="true"
-                                className="me-2"
-                              />
-                              Unlocking
-                            </>
-                          ) : (
-                            'Unlock'
-                          )}
-                        </rb.Button>
-                        <rb.Form.Control.Feedback type="invalid">
-                          Please set the wallet's password.
-                        </rb.Form.Control.Feedback>
-                      </rb.InputGroup>
-                    )
-                  )}
-                </div>
-              </div>
-            </rb.Form>
-          </rb.Card.Body>
-        </rb.Card>
-      </rb.Col>
-    </rb.Row>
+              {isActive ? <span className="text-success">Active</span> : <span className="text-muted">Inactive</span>}
+            </div>
+            <div>
+              {isActive ? (
+                hasToken ? (
+                  <>
+                    <Link className="btn btn-outline-dark me-2" to="/wallet">
+                      Open
+                    </Link>
+                    <rb.FormControl type="hidden" name="action" value="lock" />
+                    <rb.Button variant="outline-dark" type="submit" disabled={isLocking}>
+                      {isLocking ? (
+                        <>
+                          <rb.Spinner
+                            as="span"
+                            animation="border"
+                            size="sm"
+                            role="status"
+                            aria-hidden="true"
+                            className="me-2"
+                          />
+                          Locking
+                        </>
+                      ) : (
+                        'Lock'
+                      )}
+                    </rb.Button>
+                  </>
+                ) : (
+                  <rb.Alert variant="warning" className="mb-0">
+                    This wallet is active, but there is no token to interact with it. Please remove the lock file on the
+                    server.
+                  </rb.Alert>
+                )
+              ) : (
+                noneActive && (
+                  <rb.InputGroup hasValidation={true}>
+                    <rb.FormControl
+                      type="password"
+                      placeholder="Password"
+                      name="password"
+                      disabled={isUnlocking}
+                      required
+                    />
+                    <rb.FormControl type="hidden" name="action" value="unlock" />
+                    <rb.Button variant="outline-dark" className="py-1 px-3" type="submit" disabled={isUnlocking}>
+                      {isUnlocking ? (
+                        <>
+                          <rb.Spinner
+                            as="span"
+                            animation="border"
+                            size="sm"
+                            role="status"
+                            aria-hidden="true"
+                            className="me-2"
+                          />
+                          Unlocking
+                        </>
+                      ) : (
+                        'Unlock'
+                      )}
+                    </rb.Button>
+                    <rb.Form.Control.Feedback type="invalid">
+                      Please set the wallet's password.
+                    </rb.Form.Control.Feedback>
+                  </rb.InputGroup>
+                )
+              )}
+            </div>
+          </div>
+        </rb.Form>
+      </rb.Card.Body>
+    </rb.Card>
   )
 }

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -111,7 +111,7 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
   return (
     <rb.Row className="justify-content-center">
       <rb.Col md={10} lg={8} xl={6}>
-        <rb.Card className="bg-transparent border-start-0 border-end-0 border-top-0 rounded-0" {...props}>
+        <rb.Card className="bg-transparent border-start-0 border-end-0 rounded-0" {...props}>
           <rb.Card.Body>
             <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
               <div className="d-flex justify-content-between align-items-center flex-wrap">

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -113,17 +113,16 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
       <rb.Card.Body>
         <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
           <div className="d-flex justify-content-between align-items-center flex-wrap">
-            <div>
-              {isActive ? (
-                <rb.Card.Title>
+            <div class="py-1">
+              <rb.Card.Title>
+                {isActive ? (
                   <Link className="wallet-name" to="/wallet">
                     {walletDisplayName(name)}
                   </Link>
-                </rb.Card.Title>
-              ) : (
-                <rb.Card.Title>{walletDisplayName(name)}</rb.Card.Title>
-              )}
-
+                ) : (
+                  <>{walletDisplayName(name)}</>
+                )}
+              </rb.Card.Title>
               {isActive ? <span className="text-success">Active</span> : <span className="text-muted">Inactive</span>}
             </div>
             <div>

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -109,7 +109,7 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
   const noneActive = !currentWallet
 
   return (
-    <rb.Card className="bg-transparent border-start-0 border-end-0 rounded-0" {...props}>
+    <rb.Card {...props}>
       <rb.Card.Body>
         <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
           <div className="d-flex justify-content-between align-items-center flex-wrap">

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -75,7 +75,7 @@ export default function Wallets({ startWallet, stopWallet }) {
         <div className="d-flex justify-content-center">
           <Link
             to="/create-wallet"
-            className={`btn mt-4 ${walletList?.length === 0 ? 'btn-dark' : 'btn-outline-dark'}`}
+            className={`btn mt-4 ${walletList?.length === 0 ? 'btn-lg btn-dark' : 'btn-outline-dark'}`}
           >
             Create new wallet
           </Link>

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -51,6 +51,7 @@ export default function Wallets({ startWallet, stopWallet }) {
         <PageTitle
           title="Your wallets"
           subtitle={walletList?.length === 0 ? 'It looks like you do not have a wallet, yet.' : null}
+          center={true}
         />
         {alert && <Alert {...alert} />}
         {isLoading && (

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import Alert from './Alert'
 import Wallet from './Wallet'
+import PageTitle from './PageTitle'
 import { useCurrentWallet } from '../context/WalletContext'
 import { walletDisplayName } from '../utils'
 import * as Api from '../libs/JmWalletApi'
@@ -47,17 +48,15 @@ export default function Wallets({ startWallet, stopWallet }) {
   return (
     <rb.Row className="wallets justify-content-center">
       <rb.Col md={10} lg={8} xl={6}>
-        <h2 className="text-center mb-4">Your wallets</h2>
+        <PageTitle
+          title="Your wallets"
+          subtitle={walletList?.length === 0 ? 'It looks like you do not have a wallet, yet.' : null}
+        />
         {alert && <Alert {...alert} />}
         {isLoading && (
           <div>
             <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
             Loading wallets
-          </div>
-        )}
-        {walletList?.length === 0 && (
-          <div className="text-secondary text-center">
-            It looks like you do not have a wallet, yet. Please create one first.
           </div>
         )}
         {walletList?.map((wallet, index) => (

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -54,18 +54,12 @@ export default function Wallets({ startWallet, stopWallet }) {
           Loading wallets
         </div>
       )}
-      {walletList?.length !== 0 ? (
-        <rb.Row className="justify-content-center">
-          <rb.Col md={10} lg={8} xl={6}>
-            <div className="border-top px-3"></div>
-          </rb.Col>
-        </rb.Row>
-      ) : (
+      {walletList?.length === 0 && (
         <div className="text-secondary text-center">
           It looks like you do not have a wallet, yet. Please create one first.
         </div>
       )}
-      {walletList?.map((wallet) => (
+      {walletList?.map((wallet, index) => (
         <Wallet
           key={wallet}
           name={wallet}
@@ -73,6 +67,9 @@ export default function Wallets({ startWallet, stopWallet }) {
           startWallet={startWallet}
           stopWallet={stopWallet}
           setAlert={setAlert}
+          className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
+            index === 0 ? 'border-top-1' : 'border-top-0'
+          }`}
         />
       ))}
       <div className="d-flex justify-content-center">

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -3,10 +3,12 @@ import { Link } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
 import Alert from './Alert'
 import Wallet from './Wallet'
+import { useCurrentWallet } from '../context/WalletContext'
 import { walletDisplayName } from '../utils'
 import * as Api from '../libs/JmWalletApi'
 
-export default function Wallets({ currentWallet, startWallet, stopWallet }) {
+export default function Wallets({ startWallet, stopWallet }) {
+  const currentWallet = useCurrentWallet()
   const [walletList, setWalletList] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [alert, setAlert] = useState(

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -45,38 +45,43 @@ export default function Wallets({ startWallet, stopWallet }) {
   }, [currentWallet])
 
   return (
-    <div className="wallets">
-      <h2 className="text-center mb-4">Your wallets</h2>
-      {alert && <Alert {...alert} />}
-      {isLoading && (
-        <div>
-          <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
-          Loading wallets
+    <rb.Row className="wallets justify-content-center">
+      <rb.Col md={10} lg={8} xl={6}>
+        <h2 className="text-center mb-4">Your wallets</h2>
+        {alert && <Alert {...alert} />}
+        {isLoading && (
+          <div>
+            <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+            Loading wallets
+          </div>
+        )}
+        {walletList?.length === 0 && (
+          <div className="text-secondary text-center">
+            It looks like you do not have a wallet, yet. Please create one first.
+          </div>
+        )}
+        {walletList?.map((wallet, index) => (
+          <Wallet
+            key={wallet}
+            name={wallet}
+            currentWallet={currentWallet}
+            startWallet={startWallet}
+            stopWallet={stopWallet}
+            setAlert={setAlert}
+            className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
+              index === 0 ? 'border-top-1' : 'border-top-0'
+            }`}
+          />
+        ))}
+        <div className="d-flex justify-content-center">
+          <Link
+            to="/create-wallet"
+            className={`btn mt-4 ${walletList?.length === 0 ? 'btn-dark' : 'btn-outline-dark'}`}
+          >
+            Create new wallet
+          </Link>
         </div>
-      )}
-      {walletList?.length === 0 && (
-        <div className="text-secondary text-center">
-          It looks like you do not have a wallet, yet. Please create one first.
-        </div>
-      )}
-      {walletList?.map((wallet, index) => (
-        <Wallet
-          key={wallet}
-          name={wallet}
-          currentWallet={currentWallet}
-          startWallet={startWallet}
-          stopWallet={stopWallet}
-          setAlert={setAlert}
-          className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
-            index === 0 ? 'border-top-1' : 'border-top-0'
-          }`}
-        />
-      ))}
-      <div className="d-flex justify-content-center">
-        <Link to="/create-wallet" className={`btn mt-4 ${walletList?.length === 0 ? 'btn-dark' : 'btn-outline-dark'}`}>
-          Create new wallet
-        </Link>
-      </div>
-    </div>
+      </rb.Col>
+    </rb.Row>
   )
 }


### PR DESCRIPTION
More consistence in regards to other pages.

- Use one row and col for the whole page

- Alert not using full width anymore

- Slightly increased "Create new wallet" button when no wallet exists.

- The `PageTitle` is not centered anymore, which deviates from the Figma screen.
Personally, I think it looks better to have the headlines all in the same place (e.g. switching to the "Create Wallet" screen and back seemed a little awkward before) What do you think?


Before/After without wallets:
![image](https://user-images.githubusercontent.com/3358649/154500060-a743adac-45ad-465e-bda0-e06deb6ddfae.png)
![image](https://user-images.githubusercontent.com/3358649/154500119-2c749a97-ec6a-4409-bb44-5485bda1443b.png)

Before/After with wallets:
![image](https://user-images.githubusercontent.com/3358649/154500085-dafb7f64-f781-4a66-bfdf-80750064cbda.png)
![image](https://user-images.githubusercontent.com/3358649/154500146-bf3dd4f8-78e8-448f-a483-38881e80ad98.png)
