### PR TITLE
fix: use `1000` as websocket close code

### DIFF
--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -155,7 +155,7 @@ const WebsocketProvider = ({ children }) => {
         needsForceClose
       )
       if (needsForceClose) {
-        websocket.close(1001, 'Force-close pending connection')
+        websocket.close(1000, 'Force-close pending connection')
       }
     }, WEBSOCKET_ESTABLISH_CONNECTION_MAX_DURATION)
 


### PR DESCRIPTION
Firefox throws a `DOMException` when using `1001` as close code: `A parameter or an operation is not supported by the underlying object`.

Cannot really find out why this is, but in this case it does not really matter, as the code only runs if there is no connection in the first place.