### PR TITLE
ui: enhance error message on bad request errors

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -154,6 +154,7 @@
     "description_num_collaborators": "A higher number is better for privacy, but also increases the fee.",
     "error_invalid_num_collaborators": "Please use between {{ minNumCollaborators }} and {{ maxNumCollaborators }} collaborators.",
     "taker_error_message_max_fees_config_missing": "Config variables 'max_cj_fee_rel' and 'max_cj_fee_abs' must be set in your joinmarket.cfg in order to send collaborative transactions. Consider adding them to your config manually.",
+    "direct_payment_error_message_bad_request": "Please verify your inputs carefully.",
     "error_loading_wallet_failed": "Loading wallet failed.",
     "error_loading_min_makers_failed": "Loading config value 'minimum_makers' failed.",
     "alert_payment_successful": "Payment successful: Sent {{ amount }} sats to {{ address }}.",


### PR DESCRIPTION
Tiny, tiny PR to get item "Improve wording of error message when trying to send to an 'invalid' address" off the list #66

When sending non-collaborative transactions with an invalid recipient, the api responds with `400 Bad Request` and an error message of `Invalid request format`. 
`InvalidRequestFormat` error is thrown on all assertion errors.. see [wallep_rpc.py#L548](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/fd5871bb2d89e96efe344040b4576627e84fc644/jmclient/jmclient/wallet_rpc.py#L548), but  `Invalid request format` is not really useful for the user and it might not be clear what to do.
As this is an ubiquitous error message, and address validation is avoided on the client side, to give at least a hint about what might be wrong, the message is appended with "Please verify your inputs carefully." so as to know that the error might be related to the given inputs.

The only data sent when initiating a non-collaborative transactions is `mixdepth`, `destination` and `amount_sats` so this error is most definitely raised on invalid addresses. However, the appended message tries to be neutral and advice the user recheck all inputs.
(If there is a problem with the amount, `409 Conflict` with `Transaction failed` is raised)