### PR TITLE
Update regtest env

### DIFF
--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -109,7 +109,6 @@ services:
     environment:
       READY_FILE: /root/.nbxplorer/btc_fully_synched
       ENSURE_WALLET: 1
-      jm_gaplimit: 2000
       jm_rpc_wallet_file: jm_primary
       jm_max_cj_fee_abs: 42000000 # 0.42 btc
       jm_max_cj_fee_rel: 0.1337 # 13.37%
@@ -160,7 +159,6 @@ services:
       ENSURE_WALLET: 1
       APP_USER: joinmarket
       APP_PASSWORD: joinmarket
-      jm_gaplimit: 2000
       jm_rpc_wallet_file: jm_secondary
       jm_max_cj_fee_abs: 42000000 # 0.42 btc
       jm_max_cj_fee_rel: 0.1337 # 13.37%

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -122,12 +122,6 @@ services:
       jm_rpc_port: 43782
       jm_rpc_user: joinmarket
       jm_rpc_password: joinmarket
-      jm_tor_control_host: tor
-      jm_tor_control_port: 9051
-      jm_onion_socks5_host: tor
-      jm_onion_socks5_port: 9050
-      jm_socks5_host: tor
-      jm_socks5_port: 9050
     expose:
       - 8080  # payjoin server
       - 62601 # obwatch
@@ -141,12 +135,10 @@ services:
     volumes:
       - "joinmarket_datadir:/root/.joinmarket"
       - "nbxplorer_datadir:/root/.nbxplorer"
-      - "tor_datadir:/home/tor/.tor"
     depends_on:
       - bitcoind
-      - irc
       - nbxplorer
-      - tor
+      - irc
 
   joinmarket2:
     container_name: jm_regtest_joinmarket2
@@ -172,12 +164,14 @@ services:
       jm_rpc_port: 43782
       jm_rpc_user: joinmarket2
       jm_rpc_password: joinmarket2
+      # showcase exemplary tor environment vars
+      jm_socks5: 'false' # will _not_ connect to local irc over tor
+      jm_socks5_host: tor
+      jm_socks5_port: 9050
       jm_tor_control_host: tor
       jm_tor_control_port: 9051
       jm_onion_socks5_host: tor
       jm_onion_socks5_port: 9050
-      jm_socks5_host: tor
-      jm_socks5_port: 9050
     expose:
       - 80    # nginx
       - 8080  # payjoin server

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -1,104 +1,6 @@
 version: "3"
 
 services:
