### PR TITLE
fix: delay scheduler start/stop

### DIFF
--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -79,7 +79,7 @@ export default function Jam() {
 
   const reloadSchedule = useCallback(
     ({ signal }) => {
-      return Api.getTumblerSchedule({ walletName: wallet.name, token: wallet.token, signal })
+      return Api.getSchedule({ walletName: wallet.name, token: wallet.token, signal })
         .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
         .then((data) => {
           if (!signal.aborted) {
@@ -157,7 +157,7 @@ export default function Jam() {
     const body = { destination_addresses: destinations }
 
     if (process.env.NODE_ENV === 'development' && useInsecureTestingSettings && !deactivateTestingToggle) {
-      body.tumbler_options = {
+      body.scheduler_options = {
         addrcount: 3,
         minmakercount: 1,
         makercountrange: [1, 0],
@@ -172,19 +172,14 @@ export default function Jam() {
       }
     }
 
-    try {
-      const res = await Api.postTumblerStart({ walletName: wallet.name, token: wallet.token }, body)
-
-      if (!res.ok) {
-        await Api.Helper.throwError(res, t('scheduler.error_starting_schedule_failed'))
-      }
-
-      setCollaborativeOperationRunning(true)
-    } catch (err) {
-      setAlert({ variant: 'danger', message: err.message })
-    } finally {
-      setIsLoading(false)
-    }
+    return Api.postSchedulerStart({ walletName: wallet.name, token: wallet.token }, body)
+      .then((res) => (res.ok ? true : Api.Helper.throwError(res, t('scheduler.error_starting_schedule_failed'))))
+      .then((_) => setCollaborativeOperationRunning(true))
+      .then((_) => new Promise((r) => setTimeout(r, 200)))
+      .catch((err) => {
+        setAlert({ variant: 'danger', message: err.message })
+      })
+      .finally(() => setIsLoading(false))
   }
 
   const stopSchedule = async () => {
@@ -195,19 +190,14 @@ export default function Jam() {
     setAlert(null)
     setIsLoading(true)
 
-    try {
-      const res = await Api.getTumblerStop({ walletName: wallet.name, token: wallet.token })
-
-      if (!res.ok) {
-        await Api.Helper.throwError(res, t('scheduler.error_stopping_schedule_failed'))
-      }
-
-      setCollaborativeOperationRunning(false)
-    } catch (err) {
-      setAlert({ variant: 'danger', message: err.message })
-    } finally {
-      setIsLoading(false)
-    }
+    return Api.getSchedulerStop({ walletName: wallet.name, token: wallet.token })
+      .then((res) => (res.ok ? true : Api.Helper.throwError(res, t('scheduler.error_stopping_schedule_failed'))))
+      .then((_) => setCollaborativeOperationRunning(false))
+      .then((_) => new Promise((r) => setTimeout(r, 200)))
+      .catch((err) => {
+        setAlert({ variant: 'danger', message: err.message })
+      })
+      .finally(() => setIsLoading(false))
   }
 
   return (

--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -48,6 +48,7 @@ export default function Jam() {
   const INTERNAL_DEST_ACCOUNT = 0
   // Interval in milliseconds between requests to reload the schedule.
   const SCHEDULE_REQUEST_INTERVAL = process.env.NODE_ENV === 'development' ? 10_000 : 60_000
+  const SCHEDULER_STOP_RESPONSE_DELAY_MS = 2_000
 
   useEffect(() => {
     const abortCtrl = new AbortController()
@@ -175,7 +176,6 @@ export default function Jam() {
     return Api.postSchedulerStart({ walletName: wallet.name, token: wallet.token }, body)
       .then((res) => (res.ok ? true : Api.Helper.throwError(res, t('scheduler.error_starting_schedule_failed'))))
       .then((_) => setCollaborativeOperationRunning(true))
-      .then((_) => new Promise((r) => setTimeout(r, 200)))
       .catch((err) => {
         setAlert({ variant: 'danger', message: err.message })
       })
@@ -193,7 +193,7 @@ export default function Jam() {
     return Api.getSchedulerStop({ walletName: wallet.name, token: wallet.token })
       .then((res) => (res.ok ? true : Api.Helper.throwError(res, t('scheduler.error_stopping_schedule_failed'))))
       .then((_) => setCollaborativeOperationRunning(false))
-      .then((_) => new Promise((r) => setTimeout(r, 200)))
+      .then((_) => new Promise((r) => setTimeout(r, SCHEDULER_STOP_RESPONSE_DELAY_MS)))
       .catch((err) => {
         setAlert({ variant: 'danger', message: err.message })
       })

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -92,12 +92,12 @@ interface ConfigSetRequest {
   field: string
 }
 
-interface StartTumblerRequest {
+interface StartSchedulerRequest {
   destination_addresses: BitcoinAddress[]
-  tumbler_options?: TumblerOptions
+  scheduler_options?: SchedulerOptions
 }
 
-interface TumblerOptions {
+interface SchedulerOptions {
   mixdepthsrc?: number
   restart?: boolean
   schedulefile?: string
@@ -276,7 +276,7 @@ const postFreeze = async (
   })
 }
 
-const postTumblerStart = async ({ token, signal, walletName }: WalletRequestContext, req: StartTumblerRequest) => {
+const postSchedulerStart = async ({ token, signal, walletName }: WalletRequestContext, req: StartSchedulerRequest) => {
   return await fetch(`${basePath()}/v1/wallet/${walletName}/taker/schedule`, {
     method: 'POST',
     headers: { ...Authorization(token) },
@@ -285,14 +285,14 @@ const postTumblerStart = async ({ token, signal, walletName }: WalletRequestCont
   })
 }
 
-const getTumblerStop = async ({ token, signal, walletName }: WalletRequestContext) => {
+const getSchedulerStop = async ({ token, signal, walletName }: WalletRequestContext) => {
   return await fetch(`${basePath()}/v1/wallet/${walletName}/taker/stop`, {
     headers: { ...Authorization(token) },
     signal,
   })
 }
 
-const getTumblerSchedule = async ({ token, signal, walletName }: WalletRequestContext) => {
+const getSchedule = async ({ token, signal, walletName }: WalletRequestContext) => {
   return await fetch(`${basePath()}/v1/wallet/${walletName}/taker/schedule`, {
     headers: { ...Authorization(token) },
     signal,
@@ -379,8 +379,8 @@ export {
   postFreeze,
   postConfigGet,
   getWalletSeed,
-  postTumblerStart,
-  getTumblerStop,
-  getTumblerSchedule,
+  postSchedulerStart,
+  getSchedulerStop,
+  getSchedule,
   Helper,
 }

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -276,11 +276,14 @@ const postFreeze = async (
   })
 }
 
-const postSchedulerStart = async ({ token, signal, walletName }: WalletRequestContext, req: StartSchedulerRequest) => {
+const postSchedulerStart = async (
+  { token, signal, walletName }: WalletRequestContext,
+  { destination_addresses, scheduler_options }: StartSchedulerRequest
+) => {
   return await fetch(`${basePath()}/v1/wallet/${walletName}/taker/schedule`, {
     method: 'POST',
     headers: { ...Authorization(token) },
-    body: JSON.stringify({ ...req }),
+    body: JSON.stringify({ destination_addresses: destination_addresses, tumbler_options: scheduler_options }),
     signal,
   })
 }


### PR DESCRIPTION
Resolves #249.

I used the same delay (2000ms) as in the Earn screen. What do you think @theborakompanioni, is that long enough?

A bit off topic, but I also renamed all API methods to refer to "Scheduler" now.