### PR TITLE
refactor: dry up app layout

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -155,12 +155,14 @@ export default function App() {
                 </>
               )}
             </Route>
-            {currentWallet && (
-              <Route element={<Layout variant={settings.useAdvancedWalletMode ? 'wide' : 'narrow'} />}>
-                <Route
-                  path="wallet"
-                  element={settings.useAdvancedWalletMode ? <CurrentWalletAdvanced /> : <CurrentWalletMagic />}
-                />
+            {currentWallet && !settings.useAdvancedWalletMode && (
+              <Route element={<Layout variant="narrow" />}>
+                <Route path="wallet" element={<CurrentWalletMagic />} />
+              </Route>
+            )}
+            {currentWallet && settings.useAdvancedWalletMode && (
+              <Route element={<Layout variant="wide" />}>
+                <Route path="wallet" element={<CurrentWalletAdvanced />} />
               </Route>
             )}
             <Route path="*" element={<Navigate to="/" replace={true} />} />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -156,9 +156,7 @@ export default function App() {
               )}
             </Route>
             {currentWallet && (
-              <Route
-                element={<Layout isWide={settings.useAdvancedWalletMode} isNarrow={!settings.useAdvancedWalletMode} />}
-              >
+              <Route element={<Layout variant={settings.useAdvancedWalletMode ? 'wide' : 'narrow'} />}>
                 <Route
                   path="wallet"
                   element={settings.useAdvancedWalletMode ? <CurrentWalletAdvanced /> : <CurrentWalletMagic />}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,6 +10,7 @@ import CurrentWalletMagic from './CurrentWalletMagic'
 import CurrentWalletAdvanced from './CurrentWalletAdvanced'
 import Settings from './Settings'
 import Navbar from './Navbar'
+import Layout from './Layout'
 import { useSettings } from '../context/SettingsContext'
 import { useCurrentWallet, useSetCurrentWallet, useSetCurrentWalletInfo } from '../context/WalletContext'
 import { getSession, setSession, clearSession } from '../session'
@@ -127,34 +128,42 @@ export default function App() {
           <rb.Alert variant="danger">No connection to backend: {connectionError}.</rb.Alert>
         ) : (
           <Routes>
-            <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
-            <Route
-              path="create-wallet"
-              element={<CreateWallet currentWallet={currentWallet} startWallet={startWallet} />}
-            />
+            <Route element={<Layout />}>
+              <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
+              <Route
+                path="create-wallet"
+                element={<CreateWallet currentWallet={currentWallet} startWallet={startWallet} />}
+              />
+              {currentWallet && (
+                <>
+                  <Route
+                    path="send"
+                    element={<Send makerRunning={makerRunning} coinjoinInProcess={coinjoinInProcess} />}
+                  />
+                  <Route
+                    path="earn"
+                    element={
+                      <Earn
+                        currentWallet={currentWallet}
+                        coinjoinInProcess={coinjoinInProcess}
+                        makerRunning={makerRunning}
+                      />
+                    }
+                  />
+                  <Route path="receive" element={<Receive currentWallet={currentWallet} />} />
+                  <Route path="settings" element={<Settings currentWallet={currentWallet} />} />
+                </>
+              )}
+            </Route>
             {currentWallet && (
-              <>
+              <Route
+                element={<Layout isWide={settings.useAdvancedWalletMode} isNarrow={!settings.useAdvancedWalletMode} />}
+              >
                 <Route
                   path="wallet"
                   element={settings.useAdvancedWalletMode ? <CurrentWalletAdvanced /> : <CurrentWalletMagic />}
                 />
-                <Route
-                  path="send"
-                  element={<Send makerRunning={makerRunning} coinjoinInProcess={coinjoinInProcess} />}
-                />
-                <Route
-                  path="earn"
-                  element={
-                    <Earn
-                      currentWallet={currentWallet}
-                      coinjoinInProcess={coinjoinInProcess}
-                      makerRunning={makerRunning}
-                    />
-                  }
-                />
-                <Route path="receive" element={<Receive currentWallet={currentWallet} />} />
-                <Route path="settings" element={<Settings currentWallet={currentWallet} />} />
-              </>
+              </Route>
             )}
             <Route path="*" element={<Navigate to="/" replace={true} />} />
           </Routes>

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -163,30 +163,28 @@ export default function CreateWallet({ startWallet }) {
   const canCreate = !currentWallet && !isCreated
 
   return (
-    <rb.Row className="create-wallet justify-content-center">
-      <rb.Col md={10} lg={8} xl={6}>
-        {isCreated ? (
-          <PageTitle
-            title="Wallet created successfully!"
-            subtitle="Please write down your seed phrase and password! Without this information you will not be able to access and recover your wallet!"
-            success
-          />
-        ) : (
-          <PageTitle title="Create Wallet" />
-        )}
-        {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
-        {canCreate && <WalletCreationForm createWallet={createWallet} isCreating={isCreating} />}
-        {isCreated && <WalletCreationConfirmation createdWallet={createdWallet} walletConfirmed={walletConfirmed} />}
-        {!canCreate && !isCreated && (
-          <rb.Alert variant="warning">
-            Currently <strong>{walletDisplayName(currentWallet.name)}</strong> is active. You need to lock it first.{' '}
-            <Link to="/" className="alert-link">
-              Go back
-            </Link>
-            .
-          </rb.Alert>
-        )}
-      </rb.Col>
-    </rb.Row>
+    <div className="create-wallet">
+      {isCreated ? (
+        <PageTitle
+          title="Wallet created successfully!"
+          subtitle="Please write down your seed phrase and password! Without this information you will not be able to access and recover your wallet!"
+          success
+        />
+      ) : (
+        <PageTitle title="Create Wallet" />
+      )}
+      {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
+      {canCreate && <WalletCreationForm createWallet={createWallet} isCreating={isCreating} />}
+      {isCreated && <WalletCreationConfirmation createdWallet={createdWallet} walletConfirmed={walletConfirmed} />}
+      {!canCreate && !isCreated && (
+        <rb.Alert variant="warning">
+          Currently <strong>{walletDisplayName(currentWallet.name)}</strong> is active. You need to lock it first.{' '}
+          <Link to="/" className="alert-link">
+            Go back
+          </Link>
+          .
+        </rb.Alert>
+      )}
+    </div>
   )
 }

--- a/src/components/CurrentWalletAdvanced.jsx
+++ b/src/components/CurrentWalletAdvanced.jsx
@@ -51,12 +51,16 @@ export default function CurrentWalletAdvanced() {
     <div>
       {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
       {isLoading && (
-        <div className="mb-3">
-          <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
-          Loading
-        </div>
+        <rb.Row className="justify-content-center">
+          <rb.Col className="flex-grow-0">
+            <div className="d-flex mb-3">
+              <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+              Loading
+            </div>
+          </rb.Col>
+        </rb.Row>
       )}
-      {walletInfo && <DisplayAccounts accounts={walletInfo.accounts} className="mb-4" />}
+      {!isLoading && walletInfo && <DisplayAccounts accounts={walletInfo.accounts} className="mb-4" />}
       {!!fidelityBonds?.length && (
         <div className="mt-5 mb-3 pe-3">
           <h5>Fidelity Bonds</h5>

--- a/src/components/CurrentWalletAdvanced.jsx
+++ b/src/components/CurrentWalletAdvanced.jsx
@@ -14,7 +14,7 @@ export default function CurrentWalletAdvanced() {
   const [utxos, setUtxos] = useState(null)
   const [showUTXO, setShowUTXO] = useState(false)
   const [alert, setAlert] = useState(null)
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     const abortCtrl = new AbortController()

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -89,7 +89,7 @@ export default function CurrentWalletMagic() {
   }, [wallet, setWalletInfo])
 
   return (
-    <rb.Container fluid className="privacy-levels">
+    <div className="privacy-levels">
       {alert && (
         <rb.Row>
           <rb.Col>
@@ -108,54 +108,52 @@ export default function CurrentWalletMagic() {
         </rb.Row>
       )}
       {!isLoading && wallet && walletInfo && (
-        <rb.Row className="justify-content-center">
-          <rb.Col xs={10} sm={8} md={6} lg={4}>
-            <rb.Row
-              onClick={() => settingsDispatch({ showBalance: !settings.showBalance })}
-              style={{ cursor: 'pointer' }}
-            >
-              <WalletHeader
-                name={wallet.name}
-                balance={walletInfo.total_balance}
-                unit={settings.unit}
-                showBalance={settings.showBalance}
-              />
-            </rb.Row>
-            <rb.Row className="mt-4">
-              <rb.Col>
-                {/* Always receive on first mixdepth. */}
-                <Link to="/receive" state={{ account: 0 }} className="btn btn-outline-dark w-100">
-                  Deposit
-                </Link>
-              </rb.Col>
-              <rb.Col>
-                {/* Todo: Withdrawing needs to factor in the privacy levels as well.
-                Depending on the mixdepth/account there will be different amounts available. */}
-                <Link to="/send" className="btn btn-outline-dark w-100">
-                  Withdraw
-                </Link>
-              </rb.Col>
-            </rb.Row>
-            <rb.Row>
-              <hr className="my-4" />
-            </rb.Row>
-            <rb.Row>
-              <PrivacyLevels accounts={walletInfo.accounts} />
-            </rb.Row>
-            <rb.Row>
-              <hr className="my-4" />
-            </rb.Row>
-            <rb.Row>
-              <Link to="/" className="btn btn-outline-dark">
-                <div className="d-flex justify-content-center align-items-center">
-                  <Sprite symbol="wallet" width="24" height="24" />
-                  <div className="ps-1">Switch Wallet</div>
-                </div>
+        <>
+          <rb.Row
+            onClick={() => settingsDispatch({ showBalance: !settings.showBalance })}
+            style={{ cursor: 'pointer' }}
+          >
+            <WalletHeader
+              name={wallet.name}
+              balance={walletInfo.total_balance}
+              unit={settings.unit}
+              showBalance={settings.showBalance}
+            />
+          </rb.Row>
+          <rb.Row className="mt-4">
+            <rb.Col>
+              {/* Always receive on first mixdepth. */}
+              <Link to="/receive" state={{ account: 0 }} className="btn btn-outline-dark w-100">
+                Deposit
               </Link>
-            </rb.Row>
-          </rb.Col>
-        </rb.Row>
+            </rb.Col>
+            <rb.Col>
+              {/* Todo: Withdrawing needs to factor in the privacy levels as well.
+                Depending on the mixdepth/account there will be different amounts available. */}
+              <Link to="/send" className="btn btn-outline-dark w-100">
+                Withdraw
+              </Link>
+            </rb.Col>
+          </rb.Row>
+          <rb.Row>
+            <hr className="my-4" />
+          </rb.Row>
+          <rb.Row>
+            <PrivacyLevels accounts={walletInfo.accounts} />
+          </rb.Row>
+          <rb.Row>
+            <hr className="my-4" />
+          </rb.Row>
+          <rb.Row>
+            <Link to="/" className="btn btn-outline-dark">
+              <div className="d-flex justify-content-center align-items-center">
+                <Sprite symbol="wallet" width="24" height="24" />
+                <div className="ps-1">Switch Wallet</div>
+              </div>
+            </Link>
+          </rb.Row>
+        </>
       )}
-    </rb.Container>
+    </div>
   )
 }

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -232,8 +232,8 @@ export default function Earn({ currentWallet, coinjoinInProcess, makerRunning })
 
   return (
     <div className="earn">
-      <rb.Row className="justify-content-center">
-        <rb.Col md={10} lg={8} xl={6}>
+      <rb.Row>
+        <rb.Col>
           <PageTitle
             title="Earn bitcoin"
             subtitle="By making your bitcoin available for others, you help them improve their privacy and can also earn a yield."
@@ -354,8 +354,8 @@ export default function Earn({ currentWallet, coinjoinInProcess, makerRunning })
       </rb.Row>
 
       {settings.useAdvancedWalletMode && (
-        <rb.Row className="justify-content-center mt-5 mb-3">
-          <rb.Col md={10} lg={8} xl={6}>
+        <rb.Row className="mt-5 mb-3">
+          <rb.Col>
             <rb.Button
               variant="outline-dark"
               className="border-0 mb-2 d-inline-flex align-items-center"

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import * as rb from 'react-bootstrap'
+import { Outlet } from 'react-router-dom'
+
+const Col = ({ isWide, isNarrow, children }) => {
+  if (isWide) {
+    return <rb.Col>{children}</rb.Col>
+  }
+
+  if (isNarrow) {
+    return (
+      <rb.Col xs={10} sm={8} md={6} lg={4}>
+        {children}
+      </rb.Col>
+    )
+  }
+
+  return (
+    <rb.Col md={10} lg={8} xl={6}>
+      {children}
+    </rb.Col>
+  )
+}
+
+const Layout = ({ isWide = false, isNarrow = false }) => {
+  return (
+    <rb.Row className="justify-content-center">
+      <Col isWide={isWide} isNarrow={isNarrow}>
+        <Outlet />
+      </Col>
+    </rb.Row>
+  )
+}
+
+export default Layout

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -2,12 +2,12 @@ import React from 'react'
 import * as rb from 'react-bootstrap'
 import { Outlet } from 'react-router-dom'
 
-const Col = ({ isWide, isNarrow, children }) => {
-  if (isWide) {
+const Col = ({ variant, children }) => {
+  if (variant === 'wide') {
     return <rb.Col>{children}</rb.Col>
   }
 
-  if (isNarrow) {
+  if (variant === 'narrow') {
     return (
       <rb.Col xs={10} sm={8} md={6} lg={4}>
         {children}
@@ -22,10 +22,10 @@ const Col = ({ isWide, isNarrow, children }) => {
   )
 }
 
-const Layout = ({ isWide = false, isNarrow = false }) => {
+const Layout = ({ variant }) => {
   return (
     <rb.Row className="justify-content-center">
-      <Col isWide={isWide} isNarrow={isNarrow}>
+      <Col variant={variant}>
         <Outlet />
       </Col>
     </rb.Row>

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -73,124 +73,107 @@ export default function Receive({ currentWallet }) {
   }
 
   return (
-    <>
-      <rb.Row className="receive justify-content-center">
-        <rb.Col md={10} lg={8} xl={6}>
-          <PageTitle title="Receive bitcoin" subtitle="Send bitcoin to the address below." />
-          {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
-          {address && (
-            <div className="qr-container">
-              <rb.Card className={`${settings.theme === 'light' ? 'pt-2' : 'pt-4'} pb-4`}>
-                <div className="d-flex justify-content-center">
-                  {amount ? (
-                    <BitcoinQR bitcoinAddress={address} amount={satsToBtc(amount)} title={address} />
-                  ) : (
-                    <BitcoinQR bitcoinAddress={address} title={address} />
-                  )}
-                </div>
-                <rb.Card.Body className={`${settings.theme === 'light' ? 'pt-0' : 'pt-3'} pb-0`}>
-                  <rb.Card.Text className="text-center slashed-zeroes">{address}</rb.Card.Text>
-                  <div className="d-flex justify-content-center" style={{ gap: '1rem' }}>
-                    <rb.Button
-                      variant="outline-dark"
-                      data-bs-toggle="tooltip"
-                      data-bs-placement="left"
-                      onClick={() => {
-                        // might not work on iOS.
-                        navigator.clipboard.writeText(address).then(
-                          () => {
-                            setAddressCopiedFlag(addressCopiedFlag + 1)
-                          },
-                          () => {
-                            setAlert({ variant: 'warning', message: 'Could not copy address.' })
-                          }
-                        )
-                      }}
-                    >
-                      {showAddressCopiedConfirmation ? (
-                        <>
-                          Copied
-                          <Sprite color="green" symbol="checkmark" className="ms-1" width="20" height="20" />
-                        </>
-                      ) : (
-                        'Copy'
-                      )}
-                    </rb.Button>
-                  </div>
-                </rb.Card.Body>
-              </rb.Card>
-            </div>
-          )}
-          <div className="mt-4">
-            <rb.Button
-              variant={`${settings.theme}`}
-              className="ps-0 border-0 d-flex align-items-center"
-              onClick={() => setShowSettings(!showSettings)}
-            >
-              Settings
-              <Sprite symbol={`caret-${showSettings ? 'up' : 'down'}`} className="ms-1" width="20" height="20" />
-            </rb.Button>
-          </div>
-          <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
-            {showSettings && (
-              <>
-                <rb.Form.Group className="mt-4" controlId="account">
-                  <rb.Form.Label>Choose {settings.useAdvancedWalletMode ? 'account' : 'privacy level'}</rb.Form.Label>
-                  <rb.Form.Select
-                    defaultValue={account}
-                    onChange={(e) => setAccount(parseInt(e.target.value, 10))}
-                    required
-                    disabled={!settings.useAdvancedWalletMode}
-                  >
-                    {ACCOUNTS.map((val) => (
-                      <option key={val} value={val}>
-                        {settings.useAdvancedWalletMode ? 'Account' : 'Privacy level'} {val}
-                      </option>
-                    ))}
-                  </rb.Form.Select>
-                </rb.Form.Group>
-                <rb.Form.Group className="my-4" controlId="amountSats">
-                  <rb.Form.Label>Amount to request in sats</rb.Form.Label>
-                  <rb.Form.Control
-                    className="slashed-zeroes"
-                    name="amount"
-                    type="number"
-                    placeholder="0"
-                    value={amount}
-                    min={0}
-                    onChange={(e) => setAmount(e.target.value)}
-                  />
-                  <rb.Form.Control.Feedback type="invalid">Please provide a valid amount.</rb.Form.Control.Feedback>
-                </rb.Form.Group>
-              </>
-            )}
-            <hr />
-            <rb.Button
-              variant="outline-dark"
-              type="submit"
-              disabled={isLoading}
-              className="mt-2"
-              style={{ width: '100%' }}
-            >
-              {isLoading ? (
-                <div>
-                  <rb.Spinner
-                    as="span"
-                    animation="border"
-                    size="sm"
-                    role="status"
-                    aria-hidden="true"
-                    className="me-2"
-                  />
-                  Getting new address
-                </div>
+    <div className="receive">
+      <PageTitle title="Receive bitcoin" subtitle="Send bitcoin to the address below." />
+      {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
+      {address && (
+        <div className="qr-container">
+          <rb.Card className={`${settings.theme === 'light' ? 'pt-2' : 'pt-4'} pb-4`}>
+            <div className="d-flex justify-content-center">
+              {amount ? (
+                <BitcoinQR bitcoinAddress={address} amount={satsToBtc(amount)} title={address} />
               ) : (
-                'Get new address'
+                <BitcoinQR bitcoinAddress={address} title={address} />
               )}
-            </rb.Button>
-          </rb.Form>
-        </rb.Col>
-      </rb.Row>
-    </>
+            </div>
+            <rb.Card.Body className={`${settings.theme === 'light' ? 'pt-0' : 'pt-3'} pb-0`}>
+              <rb.Card.Text className="text-center slashed-zeroes">{address}</rb.Card.Text>
+              <div className="d-flex justify-content-center" style={{ gap: '1rem' }}>
+                <rb.Button
+                  variant="outline-dark"
+                  data-bs-toggle="tooltip"
+                  data-bs-placement="left"
+                  onClick={() => {
+                    // might not work on iOS.
+                    navigator.clipboard.writeText(address).then(
+                      () => {
+                        setAddressCopiedFlag(addressCopiedFlag + 1)
+                      },
+                      () => {
+                        setAlert({ variant: 'warning', message: 'Could not copy address.' })
+                      }
+                    )
+                  }}
+                >
+                  {showAddressCopiedConfirmation ? (
+                    <>
+                      Copied
+                      <Sprite color="green" symbol="checkmark" className="ms-1" width="20" height="20" />
+                    </>
+                  ) : (
+                    'Copy'
+                  )}
+                </rb.Button>
+              </div>
+            </rb.Card.Body>
+          </rb.Card>
+        </div>
+      )}
+      <div className="mt-4">
+        <rb.Button
+          variant={`${settings.theme}`}
+          className="ps-0 border-0 d-flex align-items-center"
+          onClick={() => setShowSettings(!showSettings)}
+        >
+          Settings
+          <Sprite symbol={`caret-${showSettings ? 'up' : 'down'}`} className="ms-1" width="20" height="20" />
+        </rb.Button>
+      </div>
+      <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
+        {showSettings && (
+          <>
+            <rb.Form.Group className="mt-4" controlId="account">
+              <rb.Form.Label>Choose {settings.useAdvancedWalletMode ? 'account' : 'privacy level'}</rb.Form.Label>
+              <rb.Form.Select
+                defaultValue={account}
+                onChange={(e) => setAccount(parseInt(e.target.value, 10))}
+                required
+                disabled={!settings.useAdvancedWalletMode}
+              >
+                {ACCOUNTS.map((val) => (
+                  <option key={val} value={val}>
+                    {settings.useAdvancedWalletMode ? 'Account' : 'Privacy level'} {val}
+                  </option>
+                ))}
+              </rb.Form.Select>
+            </rb.Form.Group>
+            <rb.Form.Group className="my-4" controlId="amountSats">
+              <rb.Form.Label>Amount to request in sats</rb.Form.Label>
+              <rb.Form.Control
+                className="slashed-zeroes"
+                name="amount"
+                type="number"
+                placeholder="0"
+                value={amount}
+                min={0}
+                onChange={(e) => setAmount(e.target.value)}
+              />
+              <rb.Form.Control.Feedback type="invalid">Please provide a valid amount.</rb.Form.Control.Feedback>
+            </rb.Form.Group>
+          </>
+        )}
+        <hr />
+        <rb.Button variant="outline-dark" type="submit" disabled={isLoading} className="mt-2" style={{ width: '100%' }}>
+          {isLoading ? (
+            <div>
+              <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+              Getting new address
+            </div>
+          ) : (
+            'Get new address'
+          )}
+        </rb.Button>
+      </rb.Form>
+    </div>
   )
 }

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -290,121 +290,110 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
           </rb.Col>
         </rb.Row>
       ) : (
-        <rb.Row className="send justify-content-center">
-          <rb.Col md={10} lg={8} xl={6}>
-            <PageTitle
-              title="Send bitcoin"
-              subtitle="Collaborative transactions increase the privacy of yourself and others."
-            />
+        <div className="send">
+          <PageTitle
+            title="Send bitcoin"
+            subtitle="Collaborative transactions increase the privacy of yourself and others."
+          />
 
-            <rb.Fade in={!isCoinjoinOptionEnabled} mountOnEnter={true} unmountOnExit={true}>
-              <div className="mb-4 p-3 border border-1 rounded">
-                <small className="text-secondary">
-                  {makerRunning && <>Earn is active. Stop the service in order to send collaborative transactions.</>}
-                  {coinjoinInProcess && <>A collaborative transaction is currently in progress.</>}
-                </small>
-              </div>
-            </rb.Fade>
+          <rb.Fade in={!isCoinjoinOptionEnabled} mountOnEnter={true} unmountOnExit={true}>
+            <div className="mb-4 p-3 border border-1 rounded">
+              <small className="text-secondary">
+                {makerRunning && <>Earn is active. Stop the service in order to send collaborative transactions.</>}
+                {coinjoinInProcess && <>A collaborative transaction is currently in progress.</>}
+              </small>
+            </div>
+          </rb.Fade>
 
-            {alert && (
-              <rb.Alert className="slashed-zeroes" variant={alert.variant}>
-                {alert.message}
-              </rb.Alert>
-            )}
+          {alert && (
+            <rb.Alert className="slashed-zeroes" variant={alert.variant}>
+              {alert.message}
+            </rb.Alert>
+          )}
 
-            <rb.Form onSubmit={onSubmit} noValidate id="send-form">
-              <rb.Form.Group className="mb-4" controlId="destination">
-                <rb.Form.Label>Recipient</rb.Form.Label>
-                <rb.Form.Control
-                  name="destination"
-                  placeholder="Enter address..."
-                  className="slashed-zeroes"
-                  value={destination || ''}
-                  required
-                  onChange={(e) => setDestination(e.target.value)}
-                  isInvalid={destination !== null && !isValidAddress(destination)}
-                />
-                <rb.Form.Control.Feedback type="invalid">Please provide a recipient address.</rb.Form.Control.Feedback>
-              </rb.Form.Group>
-              <rb.Form.Group className="mb-4 flex-grow-1" controlId="account">
-                <rb.Form.Label>
-                  {settings.useAdvancedWalletMode ? 'Account' : 'Privacy level'} to send from
-                </rb.Form.Label>
-                <rb.Form.Select
-                  defaultValue={account}
-                  onChange={(e) => setAccount(parseInt(e.target.value, 10))}
-                  required
-                  className="slashed-zeroes"
-                  isInvalid={!isValidAccount(account)}
-                >
-                  {walletInfo.accounts
-                    .sort((lhs, rhs) => lhs.account - rhs.account)
-                    .map(({ account, account_balance: balance }) => (
-                      <option key={account} value={account}>
-                        {settings.useAdvancedWalletMode ? 'Account' : 'Privacy Level'} {account}{' '}
-                        {settings.showBalance && `(\u20BF${balance})`}
-                      </option>
-                    ))}
-                </rb.Form.Select>
-              </rb.Form.Group>
-              <rb.Form.Group className="mb-4" controlId="amount">
-                <rb.Form.Label form="send-form">Amount in sats</rb.Form.Label>
-                <rb.Form.Control
-                  name="amount"
-                  type="number"
-                  value={amount || ''}
-                  className="slashed-zeroes"
-                  min={1}
-                  placeholder="Enter amount..."
-                  required
-                  onChange={(e) => setAmount(parseInt(e.target.value, 10))}
-                  isInvalid={amount !== null && !isValidAmount(amount)}
-                />
-                <rb.Form.Control.Feedback form="send-form" type="invalid">
-                  Please provide a valid amount.
-                </rb.Form.Control.Feedback>
-              </rb.Form.Group>
-              {isCoinjoinOptionEnabled && (
-                <rb.Form.Group controlId="isCoinjoin" className={`${isCoinjoin ? 'mb-3' : ''}`}>
-                  <ToggleSwitch
-                    label="Send as collaborative transaction for improved privacy"
-                    onToggle={(isToggled) => setIsCoinjoin(isToggled)}
-                  />
-                </rb.Form.Group>
-              )}
-            </rb.Form>
-            {isCoinjoin && (
-              <CollaboratorsSelector
-                numCollaborators={numCollaborators}
-                setNumCollaborators={setNumCollaborators}
-                minNumCollaborators={minNumCollaborators}
+          <rb.Form onSubmit={onSubmit} noValidate id="send-form">
+            <rb.Form.Group className="mb-4" controlId="destination">
+              <rb.Form.Label>Recipient</rb.Form.Label>
+              <rb.Form.Control
+                name="destination"
+                placeholder="Enter address..."
+                className="slashed-zeroes"
+                value={destination || ''}
+                required
+                onChange={(e) => setDestination(e.target.value)}
+                isInvalid={destination !== null && !isValidAddress(destination)}
               />
+              <rb.Form.Control.Feedback type="invalid">Please provide a recipient address.</rb.Form.Control.Feedback>
+            </rb.Form.Group>
+            <rb.Form.Group className="mb-4 flex-grow-1" controlId="account">
+              <rb.Form.Label>{settings.useAdvancedWalletMode ? 'Account' : 'Privacy level'} to send from</rb.Form.Label>
+              <rb.Form.Select
+                defaultValue={account}
+                onChange={(e) => setAccount(parseInt(e.target.value, 10))}
+                required
+                className="slashed-zeroes"
+                isInvalid={!isValidAccount(account)}
+              >
+                {walletInfo.accounts
+                  .sort((lhs, rhs) => lhs.account - rhs.account)
+                  .map(({ account, account_balance: balance }) => (
+                    <option key={account} value={account}>
+                      {settings.useAdvancedWalletMode ? 'Account' : 'Privacy Level'} {account}{' '}
+                      {settings.showBalance && `(\u20BF${balance})`}
+                    </option>
+                  ))}
+              </rb.Form.Select>
+            </rb.Form.Group>
+            <rb.Form.Group className="mb-4" controlId="amount">
+              <rb.Form.Label form="send-form">Amount in sats</rb.Form.Label>
+              <rb.Form.Control
+                name="amount"
+                type="number"
+                value={amount || ''}
+                className="slashed-zeroes"
+                min={1}
+                placeholder="Enter amount..."
+                required
+                onChange={(e) => setAmount(parseInt(e.target.value, 10))}
+                isInvalid={amount !== null && !isValidAmount(amount)}
+              />
+              <rb.Form.Control.Feedback form="send-form" type="invalid">
+                Please provide a valid amount.
+              </rb.Form.Control.Feedback>
+            </rb.Form.Group>
+            {isCoinjoinOptionEnabled && (
+              <rb.Form.Group controlId="isCoinjoin" className={`${isCoinjoin ? 'mb-3' : ''}`}>
+                <ToggleSwitch
+                  label="Send as collaborative transaction for improved privacy"
+                  onToggle={(isToggled) => setIsCoinjoin(isToggled)}
+                />
+              </rb.Form.Group>
             )}
-            <rb.Button
-              variant="dark"
-              type="submit"
-              disabled={isSending || !formIsValid}
-              className="mt-4"
-              form="send-form"
-            >
-              {isSending ? (
-                <div>
-                  <rb.Spinner
-                    as="span"
-                    animation="border"
-                    size="sm"
-                    role="status"
-                    aria-hidden="true"
-                    className="me-2"
-                  />
-                  Sending
-                </div>
-              ) : (
-                'Send'
-              )}
-            </rb.Button>
-          </rb.Col>
-        </rb.Row>
+          </rb.Form>
+          {isCoinjoin && (
+            <CollaboratorsSelector
+              numCollaborators={numCollaborators}
+              setNumCollaborators={setNumCollaborators}
+              minNumCollaborators={minNumCollaborators}
+            />
+          )}
+          <rb.Button
+            variant="dark"
+            type="submit"
+            disabled={isSending || !formIsValid}
+            className="mt-4"
+            form="send-form"
+          >
+            {isSending ? (
+              <div>
+                <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+                Sending
+              </div>
+            ) : (
+              'Send'
+            )}
+          </rb.Button>
+        </div>
       )}
     </>
   )

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -281,14 +281,10 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
   return (
     <>
       {isLoading ? (
-        <rb.Row className="justify-content-center">
-          <rb.Col className="flex-grow-0">
-            <div className="d-flex justify-content-center align-items-center">
-              <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
-              Loading
-            </div>
-          </rb.Col>
-        </rb.Row>
+        <div className="d-flex justify-content-center align-items-center">
+          <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+          Loading
+        </div>
       ) : (
         <div className="send">
           <PageTitle

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import * as rb from 'react-bootstrap'
 import Sprite from './Sprite'
+import PageTitle from './PageTitle'
 import { useSettings, useSettingsDispatch } from '../context/SettingsContext'
 import { SATS, BTC } from '../utils'
 
@@ -20,8 +21,7 @@ export default function Settings({ currentWallet }) {
 
   return (
     <div>
-      <h1 className="mb-4">Settings</h1>
-
+      <PageTitle title="Settings" />
       <div style={{ marginLeft: '-.75rem' }}>
         <rb.Button
           variant="outline-dark"

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -50,42 +50,40 @@ export default function Wallets({ startWallet, stopWallet }) {
   }, [currentWallet])
 
   return (
-    <rb.Row className="wallets justify-content-center">
-      <rb.Col md={10} lg={8} xl={6}>
-        <PageTitle
-          title="Your wallets"
-          subtitle={walletList?.length === 0 ? 'It looks like you do not have a wallet, yet.' : null}
-          center={true}
-        />
-        {alert && <Alert {...alert} />}
-        {isLoading && (
-          <div>
-            <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
-            Loading wallets
-          </div>
-        )}
-        {walletList?.map((wallet, index) => (
-          <Wallet
-            key={wallet}
-            name={wallet}
-            currentWallet={currentWallet}
-            startWallet={startWallet}
-            stopWallet={stopWallet}
-            setAlert={setAlert}
-            className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
-              index === 0 ? 'border-top-1' : 'border-top-0'
-            }`}
-          />
-        ))}
-        <div className="d-flex justify-content-center">
-          <Link
-            to="/create-wallet"
-            className={`btn mt-4 ${walletList?.length === 0 ? 'btn-lg btn-dark' : 'btn-outline-dark'}`}
-          >
-            Create new wallet
-          </Link>
+    <div className="wallets">
+      <PageTitle
+        title="Your wallets"
+        subtitle={walletList?.length === 0 ? 'It looks like you do not have a wallet, yet.' : null}
+        center={true}
+      />
+      {alert && <Alert {...alert} />}
+      {isLoading && (
+        <div>
+          <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+          Loading wallets
         </div>
-      </rb.Col>
-    </rb.Row>
+      )}
+      {walletList?.map((wallet, index) => (
+        <Wallet
+          key={wallet}
+          name={wallet}
+          currentWallet={currentWallet}
+          startWallet={startWallet}
+          stopWallet={stopWallet}
+          setAlert={setAlert}
+          className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
+            index === 0 ? 'border-top-1' : 'border-top-0'
+          }`}
+        />
+      ))}
+      <div className="d-flex justify-content-center">
+        <Link
+          to="/create-wallet"
+          className={`btn mt-4 ${walletList?.length === 0 ? 'btn-lg btn-dark' : 'btn-outline-dark'}`}
+        >
+          Create new wallet
+        </Link>
+      </div>
+    </div>
   )
 }

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -58,7 +58,7 @@ export default function Wallets({ startWallet, stopWallet }) {
       />
       {alert && <Alert {...alert} />}
       {isLoading && (
-        <div>
+        <div className="d-flex justify-content-center align-items-center">
           <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
           Loading wallets
         </div>


### PR DESCRIPTION
Resloves #107.

Moves the repetitive 

``` html
<Row>
  <Col md={10} lg={8} xl={6}>
    <!-- ... -->
  </Col>
</Row>
```

we had on almost every page and raises it up to the `App.jsx` level:

``` html
<Routes>
  <Route element={<Layout />}>
    <Route path="/" element={<Wallets />} />
    <Route path="create-wallet" element={<CreateWallet />}
      <!-- ... -->
  </Route>
</Routes>
```

Unfortunately, Git doesn't detect the changes well so it looks like a lot of changes when in reality its just removing the wrapping `Row` and `Col` tags from all the pages.