### PR TITLE
Fix page reloads

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -19,7 +19,7 @@ import {
   CJ_STATE_MAKER_RUNNING,
 } from '../context/WebsocketContext'
 import { useCurrentWallet, useSetCurrentWallet, useSetCurrentWalletInfo } from '../context/WalletContext'
-import { getSession, setSession, clearSession } from '../session'
+import { setSession, clearSession } from '../session'
 import * as Api from '../libs/JmWalletApi'
 import Onboarding from './Onboarding'
 
@@ -118,13 +118,6 @@ export default function App() {
       clearInterval(interval)
     }
   }, [currentWallet, setCurrentWallet, setCurrentWalletInfo])
-
-  useEffect(() => {
-    const session = getSession()
-    if (session) {
-      return startWallet(session.name, session.token)
-    }
-  }, [startWallet])
 
   if (settings.showOnboarding === true) {
     return (

--- a/src/components/CurrentWalletAdvanced.jsx
+++ b/src/components/CurrentWalletAdvanced.jsx
@@ -42,7 +42,7 @@ export default function CurrentWalletAdvanced() {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
 
-    Promise.all([loadingWallet, loadingUtxos]).finally(() => setIsLoading(false))
+    Promise.all([loadingWallet, loadingUtxos]).finally(() => !abortCtrl.signal.aborted && setIsLoading(false))
 
     return () => abortCtrl.abort()
   }, [currentWallet, setWalletInfo])

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -63,7 +63,7 @@ const PrivacyLevel = ({ numAccounts, level, balance }) => {
 export default function CurrentWalletMagic() {
   const settings = useSettings()
   const settingsDispatch = useSettingsDispatch()
-  const wallet = useCurrentWallet()
+  const currentWallet = useCurrentWallet()
   const walletInfo = useCurrentWalletInfo()
   const setWalletInfo = useSetCurrentWalletInfo()
 
@@ -72,7 +72,7 @@ export default function CurrentWalletMagic() {
 
   useEffect(() => {
     const abortCtrl = new AbortController()
-    const { name: walletName, token } = wallet
+    const { name: walletName, token } = currentWallet
 
     setAlert(null)
     setIsLoading(true)
@@ -83,10 +83,10 @@ export default function CurrentWalletMagic() {
       .catch((err) => {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
-      .finally(() => setIsLoading(false))
+      .finally(() => !abortCtrl.signal.aborted && setIsLoading(false))
 
     return () => abortCtrl.abort()
-  }, [wallet, setWalletInfo])
+  }, [currentWallet, setWalletInfo])
 
   return (
     <div className="privacy-levels">
@@ -107,14 +107,14 @@ export default function CurrentWalletMagic() {
           </rb.Col>
         </rb.Row>
       )}
-      {!isLoading && wallet && walletInfo && (
+      {!isLoading && currentWallet && walletInfo && (
         <>
           <rb.Row
             onClick={() => settingsDispatch({ showBalance: !settings.showBalance })}
             style={{ cursor: 'pointer' }}
           >
             <WalletHeader
-              name={wallet.name}
+              name={currentWallet.name}
               balance={walletInfo.total_balance}
               unit={settings.unit}
               showBalance={settings.showBalance}

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -34,11 +34,9 @@ export default function Receive({ currentWallet }) {
         .then((res) => (res.ok ? res.json() : Promise.reject(new Error(res.message || 'Loading new address failed.'))))
         .then((data) => setAddress(data.address))
         .catch((err) => {
-          if (!abortCtrl.signal.aborted) {
-            setAlert({ variant: 'danger', message: err.message })
-          }
+          !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
         })
-        .finally(() => setIsLoading(false))
+        .finally(() => !abortCtrl.signal.aborted && setIsLoading(false))
     }
 
     if (ACCOUNTS.includes(account)) {

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -226,7 +226,9 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
         !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message: err.message })
       })
 
-    Promise.all([loadingWalletInfo, loadingMinimumMakerConfig]).finally(() => setIsLoading(false))
+    Promise.all([loadingWalletInfo, loadingMinimumMakerConfig]).finally(
+      () => !abortCtrl.signal.aborted && setIsLoading(false)
+    )
 
     return () => abortCtrl.abort()
   }, [wallet, walletInfo, setWalletInfo])

--- a/src/context/WalletContext.jsx
+++ b/src/context/WalletContext.jsx
@@ -6,13 +6,12 @@ const WalletContext = createContext()
 
 const initialWalletFromSession = () => {
   const session = getSession()
-  return !(session && session.name && session.token)
-    ? null
-    : {
+  return session && session.name && session.token
+    ? {
         name: session.name,
         token: session.token,
       }
-}
+    : null
 
 const WalletProvider = ({ children }) => {
   const [currentWallet, setCurrentWallet] = useState(initialWalletFromSession())

--- a/src/context/WalletContext.jsx
+++ b/src/context/WalletContext.jsx
@@ -1,9 +1,21 @@
 import React, { createContext, useState, useContext } from 'react'
 
+import { getSession } from '../session'
+
 const WalletContext = createContext()
 
+const initialWalletFromSession = () => {
+  const session = getSession()
+  return !(session && session.name && session.token)
+    ? null
+    : {
+        name: session.name,
+        token: session.token,
+      }
+}
+
 const WalletProvider = ({ children }) => {
-  const [currentWallet, setCurrentWallet] = useState(null)
+  const [currentWallet, setCurrentWallet] = useState(initialWalletFromSession())
   const [currentWalletInfo, setCurrentWalletInfo] = useState(null)
 
   return (

--- a/src/context/WalletContext.jsx
+++ b/src/context/WalletContext.jsx
@@ -4,7 +4,7 @@ import { getSession } from '../session'
 
 const WalletContext = createContext()
 
-const initialWalletFromSession = () => {
+const restoreWalletFromSession = () => {
   const session = getSession()
   return session && session.name && session.token
     ? {
@@ -12,9 +12,10 @@ const initialWalletFromSession = () => {
         token: session.token,
       }
     : null
+}
 
 const WalletProvider = ({ children }) => {
-  const [currentWallet, setCurrentWallet] = useState(initialWalletFromSession())
+  const [currentWallet, setCurrentWallet] = useState(restoreWalletFromSession())
   const [currentWalletInfo, setCurrentWalletInfo] = useState(null)
 
   return (


### PR DESCRIPTION
Closes #161 .

This PR adapts the wallet initialization.

Before these changes, the `currentWallet` was initialized with `null` and subsequently updated with the values of a session object in an `useEffect` callback. This causes the route setup for components that need a loaded wallet to redirect to `/` on a page refresh, because they are conditionally added with `{currentWallet && (<Route element= [...] />)}`) and `currentWallet` is always `null` on initial rendering.

After these changes, the `currentWallet` will be initialized directly from the session object, if available.
If no session is available, the behaviour stays the same - it will redirect to `/`. However, if a session is available, it will be able to reload the page normally.

I was not sure at first if some components depend on the wallet being initialized "lazily".. but it seems there is really no difference, except page reloads are now working. Would be great if someone can verify this.

Edit: Some `update on unmounted component` errors are also fixed. These are now more easily reproduced by being able to fresh pages.