### PR TITLE
feat(footer): show Jam version

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -186,7 +186,7 @@ export default function App() {
             )}
           </div>
           <div className="d-flex flex-1 order-2 justify-content-end align-items-center gap-1">
-            <div className="warning-hint text-start text-secondary d-none d-md-block gap-1 pe-1">
+            <div className="warning-hint text-start text-secondary d-none d-md-block pe-1">
               <a
                 href="https://github.com/joinmarket-webui/joinmarket-webui/tags"
                 target="_blank"

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -23,6 +23,7 @@ import Onboarding from './Onboarding'
 import Cheatsheet from './Cheatsheet'
 import { routes } from '../constants/routes'
 import { isFeatureEnabled } from '../constants/featureFlags'
+import packageInfo from '../../package.json'
 
 export default function App() {
   const { t } = useTranslation()
@@ -185,6 +186,17 @@ export default function App() {
             )}
           </div>
           <div className="d-flex flex-1 order-2 justify-content-end align-items-center gap-1">
+            <div className="warning-hint text-start text-secondary d-none d-md-block gap-1 pe-1">
+              <a
+                href="https://github.com/joinmarket-webui/joinmarket-webui/tags"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="d-flex align-items-center text-secondary"
+              >
+                {' '}
+                v{packageInfo.version}
+              </a>
+            </div>
             <div className="d-flex gap-2 pe-2">
               <a
                 href="https://github.com/joinmarket-webui/joinmarket-webui"


### PR DESCRIPTION
Bottom right, next to GitHub link. Link will lead to /tags.

Won't be shown on small screens.

### Screenshots 📸

![Screenshot 2022-05-17 at 22-08-31 Jam for JoinMarket](https://user-images.githubusercontent.com/109058/168901394-0f3df1c6-edab-460a-9413-fa10baa3e09d.png)

![Screenshot 2022-05-17 at 22-08-51 Jam for JoinMarket](https://user-images.githubusercontent.com/109058/168901405-61bac2fb-6ff7-4eb8-b925-f55887ef3529.png)
