### PR TITLE
Warn on missing config vars

### DIFF
--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -189,7 +189,9 @@ export default function Earn({ currentWallet, coinjoinInProcess, makerRunning })
       })
       // show the loader a little longer to avoid flickering
       .then((_) => new Promise((r) => setTimeout(r, 200)))
-      .finally(() => setIsReportLoading(false))
+      .finally(() => {
+        !abortCtrl.signal.aborted && setIsReportLoading(false)
+      })
 
     return () => abortCtrl.abort()
   }, [makerRunning, isShowReport])

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -127,7 +127,7 @@ const enhanceTakerErrorMessageIfPossible = async (requestContext, httpStatus, er
 
     if (!maxFeeSettingsPresent) {
       return `
-        Config variables 'max_cj_fee_rel' and 'max_cj_fee_abs' must be defined in your configuration in order to send collaborative transactions. 
+        Config variables 'max_cj_fee_rel' and 'max_cj_fee_abs' must be set in your joinmarket.cfg in order to send collaborative transactions. 
         Consider adding them to your config manually.
       `
     }

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -122,7 +122,7 @@ const enhanceTakerErrorMessageIfPossible = async (requestContext, httpStatus, er
       configExists('POLICY', 'max_cj_fee_rel'),
       configExists('POLICY', 'max_cj_fee_abs'),
     ])
-      .then((arr) => arr.every((e) => e === true))
+      .then((arr) => arr.every((e) => e))
       .catch(() => false)
 
     if (!maxFeeSettingsPresent) {


### PR DESCRIPTION
Closes #135.

This is really just a workaround for users connecting Jam to existing backends.
This will never happen in our integrations like Umbrel, as we predefine max fee values.
Additional requests to check for existing max fee values are only made if the taker operation reported the error `Action cannot be performed, config vars are not set.`.

I did not find a good place to make the check and opted to do it just after the original error happens. If we check for more things like that it might be good to do that on initial application start, but I refrained from doing so for this uncommon case for now. Feedback on how to make it more clear/readable is highly appreciated.

<img src="https://user-images.githubusercontent.com/3358649/156753308-1c8c0cc5-0ed9-4ab1-94a6-b4f67e4cc17b.png" width=400 />