### PR TITLE
refactor: use Formik on Earn screen

### DIFF
--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -246,7 +246,7 @@ export default function Earn() {
       // currently no need for translation, this should never occur -> input is controlled by toggle
       errors.offertype = `Offertype must be one of ${OFFERTYPES.join(',')}`
     }
-    if (!(values.feeRel >= feeRelMin && values.feeRel <= feeRelMax)) {
+    if (values.feeRel < feeRelMin || values.feeRel > feeRelMax) {
       errors.feeRel = t('earn.feedback_invalid_rel_fee', {
         feeRelPercentageMin: `${factorToPercentage(feeRelMin)}%`,
         feeRelPercentageMax: `${factorToPercentage(feeRelMax)}%`,

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -269,7 +269,7 @@ export default function Earn() {
       })
     }
     if (values.feeAbs < 0) {
-      errors.minsize = t('earn.feedback_invalid_abs_fee')
+      errors.feeAbs = t('earn.feedback_invalid_abs_fee')
     }
     if (values.minsize < 0) {
       errors.minsize = t('earn.feedback_invalid_min_amount')

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -96,27 +96,11 @@ const factorToPercentage = (val, precision = 6) => {
   return Number((val * 100).toFixed(precision))
 }
 
-const persistOffertype = (value) => {
-  window.localStorage.setItem('jm-offertype', value)
-}
-
-const persistFeeRel = (value) => {
-  window.localStorage.setItem('jm-feeRel', value)
-}
-
-const persistFeeAbs = (value) => {
-  window.localStorage.setItem('jm-feeAbs', value)
-}
-
-const persistMinsize = (value) => {
-  window.localStorage.setItem('jm-minsize', value)
-}
-
 const persistFormValues = (values) => {
-  persistOffertype(values.offertype)
-  persistFeeRel(values.feeRel)
-  persistFeeAbs(values.feeAbs)
-  persistMinsize(values.minsize)
+  window.localStorage.setItem('jm-offertype', values.offertype)
+  window.localStorage.setItem('jm-feeRel', values.feeRel)
+  window.localStorage.setItem('jm-feeAbs', values.feeAbs)
+  window.localStorage.setItem('jm-minsize', values.minsize)
 }
 
 export default function Earn() {

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -96,12 +96,28 @@ const factorToPercentage = (val, precision = 6) => {
   return Number((val * 100).toFixed(precision))
 }
 
-const persistFormValues = (values) => {
-  window.localStorage.setItem('jm-offertype', values.offertype)
-  window.localStorage.setItem('jm-feeRel', values.feeRel)
-  window.localStorage.setItem('jm-feeAbs', values.feeAbs)
-  window.localStorage.setItem('jm-minsize', values.minsize)
+const LOCAL_STORAGE_FORM_INPUT_KEYS = {
+  offertype: 'jm-offertype',
+  feeRel: 'jm-feeRel',
+  feeAbs: 'jm-feeAbs',
+  minsize: 'jm-minsize',
 }
+
+const persistFormValues = (values) => {
+  window.localStorage.setItem(LOCAL_STORAGE_FORM_INPUT_KEYS.offertype, values.offertype)
+  window.localStorage.setItem(LOCAL_STORAGE_FORM_INPUT_KEYS.feeRel, values.feeRel)
+  window.localStorage.setItem(LOCAL_STORAGE_FORM_INPUT_KEYS.feeAbs, values.feeAbs)
+  window.localStorage.setItem(LOCAL_STORAGE_FORM_INPUT_KEYS.minsize, values.minsize)
+}
+
+const initialFormValues = (settings) => ({
+  offertype:
+    (settings.useAdvancedWalletMode && window.localStorage.getItem(LOCAL_STORAGE_FORM_INPUT_KEYS.offertype)) ||
+    OFFERTYPE_REL,
+  feeRel: parseFloat(window.localStorage.getItem(LOCAL_STORAGE_FORM_INPUT_KEYS.feeRel)) || 0.000_3,
+  feeAbs: parseInt(window.localStorage.getItem(LOCAL_STORAGE_FORM_INPUT_KEYS.feeAbs), 10) || 250,
+  minsize: parseInt(window.localStorage.getItem(LOCAL_STORAGE_FORM_INPUT_KEYS.minsize), 10) || 100_000,
+})
 
 export default function Earn() {
   const { t } = useTranslation()
@@ -233,12 +249,7 @@ export default function Earn() {
   const feeRelMax = 0.1 // 10%
   const feeRelPercentageStep = 0.0001
 
-  const initialValues = {
-    offertype: (settings.useAdvancedWalletMode && window.localStorage.getItem('jm-offertype')) || OFFERTYPE_REL,
-    feeRel: parseFloat(window.localStorage.getItem('jm-feeRel')) || 0.000_3,
-    feeAbs: parseInt(window.localStorage.getItem('jm-feeAbs'), 10) || 250,
-    minsize: parseInt(window.localStorage.getItem('jm-minsize'), 10) || 100_000,
-  }
+  const initialValues = initialFormValues(settings)
 
   const validate = (values) => {
     const errors = {}


### PR DESCRIPTION
Uses Formik for form validation on Earn screen.

Further adaptions: 
- Don't persist form values to local storage on every update, but just when the form is actually submitted
- Separate info and error alert - those are not mutually exclusive