### PR TITLE
ui: big red button for payments without improved privacy

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -414,7 +414,7 @@ export default function Send() {
   const onSubmit = async (e) => {
     e.preventDefault()
 
-    if (isOperationDisabled) return
+    if (isLoading || isOperationDisabled) return
 
     const form = e.currentTarget
     const isValid = formIsValid
@@ -728,7 +728,7 @@ export default function Send() {
           />
         )}
         <rb.Button
-          variant="dark"
+          variant={isCoinjoin ? 'dark' : 'danger'}
           type="submit"
           disabled={isOperationDisabled || isLoading || isSending || !formIsValid}
           className={`${styles['button']} ${styles['send-button']} mt-4`}
@@ -739,8 +739,10 @@ export default function Send() {
               <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
               {t('send.text_sending')}
             </div>
-          ) : (
+          ) : isCoinjoin ? (
             t('send.button_send')
+          ) : (
+            t('send.button_send_without_improved_privacy')
           )}
         </rb.Button>
       </div>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -177,6 +177,7 @@
     "feedback_invalid_amount": "Please provide a valid amount.",
     "toggle_coinjoin": "Send as collaborative transaction for improved privacy",
     "button_send": "Send",
+    "button_send_without_improved_privacy": "Send – without improved privacy",
     "text_sending": "Sending",
     "button_sweep": "Sweep",
     "button_clear_sweep": "Clear",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -177,7 +177,7 @@
     "feedback_invalid_amount": "Please provide a valid amount.",
     "toggle_coinjoin": "Send as collaborative transaction for improved privacy",
     "button_send": "Send",
-    "button_send_without_improved_privacy": "Send – without improved privacy",
+    "button_send_without_improved_privacy": "Send without privacy improvement",
     "text_sending": "Sending",
     "button_sweep": "Sweep",
     "button_clear_sweep": "Clear",


### PR DESCRIPTION
As the title says: Send button signals non-privacy payment choice as suggested in Figma.

## 📸 
<img src="https://user-images.githubusercontent.com/3358649/168660629-e7af6592-10d0-4281-8581-12b21600d9da.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/168660652-9ef69b80-3133-4a65-8a97-82681501474c.png" width=400 />

edit: Images are outdated – instead of "Normal Send – …", it just says "Send – …".