### PR TITLE
ui: decrease brightness of placeholder in light theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -502,6 +502,10 @@ h2 {
     center/1em auto no-repeat;
 }
 
+.placeholder {
+  background-color: var(--bs-gray-400);
+}
+
 /* Privacy Level Styles */
 
 .privacy-level-4 {
@@ -605,10 +609,6 @@ h2 {
   --bs-body-bg: var(--bs-gray-900);
   --bs-gray-dark: #16191c;
   --bs-black: #000;
-}
-
-.placeholder {
-  background-color: #e9ecef;
 }
 
 :root[data-theme='dark'] * {


### PR DESCRIPTION
It feels that the placeholders in light mode are little bit too bright. On some screens it is hard to tell the difference from the background. Do you think it would be an improvement if they were a little darker?

## 📸 Before
![image](https://user-images.githubusercontent.com/3358649/167100624-e65889b5-a399-4b7e-9552-07b2191616ca.png)

## 📸 After
![image](https://user-images.githubusercontent.com/3358649/167100640-2fb0225b-13e9-4422-a601-8e4e3de98298.png)


Just for reference, this would be the original Bootstrap style (applying `currentColor`):
![image](https://user-images.githubusercontent.com/3358649/167100659-d1432a10-0997-4ad7-8b27-02983d3fb488.png)
