### PR TITLE
docs: update raspiblitz install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If your node of choice is missing, feel free to integrate it and let us know so 
 The alpha version of the JoinMarket Web UI is [available as CLI install in RaspiBlitz v1.7.2](https://github.com/rootzoll/raspiblitz/pull/2747). To install it, exit the Raspiblitz menu and run:
 
 ```sh
+patch
 config.scripts/bonus.joinmarket-webui.sh on
 ```
 


### PR DESCRIPTION
Raspiblitz fixes [^1][^2] are now merged and can be fetched by running `patch`. After that, the install will work.

[^1]: https://github.com/rootzoll/raspiblitz/pull/2987
[^2]: https://github.com/rootzoll/raspiblitz/pull/2988