### PR TITLE
fix: force-close pending websockets connections

### DIFF
--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -155,7 +155,7 @@ const WebsocketProvider = ({ children }) => {
         needsForceClose
       )
       if (needsForceClose) {
-        websocket.close(1000, 'Force-close pending connection')
+        websocket.close(1001, 'Force-close pending connection')
       }
     }, WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION)
 

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -4,6 +4,7 @@ import { useCurrentWallet } from './WalletContext'
 
 const WEBSOCKET_RECONNECT_DELAY_STEP = 1_000
 const WEBSOCKET_RECONNECT_MAX_DELAY = 10_000
+const WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION = 10_000
 
 // minimum amount of time in milliseconds the connection must stay open to be considered "healthy"
 const WEBSOCKET_CONNECTION_HEALTHY_DURATION = 1_000
@@ -27,23 +28,24 @@ const CJ_STATE_TAKER_RUNNING = 0
 const CJ_STATE_MAKER_RUNNING = 1
 const CJ_STATE_NONE_RUNNING = 2
 
+const NOOP = () => {}
+const logToDebugConsoleInDevMode = process.env.NODE_ENV === 'development' ? console.debug : NOOP
+
 const createWebSocket = () => {
   const { protocol, host } = window.location
   const scheme = protocol === 'https:' ? 'wss' : 'ws'
   const websocket = new WebSocket(`${scheme}://${host}${WEBSOCKET_ENDPOINT_PATH}`)
 
   websocket.onerror = (error) => {
-    console.error('websocket error', error)
+    console.error('[Websocket] error', error)
   }
 
-  if (process.env.NODE_ENV === 'development') {
-    websocket.onopen = () => {
-      console.debug('websocket connection openend')
-    }
+  websocket.onopen = () => {
+    logToDebugConsoleInDevMode('[Websocket] connection openend')
+  }
 
-    websocket.onclose = () => {
-      console.debug('websocket connection closed')
-    }
+  websocket.onclose = (event) => {
+    logToDebugConsoleInDevMode('[Websocket] connection closed', event.code)
   }
 
   return websocket
@@ -84,9 +86,7 @@ const WebsocketProvider = ({ children }) => {
       setConnectionErrorCount(0)
     }
 
-    if (process.env.NODE_ENV === 'development') {
-      console.debug('websocket healthy', isWebsocketHealthy)
-    }
+    logToDebugConsoleInDevMode('[Websocket] healthy', isWebsocketHealthy)
   }, [isWebsocketHealthy, setConnectionErrorCount])
 
   // reconnect handling in case the socket is closed
