### PR TITLE
Fix websocket retry delay in Firefox and other small fixes

### DIFF
--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -19,7 +19,7 @@ export default function Receive({ currentWallet }) {
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [address, setAddress] = useState('')
-  const [amount, setAmount] = useState(null)
+  const [amount, setAmount] = useState('')
   const [account, setAccount] = useState(parseInt(location.state?.account, 10) || 0)
   const [addressCount, setAddressCount] = useState(0)
   const [showSettings, setShowSettings] = useState(false)

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -85,6 +85,10 @@ const WebsocketProvider = ({ children }) => {
       // and will always use the minimum delay between reconnect attempts.
       setConnectionErrorCount(0)
     }
+
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('websocket healthy', isWebsocketHealthy)
+    }
   }, [isWebsocketHealthy, setConnectionErrorCount])
 
   // reconnect handling in case the socket is closed
@@ -93,8 +97,10 @@ const WebsocketProvider = ({ children }) => {
     let retryDelayTimer
     const onOpen = (event) => {
       assumeHealthyDelayTimer = setTimeout(() => {
-        const stillConnectedToSameSocket = event.currentTarget === websocket
-        setIsWebsocketHealthy(stillConnectedToSameSocket)
+        const stillConnectedToSameSocket = event.target === websocket
+        const websocketOpen = websocket.readyState === WebSocket.OPEN
+        const healthy = stillConnectedToSameSocket && websocketOpen
+        setIsWebsocketHealthy(healthy)
       }, WEBSOCKET_CONNECTION_HEALTHY_DURATION)
     }
     const onClose = () => {


### PR DESCRIPTION
Small issues fixed:

- The websocket's health status was not properly updated in Firefox, this is currently only used to schedule delayed reconnect attempts. In firefox it has never been updated to `true`, so after a disconnect, a retry might have been delayed the max amount of time (10s), instead of the initial amount (1s).  

- On Receive screen, the "amount" input was initialized with a null value.
  Initializing it with an empty string fixes warning `Warning: 'value' prop on 'input' should not be null`.
