### PR TITLE
dev: enable npm config `engine-strict`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16]
+        node-version: ['16.11.0']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Setup Node
       - name: Setup (Node.js ${{ matrix.node-version }})
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       # Install

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 git-tag-version = false
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git@github.com:joinmarket-webui/joinmarket-webui.git",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=16.11.0",
     "npm": ">=8.0.0"
   },
   "homepage": ".",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "engines": {
     "node": ">=16.0.0",
-    "npm": ">=7.0.0"
+    "npm": ">=8.0.0"
   },
   "homepage": ".",
   "devDependencies": {


### PR DESCRIPTION
Add `engine-strict` to `.npmrc` to enforce minimum npm and node version specified in section `engines` of `package.json`.
Thereby also updating the minimum npm version from `v7.0.0` to `v8.0.0` and node from `v16.0.0` to `v16.11.0`. This is to prevent annoying diffs to `package-lock.json` when installing new packages.

If you try to execute `npm install` with an unsupported version, you will now get the following message indicating you to update your setup, e.g. with `npm install npm -g` and `nvm install --lts` (in case you are using `nvm`):
```sh
[user@home joinmarket-webui]$ npm i
npm i
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: jam@0.0.5
npm ERR! notsup Not compatible with your version of node/npm: jam@0.0.5
npm ERR! notsup Required: {"node":">=16.11.0","npm":">=8.0.0"}
npm ERR! notsup Actual:   {"npm":"1.2.3","node":"v4.5.6"}
```

Current settings are:
```json
  "engines": {
    "node": ">=16.11.0",
    "npm": ">=8.0.0"
  },
```

node `v16.11.0` has been specified, as it is an LTS release and the first version including npm `>=v8.0.0`. Please feel free to suggest other minimum version as you see fit. The only goal that must be achieved is preventing `package-lock.json` conflicts.