### PR TITLE
feat: Individual balance toggle

### DIFF
--- a/src/components/Balance.jsx
+++ b/src/components/Balance.jsx
@@ -68,8 +68,15 @@ const BalanceComponent = ({ symbol, value, symbolIsPrefix }) => {
  * @param {showBalance}: A flag indicating whether to render or hide the balance.
  * Hidden balances are masked with `*****`.
  * @param {loading}: A loading flag that renders a placeholder while true.
+ * @param {enableVisibilityToggle}: A flag that controls whether the balance can mask/unmask when clicked
  */
-export default function Balance({ valueString, convertToUnit, showBalance = false, loading = false }) {
+export default function Balance({
+  valueString,
+  convertToUnit,
+  showBalance = false,
+  loading = false,
+  enableVisibilityToggle = !showBalance,
+}) {
   const [displayMode, setDisplayMode] = useState(DISPLAY_MODE_HIDDEN)
   const [isBalanceVisible, setIsBalanceVisible] = useState(showBalance)
 
@@ -92,9 +99,7 @@ export default function Balance({ valueString, convertToUnit, showBalance = fals
     )
   }
 
-  const handleOnClick = (e) => {
-    if (showBalance === true) return
-
+  const toggleVisibility = (e) => {
     e.preventDefault()
     e.stopPropagation()
 
@@ -143,12 +148,12 @@ export default function Balance({ valueString, convertToUnit, showBalance = fals
     return <BalanceComponent symbol={''} value={valueString} symbolIsPrefix={false} />
   })()
 
-  if (showBalance === true) {
+  if (!enableVisibilityToggle) {
     return <>{balanceComponent}</>
   }
 
   return (
-    <span onClick={handleOnClick} style={{ cursor: 'pointer' }}>
+    <span onClick={toggleVisibility} style={{ cursor: 'pointer' }}>
       {balanceComponent}
     </span>
   )

--- a/src/components/Balance.test.jsx
+++ b/src/components/Balance.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { act } from 'react-dom/test-utils'
+import user from '@testing-library/user-event'
 import { render, screen } from '../testUtils'
 import { BTC, SATS } from '../utils'
 
@@ -115,5 +117,38 @@ describe('<Balance />', () => {
   it('should render a number SATS value as fallback', () => {
     render(<Balance valueString={43000} convertToUnit={SATS} showBalance={true} />)
     expect(screen.getByText(`43000`)).toBeInTheDocument()
+  })
+
+  it('should toggle visibility of initially hidden balance on click', () => {
+    render(<Balance valueString={`21`} convertToUnit={SATS} showBalance={false} />)
+    expect(screen.queryByText(`21`)).not.toBeInTheDocument()
+    expect(screen.getByText(`*****`)).toBeInTheDocument()
+
+    act(() => {
+      user.click(screen.getByText(`*****`))
+    })
+
+    expect(screen.getByText(`21`)).toBeInTheDocument()
+    expect(screen.queryByText(`*****`)).not.toBeInTheDocument()
+
+    act(() => {
+      user.click(screen.getByText(`21`))
+    })
+
+    expect(screen.queryByText(`21`)).not.toBeInTheDocument()
+    expect(screen.getByText(`*****`)).toBeInTheDocument()
+  })
+
+  it('should NOT toggle visibility of initially visible balance on click', () => {
+    render(<Balance valueString={`21`} convertToUnit={SATS} showBalance={true} />)
+    expect(screen.getByText(`21`)).toBeInTheDocument()
+    expect(screen.queryByText(`*****`)).not.toBeInTheDocument()
+
+    act(() => {
+      user.click(screen.getByText(`21`))
+    })
+
+    expect(screen.getByText(`21`)).toBeInTheDocument()
+    expect(screen.queryByText(`*****`)).not.toBeInTheDocument()
   })
 })

--- a/src/components/Balance.test.jsx
+++ b/src/components/Balance.test.jsx
@@ -119,7 +119,7 @@ describe('<Balance />', () => {
     expect(screen.getByText(`43000`)).toBeInTheDocument()
   })
 
-  it('should toggle visibility of initially hidden balance on click', () => {
+  it('should toggle visibility of initially hidden balance on click by default', () => {
     render(<Balance valueString={`21`} convertToUnit={SATS} showBalance={false} />)
     expect(screen.queryByText(`21`)).not.toBeInTheDocument()
     expect(screen.getByText(`*****`)).toBeInTheDocument()
@@ -139,13 +139,46 @@ describe('<Balance />', () => {
     expect(screen.getByText(`*****`)).toBeInTheDocument()
   })
 
-  it('should NOT toggle visibility of initially visible balance on click', () => {
+  it('should NOT toggle visibility of initially hidden balance on click when disabled via flag', () => {
+    render(<Balance valueString={`21`} convertToUnit={SATS} showBalance={false} enableVisibilityToggle={false} />)
+    expect(screen.queryByText(`21`)).not.toBeInTheDocument()
+    expect(screen.getByText(`*****`)).toBeInTheDocument()
+
+    act(() => {
+      user.click(screen.getByText(`*****`))
+    })
+
+    expect(screen.queryByText(`21`)).not.toBeInTheDocument()
+    expect(screen.getByText(`*****`)).toBeInTheDocument()
+  })
+
+  it('should NOT toggle visibility of initially visible balance on click by default', () => {
     render(<Balance valueString={`21`} convertToUnit={SATS} showBalance={true} />)
     expect(screen.getByText(`21`)).toBeInTheDocument()
     expect(screen.queryByText(`*****`)).not.toBeInTheDocument()
 
     act(() => {
       user.click(screen.getByText(`21`))
+    })
+
+    expect(screen.getByText(`21`)).toBeInTheDocument()
+    expect(screen.queryByText(`*****`)).not.toBeInTheDocument()
+  })
+
+  it('should toggle visibility of initially visible balance on click when enabled via flag', () => {
+    render(<Balance valueString={`21`} convertToUnit={SATS} showBalance={true} enableVisibilityToggle={true} />)
+    expect(screen.getByText(`21`)).toBeInTheDocument()
+    expect(screen.queryByText(`*****`)).not.toBeInTheDocument()
+
+    act(() => {
+      user.click(screen.getByText(`21`))
+    })
+
+    expect(screen.queryByText(`21`)).not.toBeInTheDocument()
+    expect(screen.getByText(`*****`)).toBeInTheDocument()
+
+    act(() => {
+      user.click(screen.getByText(`*****`))
     })
 
     expect(screen.getByText(`21`)).toBeInTheDocument()

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
-import { useSettings } from '../context/SettingsContext'
+import { useSettings, useSettingsDispatch } from '../context/SettingsContext'
 import { useCurrentWallet, useCurrentWalletInfo, useReloadCurrentWalletInfo } from '../context/WalletContext'
 import Balance from './Balance'
 import Sprite from './Sprite'
@@ -26,7 +26,12 @@ const WalletHeader = ({ name, balance, unit, showBalance, loading }) => {
       )}
       {!loading && (
         <h2>
-          <Balance valueString={balance} convertToUnit={unit} showBalance={showBalance || false} />
+          <Balance
+            valueString={balance}
+            convertToUnit={unit}
+            showBalance={showBalance || false}
+            enableVisibilityToggle={false}
+          />
         </h2>
       )}
     </div>
@@ -106,6 +111,7 @@ const PrivacyLevel = ({ numAccounts, level, balance }) => {
 export default function CurrentWalletMagic() {
   const { t } = useTranslation()
   const settings = useSettings()
+  const settingsDispatch = useSettingsDispatch()
   const currentWallet = useCurrentWallet()
   const walletInfo = useCurrentWalletInfo()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
@@ -139,7 +145,7 @@ export default function CurrentWalletMagic() {
         </rb.Row>
       )}
       <>
-        <rb.Row>
+        <rb.Row onClick={() => settingsDispatch({ showBalance: !settings.showBalance })} style={{ cursor: 'pointer' }}>
           <WalletHeader
             name={currentWallet?.name}
             balance={walletInfo?.data.display.walletinfo.total_balance}

--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
-import { useSettings, useSettingsDispatch } from '../context/SettingsContext'
+import { useSettings } from '../context/SettingsContext'
 import { useCurrentWallet, useCurrentWalletInfo, useReloadCurrentWalletInfo } from '../context/WalletContext'
 import Balance from './Balance'
 import Sprite from './Sprite'
@@ -106,7 +106,6 @@ const PrivacyLevel = ({ numAccounts, level, balance }) => {
 export default function CurrentWalletMagic() {
   const { t } = useTranslation()
   const settings = useSettings()
-  const settingsDispatch = useSettingsDispatch()
   const currentWallet = useCurrentWallet()
   const walletInfo = useCurrentWalletInfo()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
@@ -140,7 +139,7 @@ export default function CurrentWalletMagic() {
         </rb.Row>
       )}
       <>
-        <rb.Row onClick={() => settingsDispatch({ showBalance: !settings.showBalance })} style={{ cursor: 'pointer' }}>
+        <rb.Row>
           <WalletHeader
             name={currentWallet?.name}
             balance={walletInfo?.data.display.walletinfo.total_balance}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -24,6 +24,7 @@ const WalletPreview = ({ wallet, walletInfo, unit, showBalance }) => {
               valueString={walletInfo.data.display.walletinfo.total_balance}
               convertToUnit={unit}
               showBalance={showBalance || false}
+              enableVisibilityToggle={false}
             />
           </div>
         ) : (


### PR DESCRIPTION
Adds the ability to toggle balances if they are hidden by settings.
Visible balances cannot be hidden (by default).

As a user, I want to quickly see a balance and not navigate to the settings for that.
There is a toggle on the magic wallet page, but it is needed in other places too (e.g. new Jam page, wallet page in advanced mode, etc.). In addition, this toggle mechanism is per displayed balance - it does not touch the settings values.

<img src="https://user-images.githubusercontent.com/3358649/167676756-b5cc9a75-6f6c-4a3e-9ae0-39125fd6570a.png" width=400 />

It was annoying for me sometimes, hence the PR – but that does not mean this should get merged right away. Let me know what you think. 