### PR TITLE
feat: allow for deployment in subdirectory

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <link rel="base-url" href=".">
+    <link rel="public-url" href="%PUBLIC_URL%">
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg">
     <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" crossorigin="use-credentials">
@@ -12,6 +14,14 @@
     <title>JoinMarket</title>
     <script>
       window.JM = { SETTINGS_STORE_KEY: 'jm-settings', THEMES: ['light', 'dark'], THEME_ROOT_ATTR: 'data-theme' }
+      // determine base path depending on whether PUBLIC_URL is set
+      const baseUrl = document.querySelector('link[rel="base-url"]').href
+      const publicUrl = document.querySelector('link[rel="public-url"]').href
+      const base = baseUrl.length > publicUrl.length ? baseUrl : publicUrl
+      window.JM.PUBLIC_PATH = base
+        .replace(`${window.location.protocol}//${window.location.host}`, '') // remove domain part
+        .replace(/\/$/, '') // remove trailing slash
+      // theme
       const settings = JSON.parse(window.localStorage.getItem(JM.SETTINGS_STORE_KEY) || '{}')
       const userColorMode = settings.theme;
       const systemColorMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? JM.THEMES[1] : JM.THEMES[0];

--- a/src/components/Sprite.jsx
+++ b/src/components/Sprite.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function Sprite({ symbol, className, ...props }) {
   return (
     <svg role="img" className={`d-inline-block sprite sprite-${symbol}${className ? ` ${className}` : ''}`} {...props}>
-      <use href={`${process.env.PUBLIC_URL}/sprite.svg#${symbol}`}></use>
+      <use href={`${window.JM.PUBLIC_PATH}/sprite.svg#${symbol}`}></use>
     </svg>
   )
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ import '@ibunker/bitcoin-react/dist/index.css'
 import './index.css'
 
 ReactDOM.render(
-  <BrowserRouter>
+  <BrowserRouter basename={window.JM.PUBLIC_PATH}>
     <SettingsProvider>
       <WalletProvider>
         <App />

--- a/src/libs/JmWalletApi.js
+++ b/src/libs/JmWalletApi.js
@@ -10,6 +10,7 @@
  * 'x-jm-authorization' so that the reverse proxy can apply its own
  * authentication mechanism.
  */
+const BASE_PATH = `${window.JM.PUBLIC_PATH}/api`
 
 /**
  * Construct a bearer authorization header object for the given token.
@@ -25,18 +26,18 @@ const Authorization = (token) => {
 }
 
 const getSession = async ({ signal }) => {
-  return await fetch(`/api/v1/session`, { signal })
+  return await fetch(`${BASE_PATH}/v1/session`, { signal })
 }
 
 const getAddressNew = async ({ walletName, token, accountNr, signal }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/address/new/${accountNr}`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/address/new/${accountNr}`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
 const getWalletAll = async ({ signal }) => {
-  return await fetch(`/api/v1/wallet/all`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/all`, {
     signal,
   })
 }
@@ -44,7 +45,7 @@ const getWalletAll = async ({ signal }) => {
 const postWalletCreate = async ({ walletName: name, password }) => {
   const walletname = name.endsWith('.jmdat') ? name : `${name}.jmdat`
 
-  return await fetch(`/api/v1/wallet/create`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/create`, {
     method: 'POST',
     body: JSON.stringify({
       wallettype: 'sw-fb',
@@ -55,7 +56,7 @@ const postWalletCreate = async ({ walletName: name, password }) => {
 }
 
 const getWalletDisplay = async ({ walletName, token, signal }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/display`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/display`, {
     headers: { ...Authorization(token) },
     signal,
   })
@@ -68,27 +69,27 @@ const getWalletDisplay = async ({ walletName, token, signal }) => {
  * Note: Performs a non-idempotent GET request.
  */
 const getWalletLock = async ({ walletName, token }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/lock`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/lock`, {
     headers: { ...Authorization(token) },
   })
 }
 
 const postWalletUnlock = async ({ walletName }, { password }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/unlock`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/unlock`, {
     method: 'POST',
     body: JSON.stringify({ password }),
   })
 }
 
 const getWalletUtxos = async ({ walletName, token, signal }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/utxos`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/utxos`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
 const postMakerStart = async ({ walletName, token, signal }, { cjfee_a, cjfee_r, ordertype, minsize }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/maker/start`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/maker/start`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     signal,
@@ -108,13 +109,13 @@ const postMakerStart = async ({ walletName, token, signal }, { cjfee_a, cjfee_r,
  * Note: Performs a non-idempotent GET request.
  */
 const getMakerStop = async ({ walletName, token }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/maker/stop`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/maker/stop`, {
     headers: { ...Authorization(token) },
   })
 }
 
 const postDirectSend = async ({ walletName, token }, { account, destination, amount_sats }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/taker/direct-send`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/taker/direct-send`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     body: JSON.stringify({
@@ -126,7 +127,7 @@ const postDirectSend = async ({ walletName, token }, { account, destination, amo
 }
 
 const postCoinjoin = async ({ walletName, token }, { account, destination, amount_sats, counterparties }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/taker/coinjoin`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/taker/coinjoin`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     body: JSON.stringify({
@@ -139,13 +140,13 @@ const postCoinjoin = async ({ walletName, token }, { account, destination, amoun
 }
 
 const getYieldgenReport = async ({ signal }) => {
-  return await fetch(`/api/v1/wallet/yieldgen/report`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/yieldgen/report`, {
     signal,
   })
 }
 
 const postFreeze = async ({ walletName, token }, { utxo, freeze = true }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/freeze`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/freeze`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     body: JSON.stringify({
@@ -161,7 +162,7 @@ const postFreeze = async ({ walletName, token }, { utxo, freeze = true }) => {
  * @returns an object with property `configvalue` as string
  */
 const postConfigGet = async ({ walletName, token, signal }, { section, field }) => {
-  return await fetch(`/api/v1/wallet/${walletName}/configget`, {
+  return await fetch(`${BASE_PATH}/v1/wallet/${walletName}/configget`, {
     method: 'POST',
     headers: { ...Authorization(token) },
     signal,


### PR DESCRIPTION
Right now the only way to deploy the web UI is with a separate host, it does not work in a subdirectory/path like `/joinmarket/`. I came across this trying to integrate the Web UI into the BTCPay Server setup. We want to avoid the complexity of setting up different hosts (and SSL certs) per service, that's why we deploy services in paths under the main domain.  

This PR determines the deployment base path depending on whether `PUBLIC_URL` is set. We aren't making use of the [`PUBLIC_URL` environment variable](https://create-react-app.dev/docs/adding-custom-environment-variables/#referencing-environment-variables-in-the-html), which is perfectly fine as it would require us to set it on build time and different integrations might want to use different paths anyways. 

I've tested this setting up a local proxy which pipes requests from `http://localhost:4000/joinmarket/` to `http://localhost:3000/` in order to check whether or not the asset URLs and API requests still work. From my tests the approach in `index.html` works even if `PUBLIC_URL` is set. It feels a bit hacky to get to the base path that way, but I did not find any other way and it looks like it works reliably. 

The determined path is then used to set the base for the API requests and act as the [`basename` for React Router](https://reactrouterdotcom.fly.dev/docs/en/v6/api#router). The asset paths work just fine because we've already set the [`homepage` property in package.json](https://create-react-app.dev/docs/deployment/#step-1-add-homepage-to-packagejson).