### PR TITLE
reload session info on Earn and Wallets screen

### DIFF
--- a/src/components/App.test.jsx
+++ b/src/components/App.test.jsx
@@ -2,10 +2,21 @@ import React from 'react'
 import { render, screen } from '../testUtils'
 import { act } from 'react-dom/test-utils'
 import user from '@testing-library/user-event'
+import * as apiMock from '../libs/JmWalletApi'
 
 import App from './App'
 
+jest.mock('../libs/JmWalletApi', () => ({
+  ...jest.requireActual('../libs/JmWalletApi'),
+  getSession: jest.fn(),
+}))
+
 describe('<App />', () => {
+  beforeEach(() => {
+    const neverResolvingPromise = new Promise(() => {})
+    apiMock.getSession.mockReturnValue(neverResolvingPromise)
+  })
+
   it('should display Onboarding screen initially', () => {
     render(<App />)
 

--- a/src/components/App.test.jsx
+++ b/src/components/App.test.jsx
@@ -14,7 +14,7 @@ jest.mock('../libs/JmWalletApi', () => ({
 describe('<App />', () => {
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
-    apiMock.getSession.mockReturnValue(neverResolvingPromise)
+    apiMock.getSession.mockResolvedValue(neverResolvingPromise)
   })
 
   it('should display Onboarding screen initially', () => {

--- a/src/components/CreateWallet.test.jsx
+++ b/src/components/CreateWallet.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import user from '@testing-library/user-event'
-import { render, screen, waitFor, waitForElementToBeRemoved } from '../testUtils'
+import { render, screen, waitFor } from '../testUtils'
 import { act } from 'react-dom/test-utils'
 import { __testSetFeatureEnabled } from '../constants/featureFlags'
 

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -14,7 +14,11 @@ import styles from './Earn.module.css'
 const OFFERTYPE_REL = 'sw0reloffer'
 const OFFERTYPE_ABS = 'sw0absoffer'
 
-const MITIGATE_MAKER_STATE_CORRUPTION_DELAY_MS = 2_000
+// In order to prevent observed state mismatch, the 'maker stop' response is delayed shortly.
+// Even though the API states the maker as started or stopped, it seems this is reported prematurely.
+// There is currently no way to know for sure - adding a delay at least migitages the problem.
+// 2022-04-26: With value of 2_000ms, no state corruption could be provoked in a local dev setup.
+const MAKER_STOP_RESPONSE_DELAY_MS = 2_000
 
 const YieldgenReport = ({ lines, maxAmountOfRows = 25 }) => {
   const { t } = useTranslation()
@@ -175,10 +179,7 @@ export default function Earn() {
     // Wait for the websocket or session response!
     Api.getMakerStop({ walletName, token })
       .then((res) => (res.ok ? true : Api.Helper.throwError(res)))
-      // In order to prevent observed state mismatch, the response is delayed shortly.
-      // Even though the API states the maker as started or stopped, it seems this is reported prematurely.
-      // There is currently no way to know for sure - adding a delay at least migitages the problem.
-      .then((_) => new Promise((r) => setTimeout(r, MITIGATE_MAKER_STATE_CORRUPTION_DELAY_MS)))
+      .then((_) => new Promise((r) => setTimeout(r, MAKER_STOP_RESPONSE_DELAY_MS)))
       .then((_) => setIsSending(false))
       .catch((e) => {
         setIsWaitingMakerStop(false)

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -249,6 +249,10 @@ export default function Earn() {
   const onSubmit = async (e) => {
     e.preventDefault()
 
+    if (isLoading || isSending || isWaiting) {
+      return
+    }
+
     const form = e.currentTarget
     const isValid = form.checkValidity()
     setValidated(true)
@@ -381,7 +385,7 @@ export default function Earn() {
               )}
 
               <rb.Button variant="dark" type="submit" disabled={isLoading || isSending || isWaiting}>
-                {isSending ? (
+                {isSending || isWaiting ? (
                   <>
                     <rb.Spinner
                       as="span"

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -14,9 +14,9 @@ import styles from './Earn.module.css'
 const OFFERTYPE_REL = 'sw0reloffer'
 const OFFERTYPE_ABS = 'sw0absoffer'
 
-// In order to prevent observed state mismatch, the 'maker stop' response is delayed shortly.
-// Even though the API states the maker as started or stopped, it seems this is reported prematurely.
-// There is currently no way to know for sure - adding a delay at least migitages the problem.
+// In order to prevent state mismatch, the 'maker stop' response is delayed shortly.
+// Even though the API response suggests that the maker has started or stopped immediately, it seems that this is not always the case.
+// There is currently no way to know for sure - adding a delay at least mitigates the problem.
 // 2022-04-26: With value of 2_000ms, no state corruption could be provoked in a local dev setup.
 const MAKER_STOP_RESPONSE_DELAY_MS = 2_000
 

--- a/src/components/Earn.module.css
+++ b/src/components/Earn.module.css
@@ -1,0 +1,4 @@
+.input-loader {
+  height: 3.5rem;
+  border-radius: 0.25rem;
+}

--- a/src/components/Wallet.test.jsx
+++ b/src/components/Wallet.test.jsx
@@ -55,7 +55,7 @@ describe('<Wallet />', () => {
 
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
-    apiMock.getSession.mockResolvedValueOnce(neverResolvingPromise)
+    apiMock.getSession.mockReturnValue(neverResolvingPromise)
   })
 
   it('should render inactive wallet without errors', () => {

--- a/src/components/Wallets.test.jsx
+++ b/src/components/Wallets.test.jsx
@@ -19,11 +19,13 @@ describe('<Wallets />', () => {
 
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
-    apiMock.getSession.mockResolvedValueOnce(neverResolvingPromise)
+    apiMock.getSession.mockResolvedValue(neverResolvingPromise)
   })
 
   it('should render without errors', () => {
-    apiMock.getWalletAll.mockResolvedValueOnce(new Promise((r) => setTimeout(r, 1_000)))
+    const neverResolvingPromise = new Promise(() => {})
+    apiMock.getSession.mockResolvedValueOnce(neverResolvingPromise)
+    apiMock.getWalletAll.mockResolvedValueOnce(neverResolvingPromise)
 
     act(setup)
 
@@ -33,6 +35,9 @@ describe('<Wallets />', () => {
   })
 
   it('should display error message when loading wallets fails', async () => {
+    apiMock.getSession.mockResolvedValueOnce({
+      ok: false,
+    })
     apiMock.getWalletAll.mockResolvedValueOnce({
       ok: false,
     })
@@ -49,6 +54,16 @@ describe('<Wallets />', () => {
   })
 
   it('should display big call-to-action button if no wallet has been created yet', async () => {
+    apiMock.getSession.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          session: false,
+          maker_running: false,
+          coinjoin_in_process: false,
+          wallet_name: 'None',
+        }),
+    })
     apiMock.getWalletAll.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ wallets: [] }),
@@ -71,6 +86,16 @@ describe('<Wallets />', () => {
   })
 
   it('should display login for available wallets', async () => {
+    apiMock.getSession.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          session: false,
+          maker_running: false,
+          coinjoin_in_process: false,
+          wallet_name: 'None',
+        }),
+    })
     apiMock.getWalletAll.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ wallets: ['wallet0.jmdat', 'wallet1.jmdat'] }),


### PR DESCRIPTION
Closes #225.

Reloads the session information on `Earn` and `Wallets` screens.

Additional change: In order to mitigate a problem when the maker is started/stopped too quickly in succession, the "submit" button is re-enabled with a time delay (currently 2 seconds). This behaviour feels a bit strange, but I think it's still better than the service not working at all – feedback on that is welcome.