### PR TITLE
Remove skip button quiz screen

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -31,6 +31,8 @@ export default function App() {
   const settings = useSettings()
   const websocketState = useWebsocketState()
 
+  const devMode = process.env.NODE_ENV === 'development'
+
   const startWallet = useCallback(
     (name, token) => {
       setSession({ name, token })
@@ -89,7 +91,7 @@ export default function App() {
           <Routes>
             <Route element={<Layout />}>
               <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
-              <Route path="create-wallet" element={<CreateWallet startWallet={startWallet} />} />
+              <Route path="create-wallet" element={<CreateWallet startWallet={startWallet} devMode={devMode} />} />
               {currentWallet && (
                 <>
                   <Route path="send" element={<Send />} />

--- a/src/components/CreateWallet.css
+++ b/src/components/CreateWallet.css
@@ -1,0 +1,14 @@
+.create-wallet form input {
+  height: 3.5rem;
+  width: 100%;
+}
+
+.create-wallet button {
+  height: 3rem;
+  width: 100%;
+}
+
+.seedword-index-backup {
+  width: 5ch;
+  justify-content: right;
+}

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -103,9 +103,11 @@ const SeedWordInput = ({ number, targetWord, isValid, setIsValid }) => {
 }
 
 const BackupConfirmation = ({ createdWallet, walletConfirmed, parentStepSetter }) => {
+  const seedphrase = createdWallet.seedphrase.split(' ')
+  const showSkipButton = process.env.NODE_ENV === 'development'
+
   const { t } = useTranslation()
   const [seedBackup, setSeedBackup] = useState(false)
-  let seedphrase = createdWallet.seedphrase.split(' ')
   const [seedWordConfirmations, setSeedWordConfirmations] = useState(new Array(seedphrase.length).fill(false))
 
   useEffect(() => {
@@ -152,9 +154,13 @@ const BackupConfirmation = ({ createdWallet, walletConfirmed, parentStepSetter }
       </rb.Form>
       {seedBackup && <div className="text-center text-success">{t('create_wallet.feedback_seed_confirmed')}</div>}
 
-      <div className="d-flex mt-4 mb-4 gap-3">
+      <rb.Button variant="dark" onClick={() => walletConfirmed()} disabled={!seedBackup}>
+        {t('create_wallet.confirmation_button_fund_wallet')}
+      </rb.Button>
+
+      <div className="d-flex mt-4 mb-4 gap-4">
         <rb.Button
-          variant="dark"
+          variant="outline-dark"
           disabled={seedBackup}
           onClick={() => {
             parentStepSetter()
@@ -163,14 +169,12 @@ const BackupConfirmation = ({ createdWallet, walletConfirmed, parentStepSetter }
           {t('create_wallet.back_button')}
         </rb.Button>
 
-        <rb.Button variant="dark" onClick={() => walletConfirmed()} disabled={!seedBackup}>
-          {t('create_wallet.confirmation_button_fund_wallet')}
-        </rb.Button>
+        {showSkipButton && (
+          <rb.Button variant="outline-dark" onClick={() => walletConfirmed()} disabled={seedBackup}>
+            {t('create_wallet.skip_button')}
+          </rb.Button>
+        )}
       </div>
-
-      <rb.Button variant="outline-dark" onClick={() => walletConfirmed()} disabled={seedBackup}>
-        {t('create_wallet.skip_button')}
-      </rb.Button>
     </div>
   )
 }

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -132,13 +132,13 @@ const SeedWordInput = ({ number, targetWord, isValid, setIsValid }) => {
   )
 }
 
-const BackupConfirmation = ({ createdWallet, walletConfirmed, parentStepSetter }) => {
+const BackupConfirmation = ({ createdWallet, walletConfirmed, parentStepSetter, devMode }) => {
   const seedphrase = createdWallet.seedphrase.split(' ')
-  const showSkipButton = process.env.NODE_ENV === 'development'
 
   const { t } = useTranslation()
   const [seedBackup, setSeedBackup] = useState(false)
   const [seedWordConfirmations, setSeedWordConfirmations] = useState(new Array(seedphrase.length).fill(false))
+  const [showSkipButton] = useState(devMode)
 
   useEffect(() => {
     setSeedBackup(seedWordConfirmations.every((wordConfirmed) => wordConfirmed))
@@ -209,7 +209,7 @@ const BackupConfirmation = ({ createdWallet, walletConfirmed, parentStepSetter }
   )
 }
 
-const WalletCreationConfirmation = ({ createdWallet, walletConfirmed }) => {
+const WalletCreationConfirmation = ({ createdWallet, walletConfirmed, devMode }) => {
   const { t } = useTranslation()
   const [userConfirmed, setUserConfirmed] = useState(false)
   const [revealSensitiveInfo, setRevealSensitiveInfo] = useState(false)
@@ -265,13 +265,14 @@ const WalletCreationConfirmation = ({ createdWallet, walletConfirmed }) => {
           parentStepSetter={childStepSetter}
           createdWallet={createdWallet}
           walletConfirmed={walletConfirmed}
+          devMode={devMode}
         />
       )}
     </>
   )
 }
 
-export default function CreateWallet({ startWallet }) {
+export default function CreateWallet({ startWallet, devMode = false }) {
   const { t } = useTranslation()
   const serviceInfo = useServiceInfo()
   const navigate = useNavigate()
@@ -326,7 +327,9 @@ export default function CreateWallet({ startWallet }) {
       )}
       {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
       {canCreate && <WalletCreationForm createWallet={createWallet} isCreating={isCreating} />}
-      {isCreated && <WalletCreationConfirmation createdWallet={createdWallet} walletConfirmed={walletConfirmed} />}
+      {isCreated && (
+        <WalletCreationConfirmation createdWallet={createdWallet} walletConfirmed={walletConfirmed} devMode={devMode} />
+      )}
       {!canCreate && !isCreated && (
         <rb.Alert variant="warning">
           <Trans i18nKey="create_wallet.alert_other_wallet_unlocked">

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -8,6 +8,7 @@ import ToggleSwitch from './ToggleSwitch'
 import { serialize, walletDisplayName } from '../utils'
 import { useServiceInfo } from '../context/ServiceInfoContext'
 import * as Api from '../libs/JmWalletApi'
+import './CreateWallet.css'
 
 const WalletCreationForm = ({ createWallet, isCreating }) => {
   const { t } = useTranslation()

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -57,6 +57,7 @@ const WalletCreationForm = ({ createWallet, isCreating }) => {
 
   return (
     <>
+      {isCreating && <PreventLeavingPageByMistake />}
       <rb.Form onSubmit={onSubmit} validated={validated} noValidate>
         <rb.Form.Group className="mb-4" controlId="walletName">
           <rb.Form.Label>{t('create_wallet.label_wallet_name')}</rb.Form.Label>

--- a/src/components/CreateWallet.test.jsx
+++ b/src/components/CreateWallet.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import user from '@testing-library/user-event'
+import { render, screen, waitFor, waitForElementToBeRemoved } from '../testUtils'
+import { act } from 'react-dom/test-utils'
+
+import * as apiMock from '../libs/JmWalletApi'
+
+import CreateWallet from './CreateWallet'
+
+jest.mock('../libs/JmWalletApi', () => ({
+  ...jest.requireActual('../libs/JmWalletApi'),
+  getSession: jest.fn(),
+  postWalletCreate: jest.fn(),
+}))
+
+const NOOP = () => {}
+
+describe('<CreateWallet />', () => {
+  const setup = (props) => {
+    const startWallet = props?.startWallet || NOOP
+    render(<CreateWallet startWallet={startWallet} />)
+  }
+
+  beforeEach(() => {
+    const neverResolvingPromise = new Promise(() => {})
+    apiMock.getSession.mockResolvedValueOnce(neverResolvingPromise)
+  })
+
+  it('should render without errors', () => {
+    act(setup)
+
+    expect(screen.getByText('create_wallet.title')).toBeInTheDocument()
+    expect(screen.getByLabelText('create_wallet.label_wallet_name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('create_wallet.placeholder_wallet_name')).toBeInTheDocument()
+    expect(screen.getByLabelText('create_wallet.label_password')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('create_wallet.placeholder_password')).toBeInTheDocument()
+    expect(screen.getByText('create_wallet.button_create')).toBeInTheDocument()
+  })
+
+  it('should show validation messages to user if form is invalid', () => {
+    act(setup)
+
+    expect(screen.getByText('create_wallet.button_create')).toBeInTheDocument()
+
+    act(() => {
+      // click on the "create" button without filling the form
+      const createWalletButton = screen.getByText('create_wallet.button_create')
+      user.click(createWalletButton)
+    })
+
+    expect(screen.getByText('create_wallet.feedback_invalid_wallet_name')).toBeVisible()
+    expect(screen.getByText('create_wallet.feedback_invalid_password')).toBeVisible()
+  })
+
+  it('should advance to WalletCreationConfirmation after wallet is created', async () => {
+    const walletName = 'wallet'
+
+    apiMock.postWalletCreate.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          walletname: `${walletName}.jmdat`,
+          token: 'ANY_TOKEN',
+          seedphrase: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        }),
+    })
+
+    act(setup)
+
+    expect(screen.getByText('create_wallet.button_create')).toBeInTheDocument()
+    expect(screen.queryByText('create_wallet.title_wallet_created')).not.toBeInTheDocument()
+
+    await act(async () => {
+      user.type(screen.getByPlaceholderText('create_wallet.placeholder_wallet_name'), walletName)
+      user.type(screen.getByPlaceholderText('create_wallet.placeholder_password'), 'password')
+      const createWalletButton = screen.getByText('create_wallet.button_create')
+      user.click(createWalletButton)
+
+      await waitFor(() => screen.findByText(/create_wallet.button_creating/))
+    })
+
+    expect(screen.queryByText('create_wallet.button_create')).not.toBeInTheDocument()
+    expect(screen.getByText('create_wallet.title_wallet_created')).toBeInTheDocument()
+  })
+
+  it('should verify that "skip" button is only visible in development mode', async () => {
+    const walletName = 'wallet'
+
+    apiMock.postWalletCreate.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          walletname: `${walletName}.jmdat`,
+          token: 'ANY_TOKEN',
+          seedphrase: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+        }),
+    })
+
+    act(setup)
+
+    await act(async () => {
+      user.type(screen.getByPlaceholderText('create_wallet.placeholder_wallet_name'), walletName)
+      user.type(screen.getByPlaceholderText('create_wallet.placeholder_password'), 'password')
+      const createWalletButton = screen.getByText('create_wallet.button_create')
+      user.click(createWalletButton)
+
+      await waitFor(() => screen.findByText(/create_wallet.button_creating/))
+
+      const revealToggle = screen.getByText('create_wallet.confirmation_toggle_reveal_info')
+      user.click(revealToggle)
+
+      const confirmToggle = screen.getByText('create_wallet.confirmation_toggle_info_written_down')
+      user.click(confirmToggle)
+
+      const nextButton = screen.getByText('create_wallet.next_button')
+      user.click(nextButton)
+    })
+
+    expect(process.env.NODE_ENV === 'test').toBe(true)
+    expect(screen.getByText('create_wallet.back_button')).toBeInTheDocument()
+    expect(screen.queryByText('create_wallet.skip_button')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/Seedphrase.css
+++ b/src/components/Seedphrase.css
@@ -1,0 +1,16 @@
+.seedphrase {
+  gap: 0.3rem;
+}
+
+.seedphrase > div {
+  background-color: rgba(244, 244, 244, 1);
+  width: 8rem;
+}
+
+.seedword-index {
+  width: 2ch;
+}
+
+:root[data-theme='dark'] .seedphrase > div {
+  background-color: var(--bs-gray-800);
+}

--- a/src/components/Seedphrase.css
+++ b/src/components/Seedphrase.css
@@ -4,7 +4,7 @@
 
 .seedphrase > div {
   background-color: rgba(244, 244, 244, 1);
-  width: 8rem;
+  width: 9rem;
 }
 
 .seedword-index {

--- a/src/components/Seedphrase.css
+++ b/src/components/Seedphrase.css
@@ -2,13 +2,13 @@
   gap: 0.3rem;
 }
 
+.seedword-index {
+  width: 2ch;
+}
+
 .seedphrase > div {
   background-color: rgba(244, 244, 244, 1);
   width: 9rem;
-}
-
-.seedword-index {
-  width: 2ch;
 }
 
 :root[data-theme='dark'] .seedphrase > div {

--- a/src/components/Seedphrase.jsx
+++ b/src/components/Seedphrase.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import './Seedphrase.css'
 
 export default function Seedphrase({ seedphrase, isBlurred = true }) {
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -357,24 +357,7 @@ main {
   }
 }
 
-/* Wallet Creation Styles */
-
-.seedphrase {
-  gap: 0.3rem;
-}
-
-.seedphrase > div {
-  background-color: rgba(244, 244, 244, 1);
-  width: 8rem;
-}
-
-.seedword-index {
-  width: 2ch;
-}
-
-.seedword-index-backup {
-  width: 5ch;
-}
+/* Blurred Text Styles */
 
 .blurred-text {
   color: transparent;
@@ -384,20 +367,6 @@ main {
 :root[data-theme='dark'] .blurred-text {
   color: transparent;
   text-shadow: 0 0 15px var(--bs-gray-400);
-}
-
-:root[data-theme='dark'] .seedphrase > div {
-  background-color: var(--bs-gray-800);
-}
-
-.create-wallet form input {
-  height: 3.5rem;
-  width: 100%;
-}
-
-.create-wallet button {
-  height: 3rem;
-  width: 100%;
 }
 
 /* Send, Receive, Earn Styles */


### PR DESCRIPTION
Closes #196 

- [x] Show "Skip" button only in dev mode
- [x] Prevent users from leaving the page by mistake, e.g. refreshing the page or closing the tab.
  Unfortunately, for now it wont protect from clicking a link inside the app, ie. the Jam logo
- [x] Minimal tests that verifies "skip" button is not shown when `env := 'test'`

One problem still needs to be addressed: In case the wallet was successfully created, but the backend goes down (for whatever reason), the whole screen is replaced by a "No connection" error message. This should be prevented when `CreateWallet` component is active. It is partly tracked in #149 and covered in #199 