### PR TITLE
refactor: remove catch all style rule for border-color in dark mode

### DIFF
--- a/src/components/Send.module.css
+++ b/src/components/Send.module.css
@@ -104,8 +104,8 @@ input[type='number'] {
   color: var(--bs-white);
 }
 
-:root[data-theme='dark'] .selected-dark {
-  background-color: var(--bs-gray-dark) !important;
+:root[data-theme='dark'] .collaborators-selector .selected-dark {
+  background-color: var(--bs-gray-dark);
   border-color: var(--bs-gray-dark) !important;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -528,6 +528,9 @@ h2 {
   border-top: 1px solid rgba(222, 222, 222, 1);
   opacity: 1;
 }
+:root[data-theme='dark'] .privacy-levels hr {
+  border-color: var(--bs-gray-800);
+}
 
 .privacy-levels .btn.btn-outline-dark {
   padding: 0.25rem;
@@ -611,12 +614,12 @@ h2 {
   background-color: #e9ecef;
 }
 
-:root[data-theme='dark'] * {
+:root[data-theme='dark'] .border-top,
+:root[data-theme='dark'] .border-bottom,
+:root[data-theme='dark'] .border-left,
+:root[data-theme='dark'] .border-right,
+:root[data-theme='dark'] .border {
   border-color: var(--bs-gray-800) !important;
-}
-
-:root[data-theme='dark'] a.nav-link {
-  border-color: transparent !important;
 }
 
 :root[data-theme='dark'] a.nav-link.active {
@@ -640,6 +643,7 @@ h2 {
 
 :root[data-theme='dark'] .accordion-item {
   background: transparent !important;
+  border-color: var(--bs-gray-800) !important;
 }
 
 :root[data-theme='dark'] .accordion-button,
@@ -675,8 +679,18 @@ h2 {
   background-color: var(--bs-gray-900);
 }
 
+:root[data-theme='dark'] .modal-header,
+:root[data-theme='dark'] .modal-footer {
+  border-color: var(--bs-gray-800) !important;
+}
+
 :root[data-theme='dark'] .modal-header .btn-close {
   background-color: var(--bs-gray-900) !important;
+}
+
+:root[data-theme='dark'] .table,
+:root[data-theme='dark'] .table > :not(:first-child) {
+  border-color: var(--bs-gray-800) !important;
 }
 
 :root[data-theme='dark'] .form-control:disabled,


### PR DESCRIPTION
Remove catch all css rule overriding all border colors in dark mode.

Some bootstrap elements apply `border-color: transparent` to elements for a reason, e.g. buttons without borders.
These rules are overwritten by the custom rule included in `index.css`
```css
:root[data-theme='dark'] * {
  border-color: var(--bs-gray-800) !important;
}
```

It has happened more than once now that this rule gets in the way rather than being helpful.
A benefit of this change is that elements are easier to use and more consistent across themes.
A drawback is that all new elements must take the border color into account.

Also, visual effects on the elements when removing the catch all rule:
- Border color of input fields on validation (works in light mode)
  - valid input fields get a green border
  - invalid input fields get a red border

## 📸 Before
![image](https://user-images.githubusercontent.com/3358649/167107239-bfc5a2a2-146d-43f4-a89b-d3e69d6fbe48.png)

![image](https://user-images.githubusercontent.com/3358649/167114387-bc06051f-284f-4534-b914-66882d20d041.png)


## 📸 After
![image](https://user-images.githubusercontent.com/3358649/167107270-e2c1e6ce-fa60-4a99-832f-90d23302d45f.png)
![image](https://user-images.githubusercontent.com/3358649/167114518-587fea07-39a1-4efb-b54d-5aa7e9311a4c.png)

(Notice the border colors of the input fields and buttons)


Hopefully all affected elements are covered with these changes.
What do you think? Does it have advantages or would it make things complicated again in the long run?

If these changes do not provide an benefit, simply close the PR.