### PR TITLE
ui: move seed phrase on settings page to modal

### DIFF
--- a/src/components/Seedphrase.jsx
+++ b/src/components/Seedphrase.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import './Seedphrase.css'
 
-export default function Seedphrase({ seedphrase, isBlurred = true }) {
+export default function Seedphrase({ seedphrase, isBlurred = true, centered = false }) {
   return (
-    <div className="seedphrase slashed-zeroes d-flex flex-wrap">
+    <div
+      className={`seedphrase slashed-zeroes d-flex flex-wrap ${
+        centered ? 'justify-content-center align-items-center' : ''
+      }`}
+    >
       {seedphrase.split(' ').map((seedWord, index) => (
         <div key={index} className="d-flex py-2 ps-2 pe-3">
           <span className="seedword-index text-secondary text-end">{index + 1}</span>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -143,7 +143,8 @@
     "show_seed": "Show seed phrase",
     "hide_seed": "Hide seed phrase",
     "reveal_seed": "Reveal seed phrase",
-    "error_loading_seed_failed": "Could not retrieve seed phrase."
+    "error_loading_seed_failed": "Could not retrieve seed phrase.",
+    "seed_modal_subtitle": "Please write down your seed phrase and password! Without this information you will not be able to access and recover your wallet!"
   },
   "send": {
     "loading": "Loading",

--- a/src/index.css
+++ b/src/index.css
@@ -428,6 +428,16 @@ h2 {
   box-shadow: none;
 }
 
+.modal-header {
+  background-color: var(--bs-gray-800);
+  color: var(--bs-white);
+}
+
+.btn-close {
+  background: transparent
+    url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 16 16%27 fill=%27%23fff%27%3e%3cpath d=%27M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z%27/%3e%3c/svg%3e')
+    center/1em auto no-repeat;
+}
 /* Privacy Level Styles */
 
 .privacy-level-4 {


### PR DESCRIPTION
Closes #169. Show the seed phrase on settings page in a modal [based on screens](https://www.figma.com/proto/kfejZJFlwBywvLEnPEmJo1/JoinMarket-UI?page-id=2850%3A67638&node-id=3283%3A85955&viewport=367%2C48%2C0.57&scaling=min-zoom&starting-point-node-id=3283%3A85955&show-proto-sidebar=1) by @editwentyone.

##### 📸 Before
<img src="https://user-images.githubusercontent.com/3358649/161545335-3a495e70-ed73-47a4-bde9-ca7ce5677fc4.png" width=400 />

##### 📸 After
<img src="https://user-images.githubusercontent.com/3358649/161545407-1ece2321-3b6c-437e-9189-65a002f8eaef.png" width=400 /><img src="https://user-images.githubusercontent.com/3358649/161545356-28814088-4499-42cb-95f6-01e3c96c7b55.png" width=400 />
