### PR TITLE
fix: add bottom spacing to onboarding screen

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -128,7 +128,7 @@ export default function App() {
 
   if (settings.showOnboarding === true) {
     return (
-      <rb.Container className="onboarding mt-5">
+      <rb.Container className="onboarding mt-5 mb-5">
         <rb.Row className="justify-content-center mt-md-5">
           <rb.Col xs={10} sm={10} md={8} lg={6} xl={4}>
             <Onboarding />

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -128,7 +128,7 @@ export default function App() {
 
   if (settings.showOnboarding === true) {
     return (
-      <rb.Container className="onboarding mt-5 mb-5">
+      <rb.Container className="onboarding my-5">
         <rb.Row className="justify-content-center mt-md-5">
           <rb.Col xs={10} sm={10} md={8} lg={6} xl={4}>
             <Onboarding />


### PR DESCRIPTION
Tiny, tiny, tiny change..: Add bottom spacing to the onboarding screen:

Before:
<img src="https://user-images.githubusercontent.com/3358649/156003858-2a5afaff-d8bf-4121-9984-5360a10fa752.png" width=200 />
After:
<img src="https://user-images.githubusercontent.com/3358649/156003888-36718b38-12e8-48a3-8a4a-bce23b50da18.png" width=200 />
