### PR TITLE
refactor: Report overlay

### DIFF
--- a/src/components/EarnReport.jsx
+++ b/src/components/EarnReport.jsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import { useEffect, useState } from 'react'
+import * as rb from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { useSettings } from '../context/SettingsContext'
+import * as Api from '../libs/JmWalletApi'
+import styles from './EarnReport.module.css'
+
+const YieldgenReportTable = ({ lines, maxAmountOfRows = 15 }) => {
+  const { t } = useTranslation()
+  const settings = useSettings()
+
+  const empty = !lines || lines.length < 2
+  const headers = empty ? [] : lines[0].split(',')
+
+  const linesWithoutHeader = empty
+    ? []
+    : lines
+        .slice(1, lines.length)
+        .map((line) => line.split(','))
+        .reverse()
+
+  const visibleLines = linesWithoutHeader.slice(0, maxAmountOfRows)
+
+  return (
+    <>
+      {empty ? (
+        <rb.Alert variant="info">{t('earn.alert_empty_report')}</rb.Alert>
+      ) : (
+        <div>
+          <rb.Table striped bordered hover variant={settings.theme} responsive>
+            <thead>
+              <tr>
+                {headers.map((name, index) => (
+                  <th key={`header_${index}`}>{name}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {visibleLines.map((line, trIndex) => (
+                <tr key={`tr_${trIndex}`}>
+                  {line.map((val, tdIndex) => (
+                    <td key={`td_${tdIndex}`}>{val}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                {headers.map((name, index) => (
+                  <th key={`footer_${index}`}>{name}</th>
+                ))}
+              </tr>
+            </tfoot>
+          </rb.Table>
+          <div className="my-1 d-flex justify-content-end">
+            <small>
+              {t('earn.text_report_length', {
+                visibleLines: visibleLines.length,
+                linesWithoutHeader: linesWithoutHeader.length,
+              })}
+            </small>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export function EarnReport() {
+  const { t } = useTranslation()
+  const [alert, setAlert] = useState(null)
+  const [isInitialized, setIsInitialized] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [yieldgenReportLines, setYieldgenReportLines] = useState([])
+
+  useEffect(() => {
+    setIsLoading(true)
+
+    const abortCtrl = new AbortController()
+
+    Api.getYieldgenReport({ signal: abortCtrl.signal })
+      .then((res) => {
+        if (res.ok) return res.json()
+        // 404 is returned till the maker is started at least once
+        if (res.status === 404) return {}
+        return Api.Helper.throwError(res, t('earn.error_loading_report_failed'))
+      })
+      .then((data) => {
+        if (abortCtrl.signal.aborted) return
+        setYieldgenReportLines(data.yigen_data)
+      })
+      .catch((e) => {
+        if (abortCtrl.signal.aborted) return
+        setAlert({ variant: 'danger', message: e.message })
+      })
+      .finally(() => {
+        if (abortCtrl.signal.aborted) return
+        setIsLoading(false)
+        setIsInitialized(true)
+      })
+
+    return () => {
+      abortCtrl.abort()
+    }
+  }, [t])
+
+  return (
+    <div className="earn-report">
+      {!isInitialized ? (
+        Array(5)
+          .fill('')
+          .map((_, index) => {
+            return (
+              <rb.Placeholder key={index} as="div" animation="wave">
+                <rb.Placeholder xs={12} />
+              </rb.Placeholder>
+            )
+          })
+      ) : (
+        <>
+          {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
+          <rb.Row>
+            <rb.Col className="mb-3">
+              <YieldgenReportTable lines={yieldgenReportLines} />
+            </rb.Col>
+          </rb.Row>
+        </>
+      )}
+    </div>
+  )
+}
+
+export function EarnReportOverlay({ show, onHide }) {
+  const { t } = useTranslation()
+
+  return (
+    <rb.Offcanvas className={styles['report-overlay']} show={show} onHide={onHide} placement="bottom">
+      <rb.Offcanvas.Header closeButton>
+        <rb.Offcanvas.Title>{t('earn.report.title')}</rb.Offcanvas.Title>
+      </rb.Offcanvas.Header>
+      <rb.Offcanvas.Body>
+        <EarnReport />
+      </rb.Offcanvas.Body>
+    </rb.Offcanvas>
+  )
+}

--- a/src/components/EarnReport.module.css
+++ b/src/components/EarnReport.module.css
@@ -1,0 +1,5 @@
+.report-overlay {
+  width: 100vw !important;
+  height: 100vh !important;
+  z-index: 1100 !important;
+}

--- a/src/components/EarnReport.module.css
+++ b/src/components/EarnReport.module.css
@@ -3,3 +3,8 @@
   height: 100vh !important;
   z-index: 1100 !important;
 }
+
+.report-line-placeholder {
+  height: 2.625rem;
+  margin: 1px 0;
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -225,7 +225,9 @@
     "text_starting": "Starting",
     "text_stopping": "Stopping",
     "button_show_report": "Show report",
-    "button_hide_report": "Hide report"
+    "report": {
+      "title": "Report"
+    }
   },
   "cheatsheet": {
     "title": "The Cheatsheet",


### PR DESCRIPTION
Currently, the report is rendered directly on the Earn screen and is limited by the container width. This makes it cumbersome to read. This change will render the report in an overlay spanning the whole screen.

The report can generally be improved quite massively in the future. While this might be a very easy win, it is out of scope for this PR. All this change is doing is creating a better view of what was already present.

## 📸 Before

![image](https://user-images.githubusercontent.com/3358649/166922263-c06fa2ca-873a-4ce7-9d93-22fefeba2c49.png)


## 📸 After
![image](https://user-images.githubusercontent.com/3358649/166922613-920af7fd-8ba1-444c-870f-52b008475707.png)
![image](https://user-images.githubusercontent.com/3358649/166922161-21bd2abc-8749-4d30-9bd8-9db3fd41c0af.png)