@@ -108,10 +108,14 @@ const WebsocketProvider = ({ children }) => {
       if (abortCtrl.signal.aborted) return
 
       setIsWebsocketHealthy(false)
+
       setConnectionErrorCount((prev) => {
-        const retryDelay = connectionRetryDelayLinear(prev + 1)
-        console.log(`Retrying to connect websocket in ${retryDelay}ms`)
+        const retryAttempt = prev + 1
+        const retryDelay = connectionRetryDelayLinear(retryAttempt)
+
+        console.debug(`[Websocket] ${new Date().toLocaleString()} ${retryAttempt}. retry to connect in ${retryDelay}ms`)
         retryDelayTimer = setTimeout(() => {
+          console.debug(`[Websocket] ${new Date().toLocaleString()} ${retryAttempt}. retry: Create socket..`)
           setWebsocket(createWebSocket())
         }, retryDelay)
         return prev + 1
@@ -127,6 +131,39 @@ const WebsocketProvider = ({ children }) => {
       abortCtrl.abort()
     }
   }, [websocket, setConnectionErrorCount])
+
+  useEffect(() => {
+    const abortCtrl = new AbortController()
+    const forceCloseIfStillConnectingTimer = setTimeout(() => {
+      if (abortCtrl.signal.aborted) return
+      // Problem:
+      //   Some browsers will keep connecting longer than the retry delay, and if the service
+      //   comes back up in the meantime, the connection fails nonetheless...
+      //   A retry is only attempted, when the close listener is invoked.
+      //
+      // Solution:
+      //   If the socket is still `CONNECTING` after a certain duration.. force-close it!
+      //   e.g. this happens in Firefox after >10 attempts
+      //
+      // This ensures that the maximum amount of delay between retries is
+      // `WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION + WEBSOCKET_RECONNECT_MAX_DELAY`:
+      // - WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION to force-close a pending connection
+      // - WEBSOCKET_RECONNECT_MAX_DELAY to attempt the retry
+      const needsForceClose = websocket.readyState === WebSocket.CONNECTING
+      logToDebugConsoleInDevMode(
+        `[Websocket] ${new Date().toLocaleString()} Check if a force-close is needed..`,
+        needsForceClose
+      )
+      if (needsForceClose) {
+        websocket.close(1000, 'Force-close pending connection')
+      }
+    }, WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION)
+
+    return () => {
+      clearTimeout(forceCloseIfStillConnectingTimer)
+      abortCtrl.abort()
+    }
+  }, [websocket])
 
   useEffect(() => {
     const abortCtrl = new AbortController()


### PR DESCRIPTION
This commits force-closes pending websocket connections after a certain duration.
Tested in Firefox and Chrome-based browsers, and only happens in Firefox after around ~12 attempts.

A new constant `WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION` is defined (`10_000` ms),
after which a pending connection will be closed.

## Why?
Comment from the code on why this is needed:
```
// Problem:
//   Some browsers will keep connecting longer than the retry delay, and if the service
//   comes back up in the meantime, the connection fails nonetheless...
//   A retry is only attempted, when the close listener is invoked.
//
// Solution:
//   If the socket is still `CONNECTING` after a certain duration.. force-close it!
//   e.g. this happens in Firefox after >10 attempts
//
// This ensures that the maximum amount of delay between retries is
// `WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION + WEBSOCKET_RECONNECT_MAX_DELAY`:
// - WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION to force-close a pending connection
// - WEBSOCKET_RECONNECT_MAX_DELAY to attempt the retry
```

## How to test?
The best and most visual test is to have Firefox and Chrome DevTools open side by side and see on `master` how often Chrome attempts a retry in comparison to Firefox when you shutdown the dev environment. If you you then startup the dev environment, notice how long it takes for Firefox to actually reconnect. On my machine it took more than 30s longer than Chrome. If you apply this commit, Firefox still takes longer, but at least it retries way earlier than before.

See the logs from Firefox when the backend is down and comes up later on and notice that attempts `12`, `14`, `16`, `17`, `19` and `20` needed a force-close:
```
Navigated to http://localhost:3000/
[Websocket] healthy false
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:16 PM 1. retry to connect in 1000ms
[Websocket] 1/1/1970, 00:03:17 PM 1. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:17 PM 2. retry to connect in 2000ms
[Websocket] 1/1/1970, 00:03:19 PM 2. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:19 PM 3. retry to connect in 3000ms
[Websocket] 1/1/1970, 00:03:22 PM 3. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:22 PM 4. retry to connect in 4000ms
[Websocket] 1/1/1970, 00:03:26 PM 4. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:26 PM 5. retry to connect in 5000ms
[Websocket] 1/1/1970, 00:03:31 PM 5. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:31 PM 6. retry to connect in 6000ms
[Websocket] 1/1/1970, 00:03:37 PM 6. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:37 PM 7. retry to connect in 7000ms
[Websocket] 1/1/1970, 00:03:44 PM 7. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:44 PM 8. retry to connect in 8000ms
[Websocket] 1/1/1970, 00:03:52 PM 8. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:03:52 PM 9. retry to connect in 9000ms
[Websocket] 1/1/1970, 00:04:01 PM 9. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:04:01 PM 10. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:04:11 PM Check if a force-close is needed.. false
[Websocket] 1/1/1970, 00:04:11 PM 10. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:04:13 PM 11. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:04:21 PM Check if a force-close is needed.. false
[Websocket] 1/1/1970, 00:04:23 PM 11. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:04:30 PM 12. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:04:33 PM Check if a force-close is needed.. false
[Websocket] 1/1/1970, 00:04:40 PM 12. retry: Create socket..
[Websocket] 1/1/1970, 00:04:50 PM Check if a force-close is needed.. true
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:04:51 PM 13. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:05:01 PM 13. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:05:01 PM 14. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:05:11 PM Check if a force-close is needed.. false
[Websocket] 1/1/1970, 00:05:11 PM 14. retry: Create socket..
[Websocket] 1/1/1970, 00:05:21 PM Check if a force-close is needed.. true
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:05:21 PM 15. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:05:31 PM 15. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:05:40 PM 16. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:05:41 PM Check if a force-close is needed.. false
[Websocket] 1/1/1970, 00:05:50 PM 16. retry: Create socket..
[Websocket] 1/1/1970, 00:06:00 PM Check if a force-close is needed.. true
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:06:00 PM 17. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:06:10 PM 17. retry: Create socket..
[Websocket] 1/1/1970, 00:06:20 PM Check if a force-close is needed.. true
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:06:20 PM 18. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:06:30 PM 18. retry: Create socket..
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:06:39 PM 19. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:06:40 PM Check if a force-close is needed.. false
[Websocket] 1/1/1970, 00:06:49 PM 19. retry: Create socket..
[Websocket] 1/1/1970, 00:06:59 PM Check if a force-close is needed.. true
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:06:59 PM 20. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:07:09 PM 20. retry: Create socket..
[Websocket] 1/1/1970, 00:07:19 PM Check if a force-close is needed.. true
[Websocket] connection closed 1006
[Websocket] 1/1/1970, 00:07:19 PM 21. retry to connect in 10000ms
[Websocket] 1/1/1970, 00:07:29 PM 21. retry: Create socket..
[Websocket] connection openend
[Websocket] 1/1/1970, 00:07:39 PM Check if a force-close is needed.. false
[Websocket] healthy true
```

Feedback is highly appreciated.

Edit: Firefox is strange.