### PR TITLE
devtools: document and further automate release process

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version = false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Release Process
+
+This documents our release process.
+
+## Update the Code
+
+Checkout `master` and make sure to pull all the latest changes that sould be included in the release.
+
+## Bump the Version
+
+Use [`npm version`](https://docs.npmjs.com/cli/v6/commands/npm-version) to bump the version and update the changelog.
+Most of the time you will want to run:
+
+```
+npm version <patch|minor|major>
+```
+
+For more details and other possible release types see [the npm docs](https://docs.npmjs.com/cli/v6/commands/npm-version).
+
+This will:
+
+1. Create and checkout a branch for the release preparation: `prepare-v<new-version>-<timestamp>`
+1. Bump the version in `package.json` and `package.lock.json`
+1. Update the changelog
+1. Commit the changes and push the branch
+1. Open a _draft_ pull request to `master`
+
+## Merge the Release Pull Request
+
+This is a good point to clean up the changelog if needed and get feedback on the release.
+When everyone is happy with the release, merge the pull request to `master`.
+
+## Tag the Release
+
+Back on `master`, tag the release and based on the new tag crate a release on GitHub.
+This is a step we might automate completely via GitHub Actions in the future.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ This will:
 1. Bump the version in `package.json` and `package.lock.json`
 1. Update the changelog
 1. Commit the changes and push the branch
-1. Open a _draft_ pull request to `master`
+1. If you have the [GitHub CLI](https://cli.github.com/) installed it will automatically open a _draft_ pull request to `master`
 
 ## Merge the Release Pull Request
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "postinstall": "husky install",
     "lint": "prettier --check --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
     "format": "prettier --write --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
-    "changelog": "node scripts/changelog.mjs"
+    "version": "node scripts/changelog.mjs"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "postinstall": "husky install",
     "lint": "prettier --check --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
     "format": "prettier --write --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
-    "version": "node scripts/changelog.mjs"
+    "version": "node scripts/changelog.mjs && git checkout -b \"prepare-v${npm_package_version}-$(date +%s)\" && git add --all && git commit --message \"chore(release): prepare v${npm_package_version}\" && git push --set-upstream origin $(git branch --show-current)",
+    "postversion": "which gh && gh pr create --title \"chore(release): prepare v${npm_package_version}\" --body \"Prepares the v${npm_package_version} release.\" --reviewer joinmarket-webui/implementation-contributors --assignee @me --label release --repo joinmarket-webui/joinmarket-webui --draft"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint": "prettier --check --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
     "format": "prettier --write --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
     "version": "node scripts/changelog.mjs && git checkout -b \"prepare-v${npm_package_version}-$(date +%s)\" && git add --all && git commit --message \"chore(release): prepare v${npm_package_version}\" && git push --set-upstream origin $(git branch --show-current)",
-    "postversion": "which gh && gh pr create --title \"chore(release): prepare v${npm_package_version}\" --body \"Prepares the v${npm_package_version} release.\" --reviewer joinmarket-webui/implementation-contributors --assignee @me --label release --repo joinmarket-webui/joinmarket-webui --draft"
+    "postversion": "which gh && gh pr create --title \"chore(release): prepare v${npm_package_version}\" --body \"Prepares the v${npm_package_version} release.\" --assignee @me --label release --repo joinmarket-webui/joinmarket-webui --draft"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -1,8 +1,6 @@
 import conventionalChangelog from 'conventional-changelog'
 import fs from 'fs'
 
-const pkg = JSON.parse(fs.readFileSync('./package.json'))
-
 const START_OF_LAST_RELEASE_PATTERN = /(^#+ \[?[0-9]+\.[0-9]+\.[0-9]+|<a name=)/m
 
 const file = 'CHANGELOG.md'
@@ -68,4 +66,4 @@ const generateChangelog = (newVersion) => {
   })
 }
 
-await generateChangelog(pkg.version)
+await generateChangelog(process.env.npm_package_version)


### PR DESCRIPTION
Resolves #105.

Building on the feedback in #103, this integrates `npm version` into the release process.

Now, when you run e.g. `npm version patch`, it will:
1. Bump the version
2. Update the changelog
3. Commit the changes to a branch
4. Push the branch and open a _draft_ PR. (Let me know if we should add a manual step in between here.)

See the new RELEASING.md for more details.

This is just a suggestion. My main goal is to make everything as painless and automated as possible while sticking close to npm tooling. Please let me know what you think of it and what we could do better!