### PR TITLE
chore: check for dependencies in dev setup scripts

### DIFF
--- a/docker/regtest/common.sh
+++ b/docker/regtest/common.sh
@@ -54,7 +54,7 @@ fi
 
 is_docker_container_running() {
   [ -z "${1-}" ] && die "is_docker_container_running: Missing required parameter: name"
-  echo $(docker ps --filter "name=^/${1-}$" --filter status=running -q)
+  echo "$(docker ps --filter "name=^/${1-}$" --filter status=running -q)"
 }
 
 # --------------------------
@@ -77,7 +77,7 @@ unlock_wallet() {
     # param "--insecure": Is needed because a self-signed certificate is used in joinmarket regtest container
     # param "--silent": Don't show progress meter or error messages (errors are reactivated with "--show-error").
     # param "--show-error": When used with -s, --silent, it makes curl show an error message if it fails.
-    local unlock_result=$(curl "$base_url/api/v1/wallet/$wallet_name/unlock" --silent --show-error --insecure --data $unlock_request_payload | jq ".")
+    local unlock_result="$(curl "$base_url/api/v1/wallet/$wallet_name/unlock" --silent --show-error --insecure --data "$unlock_request_payload" | jq ".")"
 
     local unlock_result_error_msg=$(jq -r '. | select(.message != null) | .message' <<< "$unlock_result")
     if [ "$unlock_result_error_msg" != "" ]; then
@@ -134,7 +134,7 @@ create_wallet() {
     local wallet_password=${3:-}
     local create_request_payload="{\"password\":\"$wallet_password\",\"walletname\":\"$wallet_name\",\"wallettype\":\"sw-fb\"}"
 
-    local create_result=$(curl "$base_url/api/v1/wallet/create" --silent --show-error --insecure --data $create_request_payload | jq ".")
+    local create_result="$(curl "$base_url/api/v1/wallet/create" --silent --show-error --insecure --data "$create_request_payload" | jq ".")"
 
     local create_result_error_msg=$(jq -r '. | select(.message != null) | .message' <<< "$create_result")
     if [ "$create_result_error_msg" != "" ]; then
@@ -181,8 +181,8 @@ fetch_new_address() {
 fetch_available_wallets() {
     local base_url=${1:-}
 
-    local wallet_all_result=$(curl "$base_url/api/v1/wallet/all" --silent --show-error --insecure | jq ".")
-    local available_wallets=$(jq -r '.wallets' <<< "$wallet_all_result")
+    local wallet_all_result="$(curl "$base_url/api/v1/wallet/all" --silent --show-error --insecure | jq ".")"
+    local available_wallets="$(jq -r '.wallets' <<< "$wallet_all_result")"
 
     echo "$available_wallets"
 }
@@ -210,8 +210,8 @@ verify_no_open_session_or_throw() {
       die "Could not connect to joinmarket. Please make sure jmwalletd is running inside container."
     fi
 
-    [ $(jq -r '.session' <<< "$session_result") != "false" ] && die "Please make sure no session is active."
-    [ $(jq -r '.wallet_name' <<< "$session_result") != "None" ] && die "Please make sure no wallet is active."
+    [ "$(jq -r '.session' <<< "$session_result")" != "false" ] && die "Please make sure no session is active."
+    [ "$(jq -r '.wallet_name' <<< "$session_result")" != "None" ] && die "Please make sure no wallet is active."
 
     return 0
 }

--- a/docker/regtest/common.sh
+++ b/docker/regtest/common.sh
@@ -11,6 +11,9 @@ setup_colors() {
   fi
 }
 
+# setup colors to enable using `msg_*` functions immediately
+setup_colors
+
 msg() {
   echo >&2 -e "${1-}"
 }
@@ -37,6 +40,17 @@ die() {
   exit "$code"
 }
 
+### Check if dependencies are installed.
+################################################################################
+if ! command -v curl &> /dev/null; then
+    die "This script needs 'curl' to run. Consider installing it."
+fi
+if ! command -v jq &> /dev/null; then
+    die "This script needs 'jq' to run. Consider installing it."
+fi
+if ! command -v docker &> /dev/null; then
+    die "This script needs 'docker' to run. Consider installing it."
+fi
 
 is_docker_container_running() {
   [ -z "${1-}" ] && die "is_docker_container_running: Missing required parameter: name"

--- a/docker/regtest/common.sh
+++ b/docker/regtest/common.sh
@@ -54,7 +54,8 @@ fi
 
 is_docker_container_running() {
   [ -z "${1-}" ] && die "is_docker_container_running: Missing required parameter: name"
-  echo "$(docker ps --filter "name=^/${1-}$" --filter status=running -q)"
+  local result; result=$(docker ps --filter "name=^/${1-}$" --filter status=running -q)
+  echo "$result"
 }
 
 # --------------------------
@@ -69,17 +70,17 @@ is_docker_container_running() {
 ##    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
 ## }
 unlock_wallet() {
-    local base_url=${1:-}
-    local wallet_name=${2:-}
-    local wallet_password=${3:-}
-    local unlock_request_payload="{\"password\":\"$wallet_password\"}"
+    local base_url; base_url=${1:-}
+    local wallet_name; wallet_name=${2:-}
+    local wallet_password; wallet_password=${3:-}
+    local unlock_request_payload; unlock_request_payload="{\"password\":\"$wallet_password\"}"
 
     # param "--insecure": Is needed because a self-signed certificate is used in joinmarket regtest container
     # param "--silent": Don't show progress meter or error messages (errors are reactivated with "--show-error").
     # param "--show-error": When used with -s, --silent, it makes curl show an error message if it fails.
-    local unlock_result="$(curl "$base_url/api/v1/wallet/$wallet_name/unlock" --silent --show-error --insecure --data "$unlock_request_payload" | jq ".")"
+    local unlock_result; unlock_result="$(curl "$base_url/api/v1/wallet/$wallet_name/unlock" --silent --show-error --insecure --data "$unlock_request_payload" | jq ".")"
 
-    local unlock_result_error_msg=$(jq -r '. | select(.message != null) | .message' <<< "$unlock_result")
+    local unlock_result_error_msg; unlock_result_error_msg=$(jq -r '. | select(.message != null) | .message' <<< "$unlock_result")
     if [ "$unlock_result_error_msg" != "" ]; then
         die "$unlock_result_error_msg"
     fi
@@ -99,13 +100,13 @@ unlock_wallet() {
 ##  "already_locked": false
 ## }
 lock_wallet() {
-    local base_url=${1:-}
-    local auth_header=${2:-}
-    local wallet_name=${3:-}
+    local base_url; base_url=${1:-}
+    local auth_header; auth_header=${2:-}
+    local wallet_name; wallet_name=${3:-}
     
-    local lock_result=$(curl "$base_url/api/v1/wallet/$wallet_name/lock" --silent --show-error --insecure -H "$auth_header" | jq ".")
+    local lock_result; lock_result=$(curl "$base_url/api/v1/wallet/$wallet_name/lock" --silent --show-error --insecure -H "$auth_header" | jq ".")
 
-    local locked_wallet_name=$(jq -r '.walletname' <<< "$lock_result")
+    local locked_wallet_name; locked_wallet_name=$(jq -r '.walletname' <<< "$lock_result")
     [ "$locked_wallet_name" != "$wallet_name" ] && die "Problem while locking wallet $wallet_name"
 
     echo "$lock_result"
@@ -129,14 +130,14 @@ lock_wallet() {
 ##  "message": "Wallet file cannot be overwritten."
 ## }
 create_wallet() {
-    local base_url=${1:-}
-    local wallet_name=${2:-}
-    local wallet_password=${3:-}
-    local create_request_payload="{\"password\":\"$wallet_password\",\"walletname\":\"$wallet_name\",\"wallettype\":\"sw-fb\"}"
+    local base_url; base_url=${1:-}
+    local wallet_name; wallet_name=${2:-}
+    local wallet_password; wallet_password=${3:-}
+    local create_request_payload; create_request_payload="{\"password\":\"$wallet_password\",\"walletname\":\"$wallet_name\",\"wallettype\":\"sw-fb\"}"
 
-    local create_result="$(curl "$base_url/api/v1/wallet/create" --silent --show-error --insecure --data "$create_request_payload" | jq ".")"
+    local create_result; create_result="$(curl "$base_url/api/v1/wallet/create" --silent --show-error --insecure --data "$create_request_payload" | jq ".")"
 
-    local create_result_error_msg=$(jq -r '. | select(.message != null) | .message' <<< "$create_result")
+    local create_result_error_msg; create_result_error_msg=$(jq -r '. | select(.message != null) | .message' <<< "$create_result")
     if [ "$create_result_error_msg" != "" ]; then
         die "$create_result_error_msg"
     fi
@@ -155,14 +156,14 @@ create_wallet() {
 ##  "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
 ## }
 fetch_new_address() {
-    local base_url=${1:-}
-    local auth_header=${2:-}
-    local wallet_name=${3:-}
-    local mixdepth=${4:-}
+    local base_url; base_url=${1:-}
+    local auth_header; auth_header=${2:-}
+    local wallet_name; wallet_name=${3:-}
+    local mixdepth; mixdepth=${4:-}
 
-    local address_result=$(curl "$base_url/api/v1/wallet/$wallet_name/address/new/$mixdepth" --silent --show-error --insecure -H "$auth_header" | jq ".")
+    local address_result; address_result=$(curl "$base_url/api/v1/wallet/$wallet_name/address/new/$mixdepth" --silent --show-error --insecure -H "$auth_header" | jq ".")
 
-    local address=$(jq -r '.address' <<< "$address_result")
+    local address; address=$(jq -r '.address' <<< "$address_result")
 
     echo "$address"
 }
@@ -179,10 +180,10 @@ fetch_new_address() {
 ## }
 ##
 fetch_available_wallets() {
-    local base_url=${1:-}
+    local base_url; base_url=${1:-}
 
-    local wallet_all_result="$(curl "$base_url/api/v1/wallet/all" --silent --show-error --insecure | jq ".")"
-    local available_wallets="$(jq -r '.wallets' <<< "$wallet_all_result")"
+    local wallet_all_result; wallet_all_result="$(curl "$base_url/api/v1/wallet/all" --silent --show-error --insecure | jq ".")"
+    local available_wallets; available_wallets="$(jq -r '.wallets' <<< "$wallet_all_result")"
 
     echo "$available_wallets"
 }
@@ -202,7 +203,7 @@ fetch_available_wallets() {
 ## }
 ##
 verify_no_open_session_or_throw() {
-    local base_url=${1:-}
+    local base_url; base_url=${1:-}
 
     if session_result=$(curl "$base_url/api/v1/session" --silent --show-error --insecure | jq "."); then
       msg_success "Successfully established connection to jmwalletd"

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/docker-entrypoint.sh
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/docker-entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-export JM_onion_serving_host="$(/sbin/ip route | awk '/src/ { print $9 }')"
+export JM_ONION_SERVING_HOST
+JM_ONION_SERVING_HOST="$(/sbin/ip route|awk '/src/ { print $9 }')"
 
 # First we restore the default cfg as created by wallet-tool.py generate
 if ! [ -f "$CONFIG" ]; then
@@ -25,17 +26,17 @@ fi
 mkdir -p "${DATADIR}/logs"
 
 # auto start services
-while read p; do
+while read -r p; do
     [[ "$p" == "" ]] && continue
     [[ "$p" == "#"* ]] && continue
     echo "Auto start: $p"
     file_path="/etc/supervisor/conf.d/$p.conf"
     if [ -f "$file_path" ]; then
-      sed -i 's/autostart=false/autostart=true/g' $file_path
+      sed -i 's/autostart=false/autostart=true/g' "$file_path"
     else
       echo "$file_path not found"
     fi
-done <$AUTO_START
+done < "$AUTO_START"
 
 declare -A jmenv
 while IFS='=' read -r -d '' envkey parsedval; do
@@ -60,7 +61,7 @@ if [ "${jmenv['network']}" == "regtest" ]; then
 fi
 
 # For every env variable JM_FOO=BAR, replace the default configuration value of 'foo' by 'BAR'
-for key in ${!jmenv[@]}; do
+for key in "${!jmenv[@]}"; do
     val=${jmenv[${key}]}
     sed -i "s/^$key =.*/$key = $val/g" "$CONFIG" || echo "Couldn't set : $key = $val, please modify $CONFIG manually"
 done

--- a/docker/regtest/fund-wallet.sh
+++ b/docker/regtest/fund-wallet.sh
@@ -118,8 +118,8 @@ parse_params "$@"
 
 msg "Trying to fund wallet $wallet_name.."
 
-[ -z $(is_docker_container_running "jm_regtest_bitcoind") ] && die "Please make sure bitcoin container 'jm_regtest_bitcoind' is running."
-[ -z $(is_docker_container_running "$container") ] && die "Please make sure joinmarket container '$container' is running."
+[ -z "$(is_docker_container_running "jm_regtest_bitcoind")" ] && die "Please make sure bitcoin container 'jm_regtest_bitcoind' is running."
+[ -z "$(is_docker_container_running "$container")" ] && die "Please make sure joinmarket container '$container' is running."
 
 
 verify_no_open_session_or_throw "$base_url"
@@ -198,7 +198,7 @@ msg_success "Successfully locked wallet $wallet_name."
 # --------------------------
 # generate new blocks with rewards to wallet
 msg "Generating $blocks blocks with rewards to $address"
-. "$script_dir/mine-block.sh" $blocks $address &>/dev/null
+. "$script_dir/mine-block.sh" "$blocks" "$address" &>/dev/null
 
 if [ "$unmatured" = true ]; then
   msg_warn "Block rewards are not yet matured and will not be immediately spendable"

--- a/docker/regtest/fund-wallet.sh
+++ b/docker/regtest/fund-wallet.sh
@@ -3,6 +3,11 @@
 set -Eeuo pipefail
 trap cleanup SIGINT SIGTERM ERR EXIT
 
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 . "$script_dir/common.sh"
@@ -37,11 +42,6 @@ Examples:
 
 EOF
   exit
-}
-
-cleanup() {
-  trap - SIGINT SIGTERM ERR EXIT
-  # script cleanup here
 }
 
 parse_params() {
@@ -112,7 +112,6 @@ parse_params() {
   return 0
 }
 
-setup_colors
 parse_params "$@"
 
 # ----------------------------------------

--- a/docker/regtest/init-setup.sh
+++ b/docker/regtest/init-setup.sh
@@ -64,7 +64,7 @@ else
     msg "Starting maker service for wallet $wallet_name.."  
     start_maker_request_payload="{\"txfee\":0,\"cjfee_a\":250,\"cjfee_r\":0.0003,\"ordertype\":\"sw0absoffer\",\"minsize\":10000}"
 
-    start_maker_result=$(curl "$base_url/api/v1/wallet/$wallet_name/maker/start" --silent --show-error --insecure -H "$auth_header" --data $start_maker_request_payload | jq ".")
+    start_maker_result=$(curl "$base_url/api/v1/wallet/$wallet_name/maker/start" --silent --show-error --insecure -H "$auth_header" --data "$start_maker_request_payload" | jq ".")
 
     if [ "$start_maker_result" != "{}" ]; then
         msg_warn "There has been a problem starting the maker service: $start_maker_result"

--- a/docker/regtest/mine-block.sh
+++ b/docker/regtest/mine-block.sh
@@ -15,4 +15,4 @@ ADDRESS=${2:-bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx} # default to a "rando
 [ "$BLOCKS" -ge 1 ] || die "Invalid parameter: 'blocks' must be a positve integer"
 [ -z "${ADDRESS-}" ] && die "Missing required parameter: 'address'"
 
-docker exec -t jm_regtest_bitcoind bitcoin-cli -datadir=/data generatetoaddress $BLOCKS $ADDRESS
+docker exec -t jm_regtest_bitcoind bitcoin-cli -datadir=/data generatetoaddress "$BLOCKS" "$ADDRESS"


### PR DESCRIPTION
Closes #138 

User had `jq` not installed - this changed will print a more informative message if any dependency is missing.
Current dependencies of the development setup are `jq`, `curl` and `docker`.

If any of them is missing it will print , e.g. 
```sh
[user@home regtest]$ ./init-setup.sh 
This script needs 'curl' to run. Consider installing it.
```


Edit: Also fixes some shellcheck warnings - just minor warnings of [`SC2015`](https://github.com/koalaman/shellcheck/wiki/SC2015) left, which are intended ("Ignore this warning when you actually do intend to run C when either A or B fails.")