### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   <span> · </span>
   <a href="#-features">Features</a>
   <span> · </span>
-  <a href="#-installation">Installation</a>
+  <a href="#-running-locally">Installation</a>
   <span> · </span>
-  <a href="#-development">Development</a>
+  <a href="#-participating">Development</a>
 </h3>
 
 ---


### PR DESCRIPTION
I noticed that the Installation and Development links in the README were broken, so I updated them so that when you click on them they take you to the section again.