-  nginx:
-    container_name: jm_regtest_nginx_test_basepath
-    image: nginx
-    volumes:
-      - ./dockerfile-deps/nginx:/etc/nginx/templates
-    ports:
-      - "8000:80"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-
-  bitcoind:
-    container_name: jm_regtest_bitcoind
-    restart: unless-stopped
-    image: btcpayserver/bitcoin:22.0-1
-    environment:
-      HIDDENSERVICE_NAME: BTC-P2P,BTC-RPC
-      BTC-P2P_HIDDENSERVICE_VIRTUAL_PORT: 8333
-      BTC-P2P_HIDDENSERVICE_PORT: 39388
-      BTC-RPC_HIDDENSERVICE_VIRTUAL_PORT: 8332
-      BTC-RPC_HIDDENSERVICE_PORT: 43782
-      BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
-      BITCOIN_WALLETDIR: "/walletdata"
-      BITCOIN_EXTRA_ARGS: |
-        rpcport=43782
-        rpcbind=0.0.0.0
-        rpcallowip=0.0.0.0/0
-        port=39388
-        whitelist=0.0.0.0/0
-        maxmempool=500
-        debug=rpc
-        logips=0
-        networkactive=1
-        dnsseed=0
-        uacomment=jmdevbitcoindregtest
-        printpriority=1
-        logtimemicros=1
-        zmqpubrawblock=tcp://0.0.0.0:28332
-        zmqpubrawtx=tcp://0.0.0.0:28333
-        zmqpubhashblock=tcp://0.0.0.0:28334
-        # tor
-        dns=1
-        onion=tor:9050
-        torcontrol=tor:9051
-        # do not automatically create tor hidden service
-        listenonion=0
-        # rpcauth (user=regtest; password=regtest)
-        rpcauth=regtest:20b58677979ad9d3cf4b78b1d6e85e44$$2ec3e1e1c00c7c58d7aff1d4bf96e4a984ea1af5d676d862fd0faa857a1d4d7c
-        # rpcauth (user=joinmarket; password=joinmarket)
-        rpcauth=joinmarket:260b4c5b1fbd09d75a4aabf90226282f$$76e170af088d43a588992cdd5e7bae2242b03c33aa672cccfd1fb75f9281299e
-        # rpcauth (user=joinmarket2; password=joinmarket2)
-        rpcauth=joinmarket2:521bf9f4468529d49c0a41f9c9f8fdbf$$63ae94a73d2aa45e7ee756945d9b1e469f9873ce026b815d676a748f777e0b8d
-        # rpcauth (user=nbxplorer; password=nbxplorer)
-        rpcauth=nbxplorer:8953867752ed07ca27bc0b1d7a10fa99$$e46553870d4a2c59753bfe453797be070ab4dbd5fdfc2fecdb7862ea0ae6b127
-    expose:
-      - "43782" # RPC
-      - "39388" # P2P
-      - "28332" # ZMQ
-      - "28333" # ZMQ
-      - "28334" # ZMQ
-    volumes:
-      - "bitcoin_datadir:/data"
-      - "bitcoin_wallet_datadir:/walletdata"
-      - "tor_datadir:/home/tor/.tor"
-    depends_on:
-      - tor
-
-  nbxplorer:
-    container_name: jm_regtest_nbxplorer
-    restart: unless-stopped
-    image: nicolasdorier/nbxplorer:2.2.18
-    environment:
-      NBXPLORER_NOAUTH: 1
-      NBXPLORER_CHAINS: "btc"
-      NBXPLORER_BTCRPCURL: http://bitcoind:43782/
-      NBXPLORER_BTCRPCUSER: nbxplorer
-      NBXPLORER_BTCRPCPASSWORD: nbxplorer
-      NBXPLORER_BTCNODEENDPOINT: bitcoind:39388
-      NBXPLORER_NETWORK: ${NBITCOIN_NETWORK:-regtest}
-      NBXPLORER_BIND: 0.0.0.0:32838
-      NBXPLORER_TRIMEVENTS: 10000
-      NBXPLORER_SIGNALFILESDIR: /datadir
-    expose:
-      - "32838"
-    volumes:
-      - "nbxplorer_datadir:/datadir"
-      - "bitcoin_datadir:/root/.bitcoin"
-    depends_on:
-      - bitcoind
-      - tor
-
-  irc:
-    container_name: jm_regtest_irc
-    restart: unless-stopped
-    image: ghcr.io/ergochat/ergo:stable
-    expose:
-      - 6667
-    volumes:
-      - "irc_datadir:/ircd"
 
   joinmarket:
     container_name: jm_regtest_joinmarket
@@ -165,7 +67,7 @@ services:
       jm_rpc_user: joinmarket2
       jm_rpc_password: joinmarket2
       # showcase exemplary tor environment vars
-      jm_socks5: 'false' # will _not_ connect to local irc over tor
+      jm_socks5: "false" # will _not_ connect to local irc over tor
       jm_socks5_host: tor
       jm_socks5_port: 9050
       jm_tor_control_host: tor
@@ -193,6 +95,95 @@ services:
       - nbxplorer
       - tor
 
