### PR TITLE
chore: fix typo in en/translation.json

### DIFF
--- a/src/components/DisplayAccountUTXOs.jsx
+++ b/src/components/DisplayAccountUTXOs.jsx
@@ -22,7 +22,7 @@ export default function DisplayAccountUTXOs({ utxos, ...props }) {
         <rb.Accordion.Item key={account} eventKey={account}>
           <rb.Accordion.Header className="head">
             <h5 className="mb-0">
-              {t('current_wallet_advanced.acount')} {account}
+              {t('current_wallet_advanced.account')} {account}
             </h5>
           </rb.Accordion.Header>
           <rb.Accordion.Body>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -11,7 +11,7 @@
     "menu_mobile_wallets": "Wallets"
   },
   "app": {
-    "alert_no_connection": "No connecction to backend: {{ connectionError }}"
+    "alert_no_connection": "No connection to backend: {{ connectionError }}"
   },
   "footer": {
     "warning": "This is alpha software.<br /><1>Read this before using.</1>",


### PR DESCRIPTION
Typo:
- in translation: "connecction" => "connection"
- in translation key: "acount" => "account"

