### PR TITLE
fix: pass correct request body in send-direct request

### DIFF
--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -69,7 +69,11 @@ const Utxo = ({ utxo, ...props }) => {
           <rb.Col sm={6} md={4}>
             <rb.Stack className="d-flex align-items-end">
               <div>
-                <Balance valueString={utxo.value} convertToUnit={settings.unit} showBalance={settings.showBalance} />
+                <Balance
+                  valueString={`${utxo.value}`}
+                  convertToUnit={settings.unit}
+                  showBalance={settings.showBalance}
+                />
               </div>
               <div>
                 <small className="text-secondary">{utxo.confirmations} Confirmations</small>

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -239,7 +239,7 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
     setIsSending(true)
     let success = false
     try {
-      const res = await Api.postDirectSend({ walletName, token }, { account, destination, amount_sats })
+      const res = await Api.postDirectSend({ walletName, token }, { mixdepth: account, destination, amount_sats })
       if (res.ok) {
         const {
           txinfo: { outputs },

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -270,7 +270,12 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
     setIsSending(true)
     let success = false
     try {
-      const res = await Api.postCoinjoin(requestContext, { account, destination, amount_sats, counterparties })
+      const res = await Api.postCoinjoin(requestContext, {
+        mixdepth: account,
+        destination,
+        amount_sats,
+        counterparties,
+      })
       if (res.ok) {
         const data = await res.json()
         console.log(data)

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -116,7 +116,12 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCo
   )
 }
 
-const enhanceTakerErrorMessageIfNecessary = async (requestContext, httpStatus, errorMessage) => {
+const enhanceTakerErrorMessageIfNecessary = async (
+  requestContext,
+  httpStatus,
+  errorMessage,
+  additionalErrorMessageProvider
+) => {
   const configExists = (section, field) => Api.postConfigGet(requestContext, { section, field }).then((res) => res.ok)
 
   const tryEnhanceMessage = httpStatus === 409
@@ -129,7 +134,7 @@ const enhanceTakerErrorMessageIfNecessary = async (requestContext, httpStatus, e
       .catch(() => false)
 
     if (!maxFeeSettingsPresent) {
-      return `${errorMessage}`
+      return `${errorMessage} ${additionalErrorMessageProvider()}`
     }
   }
 
@@ -283,10 +288,8 @@ export default function Send({ makerRunning, coinjoinInProcess }) {
         success = true
       } else {
         const { message } = await res.json()
-        const displayMessage = await enhanceTakerErrorMessageIfNecessary(
-          requestContext,
-          res.status,
-          `${message} ${t('send.taker_error_message_max_fees_config_missing')}`
+        const displayMessage = await enhanceTakerErrorMessageIfNecessary(requestContext, res.status, message, () =>
+          t('send.taker_error_message_max_fees_config_missing')
         )
 
         setAlert({ variant: 'danger', message: displayMessage })


### PR DESCRIPTION
Fixes an error introduced by me while porting the api to typescript.
Request body should contain `mixdepth` as property, not `account`.