+  irc:
+    container_name: jm_regtest_irc
+    restart: unless-stopped
+    image: ghcr.io/ergochat/ergo:stable
+    expose:
+      - 6667
+    volumes:
+      - "irc_datadir:/ircd"
+
+  bitcoind:
+    container_name: jm_regtest_bitcoind
+    restart: unless-stopped
+    image: btcpayserver/bitcoin:22.0-1
+    environment:
+      HIDDENSERVICE_NAME: BTC-P2P,BTC-RPC
+      BTC-P2P_HIDDENSERVICE_VIRTUAL_PORT: 8333
+      BTC-P2P_HIDDENSERVICE_PORT: 39388
+      BTC-RPC_HIDDENSERVICE_VIRTUAL_PORT: 8332
+      BTC-RPC_HIDDENSERVICE_PORT: 43782
+      BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
+      BITCOIN_WALLETDIR: "/walletdata"
+      BITCOIN_EXTRA_ARGS: |
+        rpcport=43782
+        rpcbind=0.0.0.0
+        rpcallowip=0.0.0.0/0
+        port=39388
+        whitelist=0.0.0.0/0
+        maxmempool=500
+        debug=rpc
+        logips=0
+        networkactive=1
+        dnsseed=0
+        uacomment=jmdevbitcoindregtest
+        printpriority=1
+        logtimemicros=1
+        zmqpubrawblock=tcp://0.0.0.0:28332
+        zmqpubrawtx=tcp://0.0.0.0:28333
+        zmqpubhashblock=tcp://0.0.0.0:28334
+        # tor
+        dns=1
+        onion=tor:9050
+        torcontrol=tor:9051
+        # do not automatically create tor hidden service
+        listenonion=0
+        # rpcauth (user=regtest; password=regtest)
+        rpcauth=regtest:20b58677979ad9d3cf4b78b1d6e85e44$$2ec3e1e1c00c7c58d7aff1d4bf96e4a984ea1af5d676d862fd0faa857a1d4d7c
+        # rpcauth (user=joinmarket; password=joinmarket)
+        rpcauth=joinmarket:260b4c5b1fbd09d75a4aabf90226282f$$76e170af088d43a588992cdd5e7bae2242b03c33aa672cccfd1fb75f9281299e
+        # rpcauth (user=joinmarket2; password=joinmarket2)
+        rpcauth=joinmarket2:521bf9f4468529d49c0a41f9c9f8fdbf$$63ae94a73d2aa45e7ee756945d9b1e469f9873ce026b815d676a748f777e0b8d
+        # rpcauth (user=nbxplorer; password=nbxplorer)
+        rpcauth=nbxplorer:8953867752ed07ca27bc0b1d7a10fa99$$e46553870d4a2c59753bfe453797be070ab4dbd5fdfc2fecdb7862ea0ae6b127
+    expose:
+      - 43782 # RPC
+      - 39388 # P2P
+      - 28332 # ZMQ
+      - 28333 # ZMQ
+      - 28334 # ZMQ
+    volumes:
+      - "bitcoin_datadir:/data"
+      - "bitcoin_wallet_datadir:/walletdata"
+      - "tor_datadir:/home/tor/.tor"
+    depends_on:
+      - tor
+
+  nbxplorer:
+    container_name: jm_regtest_nbxplorer
+    restart: unless-stopped
+    image: nicolasdorier/nbxplorer:2.2.18
+    environment:
+      NBXPLORER_NOAUTH: 1
+      NBXPLORER_CHAINS: "btc"
+      NBXPLORER_BTCRPCURL: http://bitcoind:43782/
+      NBXPLORER_BTCRPCUSER: nbxplorer
+      NBXPLORER_BTCRPCPASSWORD: nbxplorer
+      NBXPLORER_BTCNODEENDPOINT: bitcoind:39388
+      NBXPLORER_NETWORK: ${NBITCOIN_NETWORK:-regtest}
+      NBXPLORER_BIND: 0.0.0.0:32838
+      NBXPLORER_TRIMEVENTS: 10000
+      NBXPLORER_SIGNALFILESDIR: /datadir
+    expose:
+      - 32838
+    volumes:
+      - "nbxplorer_datadir:/datadir"
+      - "bitcoin_datadir:/root/.bitcoin"
+    depends_on:
+      - bitcoind
+      - tor
+
   tor:
     container_name: jm_regtest_tor
     restart: unless-stopped
@@ -203,13 +194,22 @@ services:
       TOR_EXTRA_ARGS: |
         CookieAuthentication 1
     expose:
