### PR TITLE
chore: enable cheatsheet

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,7 +22,6 @@ import { setSession, clearSession } from '../session'
 import Onboarding from './Onboarding'
 import Cheatsheet from './Cheatsheet'
 import { routes } from '../constants/routes'
-import { isFeatureEnabled } from '../constants/features'
 import packageInfo from '../../package.json'
 
 export default function App() {
@@ -38,7 +37,7 @@ export default function App() {
   const [showAlphaWarning, setShowAlphaWarning] = useState(false)
   const [showCheatsheet, setShowCheatsheet] = useState(false)
 
-  const cheatsheetEnabled = currentWallet && isFeatureEnabled('cheatsheet')
+  const cheatsheetEnabled = currentWallet
 
   const startWallet = useCallback(
     (name, token) => {

--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -31,7 +31,7 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
   const { t } = useTranslation()
 
   return (
-    <rb.Offcanvas className="cheatsheet" show={show} onHide={onHide} placement="bottom">
+    <rb.Offcanvas className="cheatsheet" show={show} onHide={onHide} placement="bottom" onClick={onHide}>
       <rb.Offcanvas.Header closeButton>
         <rb.Stack>
           <rb.Offcanvas.Title>{t('cheatsheet.title')}</rb.Offcanvas.Title>

--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -78,7 +78,7 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
           <ListItem number={2}>
             <h6>
               <Trans i18nKey="cheatsheet.item_2.title">
-                <Link to={routes.send}>Send</Link> a collaborative transaction to yourself.
+                <Link to={routes.jam}>Schedule</Link> transactions.
               </Trans>
             </h6>
             <div className="small text-secondary">{t('cheatsheet.item_2.description')}</div>
@@ -105,17 +105,9 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
             <div className="small text-secondary">{t('cheatsheet.item_4.description')}</div>
           </ListItem>
           <ListItem number={5}>
-            <h6>
-              <Trans i18nKey="cheatsheet.item_5.title">
-                <Link to={routes.jam}>Schedule</Link> transactions.
-              </Trans>
-            </h6>
-            <div className="small text-secondary">{t('cheatsheet.item_5.description')}</div>
-          </ListItem>
-          <ListItem number={6}>
-            <h6>{t('cheatsheet.item_6.title')}</h6>
+            <h6>{t('cheatsheet.item_5.title')}</h6>
             <div className="small text-secondary">
-              <Trans i18nKey="cheatsheet.item_6.description">
+              <Trans i18nKey="cheatsheet.item_5.description">
                 Still confused?{' '}
                 <a
                   href="https://github.com/openoms/bitcoin-tutorials/blob/master/joinmarket/joinmarket_private_flow.md#a-private-flow-through-joinmarket"

--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -107,7 +107,7 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
           <ListItem number={5}>
             <h6>
               <Trans i18nKey="cheatsheet.item_5.title">
-                <Link to={routes.send}>Schedule</Link> transactions.
+                <Link to={routes.jam}>Schedule</Link> transactions.
               </Trans>
             </h6>
             <div className="small text-secondary">{t('cheatsheet.item_5.description')}</div>

--- a/src/constants/features.ts
+++ b/src/constants/features.ts
@@ -1,13 +1,11 @@
 interface Features {
   skipWalletBackupConfirmation: boolean
-  cheatsheet: boolean
 }
 
 const devMode = process.env.NODE_ENV === 'development'
 
 const features: Features = {
   skipWalletBackupConfirmation: devMode,
-  cheatsheet: devMode,
 }
 
 type Feature = keyof Features

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -240,8 +240,8 @@
       "description": "Deposit some funds yourself or receive it from others."
     },
     "item_2": {
-      "title": "<0>Send</0> a collaborative transaction to yourself.",
-      "description": "Collaborative transactions increase everyone's privacy."
+      "title": "<0>Schedule</0> transactions.",
+      "description": "Automatically plan and execute a series of collaborative transactions. You can also automatically sweep your funds to cold storage, or use them to open a lightning channel, for example."
     },
     "item_3": {
       "title": "Optional: <1>Lock</1> funds in a fidelity bond.",
@@ -252,10 +252,6 @@
       "description": "Offer your sats to the marketplace. No trust or custody required—you are always in full control of your funds."
     },
     "item_5": {
-      "title": "<0>Schedule</0> transactions.",
-      "description": "Automatically plan and execute a series of collaborative transactions. You can also automatically sweep your funds to cold storage, or use them to open a lightning channel, for example."
-    },
-    "item_6": {
       "title": "Go to step one and repeat.",
       "description": "Still confused? Dig into the <2>documentation</2>."
     }


### PR DESCRIPTION
Removes cheatsheet from feature flags, thereby enabling it for everyone.
Also fixed the link to the Jam page.

Did **not** change the order of the entries. But that can be done quickly. Thoughts?

<img src="https://user-images.githubusercontent.com/3358649/169276331-b262b259-fe15-4755-9b67-8af0fd0f7cf6.png" width=400 />


