### PR TITLE
fix: receive address copy button not working

### DIFF
--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { BitcoinQR } from './BitcoinQR'
 import { useLocation } from 'react-router-dom'
 import * as rb from 'react-bootstrap'
@@ -12,6 +12,7 @@ import Sprite from './Sprite'
 export default function Receive({ currentWallet }) {
   const location = useLocation()
   const settings = useSettings()
+  const inputRef = useRef()
   const [validated, setValidated] = useState(false)
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -89,15 +90,15 @@ export default function Receive({ currentWallet }) {
                   data-bs-toggle="tooltip"
                   data-bs-placement="left"
                   onClick={() => {
-                    // might not work on iOS.
-                    navigator.clipboard.writeText(address).then(
-                      () => {
-                        setAddressCopiedFlag(addressCopiedFlag + 1)
-                      },
-                      () => {
-                        setAlert({ variant: 'warning', message: 'Could not copy address.' })
-                      }
-                    )
+                    inputRef.current.select()
+                    const success = document.execCommand('copy')
+
+                    if (!success) {
+                      setAlert({ variant: 'warning', message: 'Could not copy address.' })
+                      return
+                    }
+
+                    setAddressCopiedFlag(addressCopiedFlag + 1)
                   }}
                 >
                   {showAddressCopiedConfirmation ? (
@@ -109,6 +110,16 @@ export default function Receive({ currentWallet }) {
                     'Copy'
                   )}
                 </rb.Button>
+                <input
+                  aria-hidden
+                  ref={inputRef}
+                  defaultValue={address}
+                  style={{
+                    position: 'absolute',
+                    left: '-9999px',
+                    top: '-9999px',
+                  }}
+                />
               </div>
             </rb.Card.Body>
           </rb.Card>


### PR DESCRIPTION
resolves #159 

I tested this in brave, safari, and firefox using an http tunnel with [ngrok](https://ngrok.com/), which should be similar to the app running in umbrel

While working on this I discovered that `document.execCommand` is deprecated, but still has good browser support, and  [umbrel is using the same pattern for it's copy behavior](https://github.com/getumbrel/umbrel-dashboard/blob/master/src/components/Utility/InputCopy.vue#L74).

I tried to avoid using `position: absolute` and instead making an inline invisible input but `inputRef.current.select()` doesn't work properly with that, and just selects an empty string. 

Really excited about this joinmarket webui project and hope to contribute more in the future!