### PR TITLE
fix: possible reference error in catch clause

### DIFF
--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -88,7 +88,7 @@ export default function Jam() {
           }
         })
         .catch((err) => {
-          if (err.response.status === 404) {
+          if (err.response?.status === 404) {
             // Not finding a schedule is not an error.
             // It means a single collaborative transaction is running.
             // Those have no schedule.


### PR DESCRIPTION
`err.response` is only populated by actual `JmApiErrors`, it might be `undefined`.
e.g. on aborts (`signal.aborted := true`)

This can be reproduced by artificially limiting your network connection speed, e.g. via Dev Tools (most browser should be able of doing that, I suppose).