### PR TITLE
feat: freeze/unfreeze utxos and fix style on dark theme

### DIFF
--- a/src/components/DisplayAccountUTXOs.jsx
+++ b/src/components/DisplayAccountUTXOs.jsx
@@ -26,7 +26,7 @@ export default function DisplayAccountUTXOs({ utxos, ...props }) {
             </h5>
           </rb.Accordion.Header>
           <rb.Accordion.Body>
-            <DisplayUTXOs utxos={utxos} unit={settings.unit} showBalances={settings.showBalance} />
+            <DisplayUTXOs utxos={utxos} />
           </rb.Accordion.Body>
         </rb.Accordion.Item>
       ))}

--- a/src/components/DisplayAccounts.jsx
+++ b/src/components/DisplayAccounts.jsx
@@ -5,6 +5,31 @@ import { titleize } from '../utils'
 import Balance from './Balance'
 import { useSettings } from '../context/SettingsContext'
 
+const BranchEntry = ({ entry, ...props }) => {
+  const settings = useSettings()
+
+  const { address, amount, hd_path: hdPath, labels, status } = entry
+
+  return (
+    <rb.Card {...props}>
+      <rb.Card.Body>
+        <rb.Row key={address}>
+          <rb.Col xs={'auto'}>
+            <code className="text-break">{hdPath}</code>
+          </rb.Col>
+          <rb.Col lg={{ order: 'last' }} className="d-flex align-items-center justify-content-end">
+            <Balance value={amount} unit={settings.unit} showBalance={settings.showBalance} />
+          </rb.Col>
+          <rb.Col xs={'auto'}>
+            <code className="text-break">{address}</code> {labels && <span className="badge bg-info">{labels}</span>}
+            {status && <span className="badge bg-info">{status}</span>}
+          </rb.Col>
+        </rb.Row>
+      </rb.Card.Body>
+    </rb.Card>
+  )
+}
+
 export default function DisplayAccounts({ accounts, ...props }) {
   const settings = useSettings()
 
@@ -13,18 +38,18 @@ export default function DisplayAccounts({ accounts, ...props }) {
       {Object.values(accounts).map(({ account, account_balance: balance, branches }) => (
         <rb.Accordion.Item key={account} eventKey={account}>
           <rb.Accordion.Header>
-            <rb.Row className="w-100">
-              <rb.Col>
+            <rb.Row className="w-100  me-1">
+              <rb.Col xs={'auto'}>
                 <h5 className="mb-0">
                   {settings.useAdvancedWalletMode ? 'Account' : 'Privacy Level'} {account}
                 </h5>
               </rb.Col>
-              <rb.Col className="d-flex align-items-center justify-content-end pe-5">
+              <rb.Col className="d-flex align-items-center justify-content-end">
                 <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />
               </rb.Col>
             </rb.Row>
           </rb.Accordion.Header>
-          <rb.Accordion.Body className="pe-5">
+          <rb.Accordion.Body>
             <Link to="/send" state={{ account }} className="btn btn-outline-dark">
               Send
             </Link>{' '}
@@ -35,7 +60,7 @@ export default function DisplayAccounts({ accounts, ...props }) {
               const [type, derivation, xpub] = branch.split('\t')
               return (
                 <article key={derivation}>
-                  <rb.Row className="w-100 mt-4">
+                  <rb.Row className="mt-4 pe-3">
                     <rb.Col>
                       <h6>{titleize(type)}</h6>
                     </rb.Col>
@@ -43,28 +68,22 @@ export default function DisplayAccounts({ accounts, ...props }) {
                       <Balance value={balance} unit={settings.unit} showBalance={settings.showBalance} />
                     </rb.Col>
                   </rb.Row>
-                  <rb.Row className="w-100">
+                  <rb.Row className="p-3">
                     <rb.Col xs="auto">
                       <code className="text-break">{derivation}</code>
                     </rb.Col>
-                    <rb.Col className="d-flex align-items-center">
+                    <rb.Col xs="auto">
                       <code className="text-break">{xpub}</code>
                     </rb.Col>
                   </rb.Row>
-                  {entries.map(({ address, amount, hd_path: hdPath, labels, status }) => (
-                    <rb.Row key={address} className="w-100 mt-3">
-                      <rb.Col xs="auto">
-                        <code className="text-break">{hdPath}</code>
-                      </rb.Col>
-                      <rb.Col>
-                        <code className="text-break">{address}</code>{' '}
-                        {labels && <span className="badge bg-info">{labels}</span>}
-                        {status && <span className="badge bg-info">{status}</span>}
-                      </rb.Col>
-                      <rb.Col className="d-flex align-items-center justify-content-end">
-                        <Balance value={amount} unit={settings.unit} showBalance={settings.showBalance} />
-                      </rb.Col>
-                    </rb.Row>
+                  {entries.map((entry, index) => (
+                    <BranchEntry
+                      key={entry.address}
+                      entry={entry}
+                      className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
+                        index === 0 ? 'border-top-1 mt-2' : 'border-top-0'
+                      }`}
+                    />
                   ))}
                 </article>
               )

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -22,7 +22,8 @@ const Utxo = ({ utxo, ...props }) => {
           <rb.Col>
             {utxo.locktime && <span className="me-2">Locked until {displayDate(utxo.locktime)}</span>}
             {utxo.label && <span className="me-2 badge bg-light">{utxo.label}</span>}
-            {utxo.frozen && <span className="badge bg-info">frozen</span>}
+            {utxo.frozen && <span className="me-2 badge bg-info">frozen</span>}
+            {utxo.confirmations === 0 && <span className="badge bg-secondary">unconfirmed</span>}
           </rb.Col>
           <rb.Col className="d-flex align-items-center justify-content-end pe-5">
             <small className="text-secondary">{utxo.confirmations} Confirmations</small>
@@ -37,7 +38,7 @@ export default function DisplayUTXOs({ utxos, ...props }) {
   const settings = useSettings()
 
   return (
-    <rb.ListGroup variant="flush" {...props}>
+    <div {...props}>
       {utxos.map((utxo, index) => (
         <Utxo
           key={utxo.utxo}
@@ -47,6 +48,6 @@ export default function DisplayUTXOs({ utxos, ...props }) {
           }`}
         />
       ))}
-    </rb.ListGroup>
+    </div>
   )
 }

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -4,32 +4,48 @@ import { displayDate } from '../utils'
 import Balance from './Balance'
 import { useSettings } from '../context/SettingsContext'
 
+const Utxo = ({ utxo, ...props }) => {
+  const settings = useSettings()
+
+  return (
+    <rb.Card {...props}>
+      <rb.Card.Body>
+        <rb.Row className="w-100">
+          <rb.Col>
+            <code className="text-break">{utxo.address}</code>
+          </rb.Col>
+          <rb.Col className="d-flex align-items-center justify-content-end pe-5">
+            <Balance value={utxo.value} unit={settings.unit} showBalance={settings.showBalance} />
+          </rb.Col>
+        </rb.Row>
+        <rb.Row className="w-100 mt-1">
+          <rb.Col>
+            {utxo.locktime && <span className="me-2">Locked until {displayDate(utxo.locktime)}</span>}
+            {utxo.label && <span className="me-2 badge bg-light">{utxo.label}</span>}
+            {utxo.frozen && <span className="badge bg-info">frozen</span>}
+          </rb.Col>
+          <rb.Col className="d-flex align-items-center justify-content-end pe-5">
+            <small className="text-secondary">{utxo.confirmations} Confirmations</small>
+          </rb.Col>
+        </rb.Row>
+      </rb.Card.Body>
+    </rb.Card>
+  )
+}
+
 export default function DisplayUTXOs({ utxos, ...props }) {
   const settings = useSettings()
 
   return (
     <rb.ListGroup variant="flush" {...props}>
-      {utxos.map((utxo) => (
-        <rb.ListGroup.Item key={utxo.utxo} className="px-0">
-          <rb.Row className="w-100">
-            <rb.Col>
-              <code className="text-break">{utxo.address}</code>
-            </rb.Col>
-            <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-              <Balance value={utxo.value} unit={settings.unit} showBalance={settings.showBalance} />
-            </rb.Col>
-          </rb.Row>
-          <rb.Row className="w-100 mt-1">
-            <rb.Col>
-              {utxo.locktime && <span className="me-2">Locked until {displayDate(utxo.locktime)}</span>}
-              {utxo.label && <span className="me-2 badge bg-light">{utxo.label}</span>}
-              {utxo.frozen && <span className="badge bg-info">frozen</span>}
-            </rb.Col>
-            <rb.Col className="d-flex align-items-center justify-content-end pe-5">
-              <small className="text-secondary">{utxo.confirmations} Confirmations</small>
-            </rb.Col>
-          </rb.Row>
-        </rb.ListGroup.Item>
+      {utxos.map((utxo, index) => (
+        <Utxo
+          key={utxo.utxo}
+          utxo={utxo}
+          className={`bg-transparent rounded-0 border-start-0 border-end-0 border-bottom-0 ${
+            index === 0 ? 'border-top-0' : 'border-top-1'
+          }`}
+        />
       ))}
     </rb.ListGroup>
   )

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -1,32 +1,90 @@
 import React from 'react'
+import { useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { displayDate } from '../utils'
 import Balance from './Balance'
+import Alert from './Alert'
 import { useSettings } from '../context/SettingsContext'
+import { useCurrentWallet } from '../context/WalletContext'
+import * as Api from '../libs/JmWalletApi'
 
 const Utxo = ({ utxo, ...props }) => {
   const settings = useSettings()
+  const currentWallet = useCurrentWallet()
+
+  const [alert, setAlert] = useState(null)
+  const [isSending, setIsSending] = useState(false)
+
+  const onClickFreeze = async (utxo) => {
+    const { name: walletName, token } = currentWallet
+
+    setAlert(null)
+    setIsSending(true)
+    try {
+      const res = await Api.postFreeze({ walletName, token }, { utxo: utxo.utxo, freeze: !utxo.frozen })
+
+      if (res.ok) {
+        utxo.frozen = !utxo.frozen
+      } else {
+        const { message } = await res.json()
+        setAlert({ variant: 'danger', message, dismissible: true })
+      }
+    } catch (e) {
+      setAlert({ variant: 'danger', message: e.message, dismissible: true })
+    } finally {
+      setIsSending(false)
+    }
+  }
 
   return (
     <rb.Card {...props}>
       <rb.Card.Body>
-        <rb.Row className="w-100">
+        {alert && (
+          <rb.Row>
+            <rb.Col>
+              <Alert {...alert} />
+            </rb.Col>
+          </rb.Row>
+        )}
+        <rb.Row>
           <rb.Col>
             <code className="text-break">{utxo.address}</code>
           </rb.Col>
-          <rb.Col className="d-flex align-items-center justify-content-end pe-5">
+          <rb.Col className="d-flex align-items-center justify-content-end">
             <Balance value={utxo.value} unit={settings.unit} showBalance={settings.showBalance} />
           </rb.Col>
         </rb.Row>
-        <rb.Row className="w-100 mt-1">
+        <rb.Row className="mt-1">
           <rb.Col>
             {utxo.locktime && <span className="me-2">Locked until {displayDate(utxo.locktime)}</span>}
             {utxo.label && <span className="me-2 badge bg-light">{utxo.label}</span>}
             {utxo.frozen && <span className="me-2 badge bg-info">frozen</span>}
             {utxo.confirmations === 0 && <span className="badge bg-secondary">unconfirmed</span>}
           </rb.Col>
-          <rb.Col className="d-flex align-items-center justify-content-end pe-5">
+          <rb.Col className="d-flex align-items-center justify-content-end">
             <small className="text-secondary">{utxo.confirmations} Confirmations</small>
+          </rb.Col>
+        </rb.Row>
+        <rb.Row className="mt-1">
+          <rb.Col className="d-flex align-items-center justify-content-end">
+            <rb.Button
+              size="sm"
+              variant={utxo.frozen ? 'outline-warning' : 'outline-info'}
+              disabled={isSending}
+              onClick={() => onClickFreeze(utxo)}
+            >
+              {utxo.frozen ? 'unfreeze' : 'freeze'}
+              {isSending && (
+                <rb.Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
+                  role="status"
+                  aria-hidden="true"
+                  className="ms-2 me-1"
+                />
+              )}
+            </rb.Button>
           </rb.Col>
         </rb.Row>
       </rb.Card.Body>
@@ -35,8 +93,6 @@ const Utxo = ({ utxo, ...props }) => {
 }
 
 export default function DisplayUTXOs({ utxos, ...props }) {
-  const settings = useSettings()
-
   return (
     <div {...props}>
       {utxos.map((utxo, index) => (

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -144,6 +144,17 @@ const getYieldgenReport = async ({ signal }) => {
   })
 }
 
+const postFreeze = async ({ walletName, token }, { utxo, freeze = true }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/freeze`, {
+    method: 'POST',
+    headers: { ...Authorization(token) },
+    body: JSON.stringify({
+      'utxo-string': utxo,
+      freeze,
+    }),
+  })
+}
+
 export {
   postMakerStart,
   getMakerStop,
@@ -158,4 +169,5 @@ export {
   postWalletUnlock,
   getWalletUtxos,
   getYieldgenReport,
+  postFreeze,
 }


### PR DESCRIPTION
I didn't want to cheat a feature in before the next version. I was just fixing the display in dark mode... and I thought... why not?

I'm happy to just fix the visual defect if you want. However, this would at least provide a proper workaround for users just trying things or testing to recover when they mistakenly sent to an address twice.

Before/After UTXO:
![image](https://user-images.githubusercontent.com/3358649/154507836-8160f6c0-bded-491f-afde-b334df19f142.png)
![image](https://user-images.githubusercontent.com/3358649/154517406-0a4298a6-6ebf-471d-9a91-b164ef847485.png)

Before/After Accounts:
<img width=200 src="https://user-images.githubusercontent.com/3358649/154599538-30837ebf-f7d6-427c-8334-cf46409cff66.png" />
<img width=200 src="https://user-images.githubusercontent.com/3358649/154599524-e802983a-2d6b-495e-99ba-bf3a764a1986.png" />

