### PR TITLE
Take minimum_makers config var value into account on Send page

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -27,9 +27,9 @@ const isValidAmount = (candidate) => {
   return !isNaN(parsed) && parsed > 0
 }
 
-const isValidNumCollaborators = (candidate) => {
+const isValidNumCollaborators = (candidate, minNumCollaborators) => {
   const parsed = parseInt(candidate, 10)
-  return !isNaN(parsed) && parsed >= 1 && parsed <= 99
+  return !isNaN(parsed) && parsed >= minNumCollaborators && parsed <= 99
 }
 
 const extractErrorMessage = async (response, fallbackReason = 'Unknown Error - No exact reasons are available : (') => {
@@ -53,20 +53,20 @@ const extractErrorMessage = async (response, fallbackReason = 'Unknown Error - N
   return message || fallbackReason
 }
 
-const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators }) => {
+const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCollaborators }) => {
   const settings = useSettings()
 
   const [usesCustomNumCollaborators, setUsesCustomNumCollaborators] = useState(false)
 
   const validateAndSetCustomNumCollaborators = (candidate) => {
-    if (isValidNumCollaborators(candidate)) {
+    if (isValidNumCollaborators(candidate, minNumCollaborators)) {
       setNumCollaborators(candidate)
     } else {
       setNumCollaborators(null)
     }
   }
 
-  const defaultCollaboratorsSelection = [3, 5, 6, 7, 9]
+  const defaultCollaboratorsSelection = [0, 2, 3, 4, 6].map((val) => val + minNumCollaborators)
 
   return (
     <rb.Form noValidate className="collaborators-selector">
@@ -101,9 +101,9 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators }) => {
           })}
           <rb.Form.Control
             type="number"
-            min={1}
+            min={minNumCollaborators}
             max={99}
