### PR TITLE
feat: readd websocket connection

### DIFF
--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -124,10 +124,12 @@ services:
       - 8080  # payjoin server
       - 62601 # obwatch
       - 27183 # joinmarketd
-      - 28183 # jmwalletd
+      - 28183 # jmwalletd api
+      - 28283 # jmwalletd websocket
     ports:
       - "62601:62601"
       - "28183:28183"
+      - "28283:28283"
     volumes:
       - "joinmarket_datadir:/root/.joinmarket"
       - "nbxplorer_datadir:/root/.nbxplorer"

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -176,9 +176,11 @@ services:
       - 8080  # payjoin server
       - 62601 # obwatch
       - 27183 # joinmarketd
-      - 28183 # jmwalletd
+      - 28183 # jmwalletd api
+      - 28283 # jmwalletd websocket
     ports:
       - "29183:28183"
+      - "29283:28283"
       - "29080:80"
     volumes:
       - "joinmarket2_datadir:/root/.joinmarket"

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -38,7 +38,9 @@ EXPOSE 8080
 EXPOSE 62601 
 # joinmarketd daemon
 EXPOSE 27183
-# jmwallet daemon
+# jmwallet api
 EXPOSE 28183
+# jmwallet websocket
+EXPOSE 28283
 
 ENTRYPOINT  [ "tini", "-g", "--", "./docker-entrypoint.sh" ]

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -38,9 +38,9 @@ EXPOSE 8080
 EXPOSE 62601 
 # joinmarketd daemon
 EXPOSE 27183
-# jmwallet api
+# jmwalletd api
 EXPOSE 28183
