### PR TITLE
fix: missing APP_USER env variable

### DIFF
--- a/docker/regtest/dockerfile-deps/joinmarket/latest/docker-entrypoint.sh
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+export APP_USER=root
 export JM_onion_serving_host="$(/sbin/ip route | awk '/src/ { print $9 }')"
 
 # First we restore the default cfg as created by wallet-tool.py generate


### PR DESCRIPTION
This is possibly a docker issue for development. I wasn't able to run `regtest_joinmarket2` without this environment variable