### PR TITLE
fix: do not hide CreateWallet component on connection errors

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -81,37 +81,50 @@ export default function App() {
       )}
       <Navbar />
       <rb.Container as="main" className="py-5">
-        {sessionConnectionError ? (
+        {sessionConnectionError && (
           <rb.Alert variant="danger">
             {t('app.alert_no_connection', { connectionError: sessionConnectionError.message })}.
           </rb.Alert>
-        ) : (
-          <Routes>
-            <Route element={<Layout />}>
-              <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
-              <Route path="create-wallet" element={<CreateWallet startWallet={startWallet} />} />
-              {currentWallet && (
-                <>
-                  <Route path="send" element={<Send />} />
-                  <Route path="earn" element={<Earn />} />
-                  <Route path="receive" element={<Receive />} />
-                  <Route path="settings" element={<Settings />} />
-                </>
-              )}
-            </Route>
-            {currentWallet && !settings.useAdvancedWalletMode && (
-              <Route element={<Layout variant="narrow" />}>
-                <Route path="wallet" element={<CurrentWalletMagic />} />
-              </Route>
-            )}
-            {currentWallet && settings.useAdvancedWalletMode && (
-              <Route element={<Layout variant="wide" />}>
-                <Route path="wallet" element={<CurrentWalletAdvanced />} />
-              </Route>
-            )}
-            <Route path="*" element={<Navigate to="/" replace={true} />} />
-          </Routes>
         )}
+        <Routes>
+          {/**
+           * This sections defines all routes that can be displayed, even if the connection
+           * to the backend is down, e.g. "create-wallet" shows the seed quiz and it is important
+           * that it stays visible in case the backend becomes unavailable.
+           */}
+          <Route element={<Layout />}>
+            <Route path="create-wallet" element={<CreateWallet startWallet={startWallet} />} />
+          </Route>
+          {/**
+           * This section defines all routes that are displayed only if the backend is reachable.
+           */}
+          {!sessionConnectionError && (
+            <>
+              <Route element={<Layout />}>
+                <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
+                {currentWallet && (
+                  <>
+                    <Route path="send" element={<Send />} />
+                    <Route path="earn" element={<Earn />} />
+                    <Route path="receive" element={<Receive />} />
+                    <Route path="settings" element={<Settings />} />
+                  </>
+                )}
+              </Route>
+              {currentWallet && !settings.useAdvancedWalletMode && (
+                <Route element={<Layout variant="narrow" />}>
+                  <Route path="wallet" element={<CurrentWalletMagic />} />
+                </Route>
+              )}
+              {currentWallet && settings.useAdvancedWalletMode && (
+                <Route element={<Layout variant="wide" />}>
+                  <Route path="wallet" element={<CurrentWalletAdvanced />} />
+                </Route>
+              )}
+              <Route path="*" element={<Navigate to="/" replace={true} />} />
+            </>
+          )}
+        </Routes>
       </rb.Container>
       <rb.Nav as="footer" className="border-top py-2">
         <rb.Container fluid="xl" className="d-flex flex-column flex-md-row justify-content-center py-2 px-4">

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -101,7 +101,7 @@ export default function App() {
           {!sessionConnectionError && (
             <>
               <Route element={<Layout />}>
-                <Route exact path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
+                <Route path="/" element={<Wallets startWallet={startWallet} stopWallet={stopWallet} />} />
                 {currentWallet && (
                   <>
                     <Route path="send" element={<Send />} />

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -251,18 +251,15 @@ export default function CreateWallet({ startWallet }) {
 
     try {
       const res = await Api.postWalletCreate({ walletname: walletName, password })
+      const body = await (res.ok ? res.json() : Api.Helper.throwError(res))
 
-      if (res.ok) {
-        const { seedphrase, token, walletname: createdWalletName } = await res.json()
-        setCreatedWallet({ name: createdWalletName, seedphrase, password, token })
-      } else {
-        const { message } = await res.json()
-        setAlert({ variant: 'danger', message })
-      }
-    } catch (e) {
-      setAlert({ variant: 'danger', message: e.message })
-    } finally {
       setIsCreating(false)
+
+      const { seedphrase, token, walletname: createdWalletName } = body
+      setCreatedWallet({ name: createdWalletName, seedphrase, password, token })
+    } catch (e) {
+      setIsCreating(false)
+      setAlert({ variant: 'danger', message: e.message })
     }
   }
 

--- a/src/components/DisplayUTXOs.jsx
+++ b/src/components/DisplayUTXOs.jsx
@@ -20,20 +20,13 @@ const Utxo = ({ utxo, ...props }) => {
   const onClickFreeze = async (utxo) => {
     if (isSending) return
 
+    setIsSending(true)
+    setAlert(null)
+
     const { name: walletName, token } = currentWallet
 
-    setAlert(null)
-    setIsSending(true)
-
     await Api.postFreeze({ walletName, token }, { utxo: utxo.utxo, freeze: !utxo.frozen })
-      .then(async (res) => {
-        if (res.ok) {
-          return true
-        } else {
-          const { message } = await res.json()
-          throw new Error(message || t('current_wallet_advanced.error_freeze_failed'))
-        }
-      })
+      .then((res) => (res.ok ? true : Api.Helper.throwError(res, t('current_wallet_advanced.error_freeze_failed'))))
       .then((_) => (utxo.frozen = !utxo.frozen))
       .catch((err) => {
         setAlert({ variant: 'danger', message: err.message, dismissible: true })

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -133,11 +133,11 @@ export default function Earn() {
   }
 
   const startMakerService = async (cjfee_a, cjfee_r, ordertype, minsize) => {
-    const { name: walletName, token } = currentWallet
-
     setAlert(null)
     setIsSending(true)
     setIsWaitingMakerStart(false)
+
+    const { name: walletName, token } = currentWallet
     try {
       const res = await Api.postMakerStart(
         { walletName, token },
@@ -149,18 +149,17 @@ export default function Earn() {
         }
       )
 
-      if (res.ok) {
-        // There is no response data to check if maker got started:
-        // Wait for the websocket or session response!
-        setIsWaitingMakerStart(true)
-      } else {
-        const { message } = await res.json()
-        setAlert({ variant: 'danger', message })
+      // There is no response data to check if maker got started:
+      // Wait for the websocket or session response!
+      if (!res.ok) {
+        await Api.Helper.throwError(res)
       }
-    } catch (e) {
-      setAlert({ variant: 'danger', message: e.message })
-    } finally {
+
       setIsSending(false)
+      setIsWaitingMakerStart(true)
+    } catch (e) {
+      setIsSending(false)
+      setAlert({ variant: 'danger', message: e.message })
     }
   }
 
@@ -208,26 +207,25 @@ export default function Earn() {
   }, [serviceInfo, isShowReport, t])
 
   const stopMakerService = async () => {
-    const { name: walletName, token } = currentWallet
-
     setAlert(null)
     setIsSending(true)
     setIsWaitingMakerStop(false)
+
+    const { name: walletName, token } = currentWallet
     try {
       const res = await Api.getMakerStop({ walletName, token })
 
-      if (res.ok) {
-        // There is no response data to check if maker got stopped:
-        // Wait for the websocket or session response!
-        setIsWaitingMakerStop(true)
-      } else {
-        const { message } = await res.json()
-        setAlert({ variant: 'danger', message })
+      // There is no response data to check if maker got stopped:
+      // Wait for the websocket or session response!
+      if (!res.ok) {
+        await Api.Helper.throwError(res)
       }
-    } catch (e) {
-      setAlert({ variant: 'danger', message: e.message })
-    } finally {
+
       setIsSending(false)
+      setIsWaitingMakerStop(true)
+    } catch (e) {
+      setIsSending(false)
+      setAlert({ variant: 'danger', message: e.message })
     }
   }
 

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -61,34 +61,29 @@ export default function Wallet({
     setIsUnlocking(true)
     try {
       const res = await Api.postWalletUnlock({ walletName }, { password })
-      const body = await res.json()
+      const body = await (res.ok ? res.json() : Api.Helper.throwError(res))
 
       setIsUnlocking(false)
 
-      if (res.ok) {
-        const { walletname: unlockedWalletName, token } = body
-        startWallet(unlockedWalletName, token)
-        navigate('/wallet')
-      } else {
-        setAlert({
-          variant: 'danger',
-          message: body.message.replace('Wallet', walletName),
-        })
-      }
+      const { walletname: unlockedWalletName, token } = body
+      startWallet(unlockedWalletName, token)
+      navigate('/wallet')
     } catch (e) {
       setIsUnlocking(false)
-      setAlert({ variant: 'danger', message: e.message })
+
+      const message = e.message.replace('Wallet', walletName)
+      setAlert({ variant: 'danger', message })
     }
   }
 
   const lockWallet = async () => {
+    setAlert(null)
+    setIsLocking(true)
+
     try {
       const { name: walletName, token } = currentWallet
-      setAlert(null)
-      setIsLocking(true)
 
       const res = await Api.getWalletLock({ walletName, token })
-      const body = await res.json()
 
       setIsLocking(false)
 
@@ -100,6 +95,7 @@ export default function Wallet({
         stopWallet()
       }
 
+      const body = await res.json()
       if (res.ok) {
         const { walletname: lockedWalletName, already_locked } = body
 

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -60,7 +60,7 @@ const ServiceInfoProvider = ({ children }: React.PropsWithChildren<{}>) => {
 
     const refreshSession = () => {
       Api.getSession({ signal: abortCtrl.signal })
-        .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res, res.statusText)))
+        .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
         .then((data: JmSessionData) => {
           if (!abortCtrl.signal.aborted) {
             const {

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,10 +1,50 @@
-import React, { createContext, useState, useContext } from 'react'
+import React, { createContext, useState, useContext, PropsWithChildren } from 'react'
 
 import { getSession } from '../session'
 
-const WalletContext = createContext()
+interface CurrentWallet {
+  name: string
+  token: string
+}
 
-const restoreWalletFromSession = () => {
+// TODO: move these interfaces to JmWalletApi, once distinct types are used as return value instead of plain "Response"
+interface WalletInfo {
+  wallet_name: string
+  total_balance: string
+  accounts: Account[]
+}
+
+interface Account {
+  account: string
+  account_balance: string
+  branches: Branch[]
+}
+
+interface Branch {
+  branch: string
+  balance: string
+  entries: BranchEntry[]
+}
+
+interface BranchEntry {
+  hd_path: string
+  address: string
+  amount: string
+  status: string
+  label: string
+  extradata: string
+}
+
+interface WalletContextEntry {
+  currentWallet: CurrentWallet | null
+  setCurrentWallet: React.Dispatch<React.SetStateAction<CurrentWallet | null>>
+  currentWalletInfo: WalletInfo | null
+  setCurrentWalletInfo: React.Dispatch<React.SetStateAction<WalletInfo | null>>
+}
+
+const WalletContext = createContext<WalletContextEntry | undefined>(undefined)
+
+const restoreWalletFromSession = (): CurrentWallet | null => {
   const session = getSession()
   return session && session.name && session.token
     ? {
@@ -14,9 +54,9 @@ const restoreWalletFromSession = () => {
     : null
 }
 
-const WalletProvider = ({ children }) => {
+const WalletProvider = ({ children }: PropsWithChildren<any>) => {
   const [currentWallet, setCurrentWallet] = useState(restoreWalletFromSession())
-  const [currentWalletInfo, setCurrentWalletInfo] = useState(null)
+  const [currentWalletInfo, setCurrentWalletInfo] = useState<WalletInfo | null>(null)
 
   return (
     <WalletContext.Provider value={{ currentWallet, setCurrentWallet, currentWalletInfo, setCurrentWalletInfo }}>

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -249,7 +249,7 @@ const Helper = (() => {
     try {
       // The server will answer with a html response instead of json on certain errors.
       // The situation is mitigated by parsing the returned html.
-      const isHtmlErrorMessage = response.headers.get('content-type') === 'text/html'
+      const isHtmlErrorMessage = response.headers && response.headers.get('content-type') === 'text/html'
 
       if (isHtmlErrorMessage) {
         return await response
@@ -266,7 +266,7 @@ const Helper = (() => {
       return message || fallbackReason
     } catch (err) {
       if (process.env.NODE_ENV === 'development') {
-        console.warn('Error while extracting error message from api response - will use fallback reason', err)
+        console.warn('Will use fallback reason - Error while extracting error message from api response:', err)
       }
 
       return fallbackReason


### PR DESCRIPTION
Closes #149, ie. do not navigate away when a user is in the process of writing down the seed.

Additional changes:
- refactor: always extract api error message with Api.Helper
- refactor: port WalletContext from jsx to tsx
- remove 'exact' property as it is not available in react-router v6 anymore