-# jmwallet websocket
+# jmwalletd websocket
 EXPOSE 28283
 
 ENTRYPOINT  [ "tini", "-g", "--", "./docker-entrypoint.sh" ]

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -33,6 +33,7 @@ export default function App() {
 
   const [makerRunning, setMakerRunning] = useState()
   const [connectionError, setConnectionError] = useState()
+  const [websocketConnected, setWebsocketConnected] = useState()
   const [coinjoinInProcess, setCoinjoinInProcess] = useState()
   const [showAlphaWarning, setShowAlphaWarning] = useState(false)
   const settings = useSettings()
@@ -75,11 +76,7 @@ export default function App() {
   // update the connection indicator based on the websocket connection state
   useEffect(() => {
     const websocketError = websocketState !== WebSocket.CONNECTING && websocketState !== WebSocket.OPEN
-    if (!websocketError) {
-      setConnectionError(null)
-    } else {
-      setConnectionError('Websocket is disconnected.')
-    }
+    setWebsocketConnected(!websocketError)
   }, [websocketState])
 
   useEffect(() => {
@@ -110,9 +107,6 @@ export default function App() {
         })
         .catch((err) => {
           if (!abortCtrl.signal.aborted) {
-            // set the connection error message from the http request as it
-            // might contain more useful information for the user than just
-            // "Websocket is disconnected", e.g. "Gateway Timeout"
             setConnectionError(err.message)
             resetState()
           }
@@ -267,8 +261,8 @@ export default function App() {
             </rb.Nav.Item>
           </div>
           <div className="d-flex order-0 order-md-2 flex-1 justify-content-center justify-content-md-end align-items-center">
-            <span className={`mx-1 ${connectionError ? 'text-danger' : 'text-success'}`}>•</span>
-            <span className="text-secondary">{connectionError ? 'Disconnected' : 'Connected'}</span>
+            <span className={`mx-1 ${websocketConnected ? 'text-success' : 'text-danger'}`}>•</span>
+            <span className="text-secondary">{websocketConnected ? 'Connected' : 'Disconnected'}</span>
           </div>
         </rb.Container>
       </rb.Nav>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -75,8 +75,7 @@ export default function App() {
 
   // update the connection indicator based on the websocket connection state
   useEffect(() => {
-    const websocketError = websocketState !== WebSocket.CONNECTING && websocketState !== WebSocket.OPEN
-    setWebsocketConnected(!websocketError)
+    setWebsocketConnected(websocketState === WebSocket.OPEN)
   }, [websocketState])
 
   useEffect(() => {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -11,7 +11,12 @@ import CurrentWalletAdvanced from './CurrentWalletAdvanced'
 import Settings from './Settings'
 import Navbar from './Navbar'
 import { useSettings } from '../context/SettingsContext'
-import { useWebsocket, useWebsocketState } from '../context/WebsocketContext'
+import {
+  useWebsocket,
+  useWebsocketState,
+  CJ_STATE_TAKER_RUNNING,
+  CJ_STATE_MAKER_RUNNING,
+} from '../context/WebsocketContext'
 import { useCurrentWallet, useSetCurrentWallet, useSetCurrentWalletInfo } from '../context/WalletContext'
 import { getSession, setSession, clearSession } from '../session'
 import * as Api from '../libs/JmWalletApi'
@@ -51,14 +56,10 @@ export default function App() {
   const onWebsocketMessage = useCallback((message) => {
     const data = JSON.parse(message?.data)
 
-    // if the data contains a property named `coinjoin_state`...
+    // update the maker/taker indicator according to `coinjoin_state` property
     if (data && typeof data.coinjoin_state === 'number') {
-      // ... update the maker/taker indicator accordingly:
-      // 0 := Taker running
-      // 1 := Maker running
-      // 2 := Neither are running
-      setCoinjoinInProcess(data.coinjoin_state === 0)
-      setMakerRunning(data.coinjoin_state === 1)
+      setCoinjoinInProcess(data.coinjoin_state === CJ_STATE_TAKER_RUNNING)
+      setMakerRunning(data.coinjoin_state === CJ_STATE_MAKER_RUNNING)
     }
   }, [])
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -47,9 +47,16 @@ export default function App() {
     setCurrentWalletInfo(null)
   }
 
+  // update maker/taker indicator based on websocket data
   const onWebsocketMessage = useCallback((message) => {
     const data = JSON.parse(message?.data)
+
+    // if the data contains a property named `coinjoin_state`...
     if (data && typeof data.coinjoin_state === 'number') {
+      // ... update the maker/taker indicator accordingly:
+      // 0 := Taker running
+      // 1 := Maker running
+      // 2 := Neither are running
       setCoinjoinInProcess(data.coinjoin_state === 0)
       setMakerRunning(data.coinjoin_state === 1)
     }
@@ -60,9 +67,10 @@ export default function App() {
 
     websocket.addEventListener('message', onWebsocketMessage)
 
-    return () => websocket.removeEventListener('message', onWebsocketMessage)
+    return () => websocket && websocket.removeEventListener('message', onWebsocketMessage)
   }, [websocket, onWebsocketMessage])
 
+  // update the connection indicator based on the websocket connection state
   useEffect(() => {
     const websocketError = websocketState !== WebSocket.CONNECTING && websocketState !== WebSocket.OPEN
     if (!websocketError) {

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -330,14 +330,15 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
                 className="slashed-zeroes"
                 isInvalid={!isValidAccount(account)}
               >
-                {walletInfo.accounts
-                  .sort((lhs, rhs) => lhs.account - rhs.account)
-                  .map(({ account, account_balance: balance }) => (
-                    <option key={account} value={account}>
-                      {settings.useAdvancedWalletMode ? 'Account' : 'Privacy Level'} {account}{' '}
-                      {settings.showBalance && `(\u20BF${balance})`}
-                    </option>
-                  ))}
+                {walletInfo &&
+                  walletInfo.accounts
+                    .sort((lhs, rhs) => lhs.account - rhs.account)
+                    .map(({ account, account_balance: balance }) => (
+                      <option key={account} value={account}>
+                        {settings.useAdvancedWalletMode ? 'Account' : 'Privacy Level'} {account}{' '}
+                        {settings.showBalance && `(\u20BF${balance})`}
+                      </option>
+                    ))}
               </rb.Form.Select>
             </rb.Form.Group>
             <rb.Form.Group className="mb-4" controlId="amount">

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -18,21 +18,23 @@ const createWebSocket = () => {
   const scheme = protocol === 'https:' ? 'wss' : 'ws'
   const websocket = new WebSocket(`${scheme}://${host}${WEBSOCKET_ENDPOINT_PATH}`)
 
-  websocket.onopen = () => {
-    console.debug('websocket connection openend')
-  }
+  if (process.env.NODE_ENV !== 'production') {
+    websocket.onopen = () => {
+      console.debug('websocket connection openend')
+    }
 
-  websocket.onclose = () => {
-    console.debug('websocket connection closed')
+    websocket.onclose = () => {
+      console.debug('websocket connection closed')
+    }
+
+    websocket.onmessage = (event) => {
+      const data = JSON.parse(event?.data)
+      console.debug('websocket message', data)
+    }
   }
 
   websocket.onerror = (error) => {
     console.error('websocket error', error)
-  }
-
-  websocket.onmessage = (event) => {
-    const data = JSON.parse(event?.data)
-    console.debug('websocket message', data)
   }
 
   return websocket

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -20,6 +20,7 @@ const WebsocketProvider = ({ children }) => {
     websocket.current.onopen = () => {
       console.debug('websocket connection openend')
     }
+
     websocket.current.onclose = () => {
       console.debug('websocket connection closed')
     }
@@ -43,8 +44,14 @@ const WebsocketProvider = ({ children }) => {
     // The client must send the authentication token when it connects,
     // otherwise it will not receive any notifications.
     const initNotifications = () => {
-      if (websocket.current && currentWallet) {
+      if (!websocket.current || !currentWallet) return
+
+      if (websocket.current.readyState === WebSocket.OPEN) {
         websocket.current.send(currentWallet.token)
+      } else if (websocket.current.readyState === WebSocket.CONNECTING) {
+        websocket.current.onopen = () => {
+          websocket.current.send(currentWallet.token)
+        }
       }
     }
 

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -1,0 +1,65 @@
+import React, { createContext, useEffect, useRef, useContext } from 'react'
+
+import { useCurrentWallet } from './WalletContext'
+
+const WebsocketContext = createContext()
+
+const WebsocketProvider = ({ children }) => {
+  const websocket = useRef(null)
+  const currentWallet = useCurrentWallet()
+
+  useEffect(() => {
+    if (websocket.current) {
+      websocket.current.close()
+    }
+
+    const { protocol, host } = window.location
+    const scheme = protocol === 'https:' ? 'wss' : 'ws'
+    websocket.current = new WebSocket(`${scheme}://${host}/jmws`)
+
+    websocket.current.onopen = () => {
+      console.debug('websocket connection openend')
+    }
+    websocket.current.onclose = () => {
+      console.debug('websocket connection closed')
+    }
+
+    websocket.current.onerror = (error) => {
+      console.error('websocket error', error)
+    }
+
+    websocket.current.onmessage = (event) => {
+      const wsdata = JSON.parse(event.data)
+      console.debug('websocket sent', wsdata)
+    }
+
+    const wsCurrent = websocket.current
+    return () => {
+      wsCurrent.close()
+    }
+  }, [])
+
+  useEffect(() => {
+    // The client must send the authentication token when it connects,
+    // otherwise it will not receive any notifications.
+    const initNotifications = () => {
+      if (websocket.current && currentWallet) {
+        websocket.current.send(currentWallet.token)
+      }
+    }
+
+    initNotifications()
+  }, [currentWallet])
+
+  return <WebsocketContext.Provider value={{ websocket: websocket.current }}>{children}</WebsocketContext.Provider>
+}
+
+const useWebsocket = () => {
+  const context = useContext(WebsocketContext)
+  if (context === undefined) {
+    throw new Error('useWebsocket must be used within a WebsocketProvider')
+  }
+  return context.websocket
+}
+
+export { WebsocketContext, WebsocketProvider, useWebsocket }

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -29,6 +29,10 @@ const createWebSocket = () => {
   const scheme = protocol === 'https:' ? 'wss' : 'ws'
   const websocket = new WebSocket(`${scheme}://${host}${WEBSOCKET_ENDPOINT_PATH}`)
 
+  websocket.onerror = (error) => {
+    console.error('websocket error', error)
+  }
+
   if (process.env.NODE_ENV !== 'production') {
     websocket.onopen = () => {
       console.debug('websocket connection openend')
@@ -37,15 +41,6 @@ const createWebSocket = () => {
     websocket.onclose = () => {
       console.debug('websocket connection closed')
     }
-
-    websocket.onmessage = (event) => {
-      const data = JSON.parse(event?.data)
-      console.debug('websocket message', data)
-    }
-  }
-
-  websocket.onerror = (error) => {
-    console.error('websocket error', error)
   }
 
   return websocket

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -8,6 +8,11 @@ const WEBSOCKET_RECONNECT_DELAY = 1_000
 // path that will be proxied to the backend server
 const WEBSOCKET_ENDPOINT_PATH = '/jmws'
 
+// possible values for property `coinjoin_state` in websocket messages
+const CJ_STATE_TAKER_RUNNING = 0
+const CJ_STATE_MAKER_RUNNING = 1
+const CJ_STATE_NONE_RUNNING = 2
+
 const createWebSocket = () => {
   const { protocol, host } = window.location
   const scheme = protocol === 'https:' ? 'wss' : 'ws'
@@ -114,4 +119,12 @@ const useWebsocketState = () => {
   return context.websocketState
 }
 
-export { WebsocketContext, WebsocketProvider, useWebsocket, useWebsocketState }
+export {
+  WebsocketContext,
+  WebsocketProvider,
+  useWebsocket,
+  useWebsocketState,
+  CJ_STATE_TAKER_RUNNING,
+  CJ_STATE_MAKER_RUNNING,
+  CJ_STATE_NONE_RUNNING,
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './components/App'
 import { SettingsProvider } from './context/SettingsContext'
 import { WalletProvider } from './context/WalletContext'
+import { WebsocketProvider } from './context/WebsocketContext'
 import reportWebVitals from './reportWebVitals'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import '@ibunker/bitcoin-react/dist/index.css'
@@ -13,7 +14,9 @@ ReactDOM.render(
   <BrowserRouter>
     <SettingsProvider>
       <WalletProvider>
-        <App />
+        <WebsocketProvider>
+          <App />
+        </WebsocketProvider>
       </WalletProvider>
     </SettingsProvider>
   </BrowserRouter>,

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -2,8 +2,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware')
 
 module.exports = (app) => {
   app.use(
-    '/api/',
-    createProxyMiddleware({
+    createProxyMiddleware('/api/', {
       target: 'https://localhost:28183',
       changeOrigin: true,
       secure: false,
@@ -15,10 +14,12 @@ module.exports = (app) => {
       },
     })
   )
+
+  // https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/JSON-RPC-API-using-jmwalletd.md#websocket
   app.use(
-    '/ws/',
-    createProxyMiddleware({
-      target: 'wss://localhost:28183',
+    createProxyMiddleware('/jmws', {
+      target: 'https://localhost:28283',
+      pathRewrite: { '^/jmws': '' },
       changeOrigin: true,
       secure: false,
       ws: true,


### PR DESCRIPTION
This PR reintroduces the websocket connection to the backend. Closes #46.

The backend listens on port 28283 for incoming websocket connections.
See the [jmwalletd websocket documentation](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.5/docs/JSON-RPC-API-using-jmwalletd.md#websocket).

A reverse proxy must pass all incoming connections with path `/jmws` to the backend server.
`/jmws` was chosen, as `/ws` is used by [`WebpackDevServer` by default](https://github.com/facebook/create-react-app/blob/v5.0.0/packages/react-dev-utils/webpackHotDevClient.js#L66). We could change that, but having it on a different path has some benefits.

The websocket connection, as it is currently implemented, is responsible for two things:
- Updating the maker/taker state
- Updating the connection indicator

#### Updating the maker/taker state
Before this PR the maker/taker state has only been updated by polling the `/session` api endpoint.
As the endpoint is polled only every 10 seconds (at the time of writing), this resulted in a user not being informed for some time whether an action had actually been performed. Now, the user is informed in (near) real-time.

#### Updating the connection indicator
Once the websocket connection is lost or closed, the connection indicator is updated. Also resulting in (near) real-time information to the user.

### Approach
As a websocket connection can be established without any authentication, it will be created when the application is loaded.
Once a wallet has been created or unlocked, the token is sent to the server, enabling receiving sensitive information.
When a wallet is closed or locked, the websocket connection is  kept open and reused once another wallet is unlocked.

If the connection is closed, an attempt is made to reopen the connection after a short delay. This delay is currently set to 1 second.

TODO:
- [x] Establish websocket connection
- [x] Update taker/maker state based on event data
- [x] Handle disconnects
- [x] Connection indicator based on websocket state in addition to state of request polling
- [x] Documentation (code, PR, etc.)
- [x] Update docker setup (see https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/21)

Manual tests:
- [x] Reconnect after connection loss
- [x] Connect after initial failing connection
- [x] Successful connection with the (currently used) basic auth setup
- [x] Messages received correctly when switching wallets

#### Known Issues
- Shortly before unloading the window (e.g on a page refresh), the "No connection to backend" message is briefly displayed. This is expected as the websocket connection is closed, but it is rather unattractive. Guess it can be lived with (?).
- A "normal" transaction is received multiple times via websocket (consistently 4 times during testing), a collaborative transaction is received multiple times every 5 seconds (everytime the backend calls bitcoin core's `listtransactions` rpc method). We don't use this information or display it to the user anywhere, so it might not that big of a problem for now.