-      - "9050"  # SOCKS
-      - "9051"  # Tor Control
+      - 9050  # SOCKS
+      - 9051  # Tor Control
     volumes:
       - "tor_datadir:/home/tor/.tor"
       - "tor_torrcdir:/usr/local/etc/tor"
       - "tor_servicesdir:/var/lib/tor/hidden_services"
 
+  nginx:
+    container_name: jm_regtest_nginx_test_basepath
+    image: nginx
+    volumes:
+      - ./dockerfile-deps/nginx:/etc/nginx/templates
+    ports:
+      - "8000:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   bitcoin_datadir:

--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -7,22 +7,22 @@ It starts two JoinMarket containers, hence not only API calls but also actual Co
 
 ### Run
 
-Go to the docker directory (`cd docker/regtest`) and execute:
+Start the regtest environment with:
 
 ```sh
-docker-compose up
+npm run regtest:up
 ```
 
 ### Stop
 
 ```sh
-docker-compose down
+npm run regtest:down
 ```
 
-If you want to start from scratch, pass the `--volumes` param:
+If you want to start from scratch (removing all volumes):
 
 ```sh
-docker-compose down --volumes
+npm run regtest:clear
 ```
 
 ## Images
@@ -41,7 +41,7 @@ In order to incorporate the current contents of `master` branch, simply rebuild 
 
 ```sh
 # rebuilding the images with contents of current master branch
-docker-compose build --pull --no-cache
+npm run regtest:rebuild
 ```
 
 ## Debugging
@@ -49,7 +49,8 @@ docker-compose build --pull --no-cache
 ### Debug logs
 
 ```sh
-docker exec -t jm_regtest_joinmarket tail -f /root/.joinmarket/logs/jmwalletd_stdout.log
+# logs and follows content of log file `.joinmarket/logs/jmwalletd_stdout.log` in primary joinmarket container
+npm run regtest:logs:jmwalletd
 ```
 
 ### Display running JoinMarket version

--- a/package.json
+++ b/package.json
@@ -50,7 +50,12 @@
     "lint": "prettier --check --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
     "format": "prettier --write --no-error-on-unmatched-pattern src/**/*.{js,jsx,json,css,md}",
     "version": "node scripts/changelog.mjs && git checkout -b \"prepare-v${npm_package_version}-$(date +%s)\" && git add --all && git commit --message \"chore(release): prepare v${npm_package_version}\" && git push --set-upstream origin $(git branch --show-current)",
-    "postversion": "which gh && gh pr create --title \"chore(release): prepare v${npm_package_version}\" --body \"Prepares the v${npm_package_version} release.\" --assignee @me --label release --repo joinmarket-webui/joinmarket-webui --draft"
+    "postversion": "which gh && gh pr create --title \"chore(release): prepare v${npm_package_version}\" --body \"Prepares the v${npm_package_version} release.\" --assignee @me --label release --repo joinmarket-webui/joinmarket-webui --draft",
+    "regtest:rebuild": "npm run regtest:clear && docker-compose --file docker/regtest/docker-compose.yml build --pull --no-cache",
+    "regtest:clear": "docker-compose --file docker/regtest/docker-compose.yml down --volumes --remove-orphans",
+    "regtest:up": "docker-compose --file docker/regtest/docker-compose.yml up",
+    "regtest:down": "docker-compose --file docker/regtest/docker-compose.yml down",
+    "regtest:logs:jmwalletd": "docker exec -t jm_regtest_joinmarket tail -f /root/.joinmarket/logs/jmwalletd_stdout.log"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Small cleanups and improvements for the regtest environment:
- remove custom `gaplimit` in jm containers (as it is not really needed and we should aim at using defaults wherever it is possible)
- remove unused tor config in primary jm container (left unchanged for secondary container)
- reorder container definitions according to their "importance" (e.g. jm containers first)
- add npm scripts to interact with regtest env

e.g. when you want to use the latest update for the regtest environment, instead of
```sh
docker-compose -f ./docker/regtest/docker-compose.yml build --pull --no-cache
```
you can now just execute:
```sh
npm run regtest:rebuild
```