-            isInvalid={!isValidNumCollaborators(numCollaborators)}
+            isInvalid={!isValidNumCollaborators(numCollaborators, minNumCollaborators)}
             placeholder="Other"
             defaultValue=""
             className={`p-2 border border-1 rounded text-center${
@@ -122,7 +122,7 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators }) => {
           />
           {usesCustomNumCollaborators && (
             <rb.Form.Control.Feedback type="invalid">
-              Please use between 1 and 99 collaborators.
+              Please use between {minNumCollaborators} and 99 collaborators.
             </rb.Form.Control.Feedback>
           )}
         </div>
@@ -139,15 +139,17 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
 
   const location = useLocation()
   const [alert, setAlert] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
   const [isSending, setIsSending] = useState(false)
   const [isCoinjoin, setIsCoinjoin] = useState(false)
   const [isCoinjoinOptionEnabled, setIsCoinjoinOptionEnabled] = useState(!makerRunning && !coinjoinInProcess)
+  const [minNumCollaborators, setMinNumCollaborators] = useState(4) // default value from an unchanged joinmarket.cfg (last check 2022-02-20)
 
   const initialDestination = null
   const initialAccount = 0
   const initialAmount = null
   const initialNumCollaborators = () => {
-    return pseudoRandomNumber(5, 7)
+    return pseudoRandomNumber(minNumCollaborators + 1, minNumCollaborators + 3)
   }
 
   const [destination, setDestination] = useState(initialDestination)
@@ -171,28 +173,45 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
       isValidAddress(destination) &&
       isValidAccount(account) &&
       isValidAmount(amount) &&
-      (isCoinjoin ? isValidNumCollaborators(numCollaborators) : true)
+      (isCoinjoin ? isValidNumCollaborators(numCollaborators, minNumCollaborators) : true)
     ) {
       setFormIsValid(true)
     } else {
       setFormIsValid(false)
     }
-  }, [destination, account, amount, numCollaborators, isCoinjoin])
+  }, [destination, account, amount, numCollaborators, minNumCollaborators, isCoinjoin])
 
   useEffect(() => {
-    // Reload wallet info if not already available.
-    if (walletInfo) return
-
     const abortCtrl = new AbortController()
 
     setAlert(null)
+    setIsLoading(true)
 
-    Api.getWalletDisplay({ walletName: wallet.name, token: wallet.token, signal: abortCtrl.signal })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
-      .then((data) => setWalletInfo(data.walletinfo))
+    const requestContext = { walletName: wallet.name, token: wallet.token, signal: abortCtrl.signal }
+    // Reload wallet info if not already available.
+    const loadingWalletInfo = walletInfo
+      ? Promise.resolve()
+      : Api.getWalletDisplay(requestContext)
+          .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading wallet failed.'))))
+          .then((data) => setWalletInfo(data.walletinfo))
+          .catch((err) => {
+            !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
+          })
+
+    const loadingMinimumMakerConfig = Api.postConfigGet(requestContext, { section: 'POLICY', field: 'minimum_makers' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading config value failed.'))))
+      .then((data) => setMinNumCollaborators(parseInt(data.configvalue, 10)))
       .catch((err) => {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
+
+    Promise.all([loadingWalletInfo, loadingMinimumMakerConfig])
+      .then((_) => {
+        if (minNumCollaborators && numCollaborators < minNumCollaborators) {
+          setNumCollaborators(minNumCollaborators)
+        }
+      })
+      .finally(() => setIsLoading(false))
 
     return () => abortCtrl.abort()
   }, [wallet, setWalletInfo, walletInfo])
@@ -261,7 +280,7 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
     const isValid = formIsValid
 
     if (isValid) {
-      const counterparties = parseInt(numCollaborators)
+      const counterparties = parseInt(numCollaborators, 10)
 
       const success = isCoinjoin
         ? await startCoinjoin(account, destination, amount, counterparties)
@@ -280,7 +299,7 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
 
   return (
     <>
-      {!walletInfo ? (
+      {isLoading ? (
         <rb.Row className="justify-content-center">
           <rb.Col className="flex-grow-0">
             <div className="d-flex justify-content-center align-items-center">
@@ -374,7 +393,11 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
               )}
             </rb.Form>
             {isCoinjoin && (
-              <CollaboratorsSelector numCollaborators={numCollaborators} setNumCollaborators={setNumCollaborators} />
+              <CollaboratorsSelector
+                numCollaborators={numCollaborators}
+                setNumCollaborators={setNumCollaborators}
+                minNumCollaborators={minNumCollaborators}
+              />
             )}
             <rb.Button
               variant="dark"

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -32,27 +32,6 @@ const isValidNumCollaborators = (candidate, minNumCollaborators) => {
   return !isNaN(parsed) && parsed >= minNumCollaborators && parsed <= 99
 }
 
-const extractErrorMessage = async (response, fallbackReason = 'Unknown Error - No exact reasons are available : (') => {
-  // The server will answer with a html response instead of json on certain errors.
-  // The situation is mitigated by parsing the returned html till a fix is available.
-  // Tracked here: https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1170 (last checked: 2022-02-11)
-  const isHtmlErrorMessage = response.headers.get('content-type') === 'text/html'
-
-  if (isHtmlErrorMessage) {
-    return await response
-      .text()
-      .then((html) => {
-        var parser = new DOMParser()
-        var doc = parser.parseFromString(html, 'text/html')
-        return doc.title || fallbackReason
-      })
-      .then((reason) => `The server reported a problem: ${reason}`)
-  }
-
-  const { message } = await response.json()
-  return message || fallbackReason
-}
-
 const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCollaborators }) => {
   const settings = useSettings()
 
@@ -235,7 +214,7 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
         })
         success = true
       } else {
-        const message = await extractErrorMessage(res)
+        const { message } = await res.json()
         setAlert({ variant: 'danger', message })
       }
     } catch (e) {
@@ -261,7 +240,7 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
         setAlert({ variant: 'success', message: 'Collaborative transaction started' })
         success = true
       } else {
-        const message = await extractErrorMessage(res)
+        const { message } = await res.json()
         setAlert({ variant: 'danger', message })
       }
     } catch (e) {

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -8,6 +8,9 @@ import { useCurrentWalletInfo, useSetCurrentWalletInfo, useCurrentWallet } from 
 import { useSettings } from '../context/SettingsContext'
 import * as Api from '../libs/JmWalletApi'
 
+// initial value for `minimum_markers` from the default joinmarket.cfg (last check on 2022-02-20 of v0.9.5)
+const MINIMUM_MAKERS_DEFAULT_VAL = 4
+
 // not cryptographically random
 const pseudoRandomNumber = (min, max) => {
   return Math.round(Math.random() * (max - min)) + min
@@ -122,13 +125,14 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
   const [isSending, setIsSending] = useState(false)
   const [isCoinjoin, setIsCoinjoin] = useState(false)
   const [isCoinjoinOptionEnabled, setIsCoinjoinOptionEnabled] = useState(!makerRunning && !coinjoinInProcess)
-  const [minNumCollaborators, setMinNumCollaborators] = useState(4) // default value from an unchanged joinmarket.cfg (last check 2022-02-20)
+  const [minNumCollaborators, setMinNumCollaborators] = useState(MINIMUM_MAKERS_DEFAULT_VAL)
 
   const initialDestination = null
   const initialAccount = 0
   const initialAmount = null
   const initialNumCollaborators = (minValue) => {
-    return minValue + pseudoRandomNumber(1, 3)
+    // always suggest a reasonably large number even when the configured minimum is unreasonably low
+    return Math.max(MINIMUM_MAKERS_DEFAULT_VAL, minValue) + pseudoRandomNumber(1, 3)
   }
 
   const [destination, setDestination] = useState(initialDestination)

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -155,6 +155,23 @@ const postFreeze = async ({ walletName, token }, { utxo, freeze = true }) => {
   })
 }
 
+/**
+ * Get the value of a specific config setting. Note values are always returned as string.
+ *
+ * @returns an object with property `configvalue` as string
+ */
+const postConfigGet = async ({ walletName, token, signal }, { section, field }) => {
+  return await fetch(`/api/v1/wallet/${walletName}/configget`, {
+    method: 'POST',
+    headers: { ...Authorization(token) },
+    signal,
+    body: JSON.stringify({
+      section,
+      field,
+    }),
+  })
+}
+
 export {
   postMakerStart,
   getMakerStop,
@@ -170,4 +187,5 @@ export {
   getWalletUtxos,
   getYieldgenReport,
   postFreeze,
+  postConfigGet,
 }

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -156,7 +156,7 @@ const postFreeze = async ({ walletName, token }, { utxo, freeze = true }) => {
 }
 
 /**
- * Get the value of a specific config setting. Note values are always returned as string.
+ * Get the value of a specific config setting. Note that values are always returned as string.
  *
  * @returns an object with property `configvalue` as string
  */


### PR DESCRIPTION
Closes #101 

This PR fetches the `minimum_makers` config variable and uses it as minimum amount of collaborators on the Send page.
This means a taker operation cannot be started with a lower value than what is specified in the config file.

One little caveat is that the initial value for the amount collaborators is randomized between `[5, 7]` (min +1, min +3), which can lead to the initial value not being shown as active button in the `CollaboratorsSelector` component. 

<img src="https://user-images.githubusercontent.com/3358649/154958905-3a7ec529-122e-4716-b1a5-6c64ee6f58f9.png" width=400 />
Is this acceptable for now? What do you think?

<br />
<br />

Screenshot for `minimum_makers := 2`:
<img src="https://user-images.githubusercontent.com/3358649/154958686-bead4a3a-9aad-4621-86e0-b40d3d47dcc0.png" width=400 />

<br />

Also, the approach of parsing an error message from `text/html` is removed as this has been fixed in [joinmarket-clientserver#1170](https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1170)

Edit: this also does not take into account if the value is greater than `99` - which is the default maximum amount. Guess that is an unreasonable value and can therefore be ignored.