### PR TITLE
fix: set state on mounted component only

### DIFF
--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -36,10 +36,10 @@ export default function Wallet({ name, currentWallet, startWallet, stopWallet, s
             variant: 'danger',
             message: message.replace('Wallet', walletName),
           })
+          setIsUnlocking(false)
         }
       } catch (e) {
         setAlert({ variant: 'danger', message: e.message })
-      } finally {
         setIsUnlocking(false)
       }
     }

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -40,7 +40,11 @@ export default function Wallets({ startWallet, stopWallet }) {
           setAlert({ variant: 'danger', message: err.message })
         }
       })
-      .finally(() => setIsLoading(false))
+      .finally(() => {
+        if (!abortCtrl.signal.aborted) {
+          setIsLoading(false)
+        }
+      })
 
     return () => abortCtrl.abort()
   }, [currentWallet])


### PR DESCRIPTION
Resolves #43.

Fixes two inaccuracies where a component's state was set after it was not mounted anymore.

<details>
<summary>Click for original error messages</summary>
<p><code>
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
Wallet@http://localhost:3000/main.b9362308f6a079a3bad2.hot-update.js:50:7
div
./node_modules/react-bootstrap/esm/Col.js/Col<@http://localhost:3000/static/js/bundle.js:25391:14
div
./node_modules/react-bootstrap/esm/Row.js/Row<@http://localhost:3000/static/js/bundle.js:27416:7
Wallets@http://localhost:3000/static/js/bundle.js:6638:7
</code></p>

<p><code>
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
Wallets@http://localhost:3000/static/js/bundle.js:6638:7
</code></p>
</summary>