### PR TITLE
fix: use resolvedLanguage in language picker

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -93,7 +93,7 @@ export default function Settings({ currentWallet }) {
         <rb.Dropdown>
           <rb.Dropdown.Toggle variant="outline-dark" className="border-0 mb-2 d-inline-flex align-items-center">
             <Sprite symbol="globe" width="24" height="24" className="me-2" />
-            {languages.find((lng) => lng.key === i18n.language).description}
+            {languages.find((lng) => lng.key === i18n.resolvedLanguage)?.description}
           </rb.Dropdown.Toggle>
 
           <rb.Dropdown.Menu variant={settings.theme === 'light' ? 'light' : 'dark'}>

--- a/src/components/Settings.test.jsx
+++ b/src/components/Settings.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render, screen } from '../testUtils'
+import { act } from 'react-dom/test-utils'
+
+import Settings from './Settings'
+
+describe('<Settings />', () => {
+  const setup = () => {
+    render(<Settings />)
+  }
+
+  it('should render settings without errors', () => {
+    act(setup)
+
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.queryByText(/(Show|Hide) balance/)).toBeInTheDocument()
+    expect(screen.queryByText(/Display amounts in (sats|BTC)/)).toBeInTheDocument()
+    expect(screen.queryByText(/Switch to (dark|light) theme/)).toBeInTheDocument()
+    expect(screen.queryByText(/Use (advanced|magic) wallet mode/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Ahh, the ghost in the machine revealed itself.

This uses `resolvedLanguage` (e.g, 'en') instead of `language` (e.g. 'en-US').
From the docs of `resolvedLanguage`:
> Is set to the current resolved language.
   It can be used as primary used language, for example in a language switcher.

It might still be unset, which is the case in unit tests, however it has not happened in a real browser. I have to read up on this, but as a quickfix it might be enough.