### PR TITLE
ui: cheatsheet optimization

### DIFF
--- a/src/components/Cheatsheet.module.css
+++ b/src/components/Cheatsheet.module.css
@@ -1,0 +1,45 @@
+.cheatsheet {
+  height: auto;
+  /* page height - navbar height - some spacing*/
+  max-height: calc(100vh - 76px - 1rem);
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+  margin: 0px auto;
+  width: 528px;
+}
+
+.cheatsheet button[aria-label='Close'] {
+  margin-bottom: auto;
+}
+
+.cheatsheet a {
+  color: inherit;
+}
+
+.cheatsheet-list-item {
+  align-items: start;
+}
+
+.cheatsheet-list-item.upcoming-feature {
+  opacity: 0.25;
+}
+
+.cheatsheet-list-item h6 {
+  margin-bottom: 0.1rem;
+}
+
+.numbered {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background-color: rgb(0, 0, 0);
+  color: white;
+}
+
+:root[data-theme='dark'] .numbered {
+  color: rgb(0, 0, 0);
+  background-color: white;
+}

--- a/src/components/Cheatsheet.module.css
+++ b/src/components/Cheatsheet.module.css
@@ -3,9 +3,16 @@
   /* page height - navbar height - some spacing*/
   max-height: calc(100vh - 76px - 1rem) !important;
   margin: 0px auto !important;
+  border: none !important;
   border-top-left-radius: 1rem;
   border-top-right-radius: 1rem;
   width: 528px;
+
+  box-shadow: 6px -3px 12px 3px rgba(0, 0, 0, 0.1);
+}
+
+:root[data-theme='dark'] .cheatsheet {
+  box-shadow: 6px -3px 12px 3px rgba(0, 0, 0, 0.5);
 }
 
 .cheatsheet button[aria-label='Close'] {

--- a/src/components/Cheatsheet.module.css
+++ b/src/components/Cheatsheet.module.css
@@ -23,7 +23,7 @@
   color: inherit !important;
 }
 
-.cheatsheet-list-item {
+.cheatsheet .cheatsheet-list-item {
   align-items: start;
 }
 

--- a/src/components/Cheatsheet.module.css
+++ b/src/components/Cheatsheet.module.css
@@ -1,10 +1,10 @@
 .cheatsheet {
-  height: auto;
+  height: auto !important;
   /* page height - navbar height - some spacing*/
-  max-height: calc(100vh - 76px - 1rem);
+  max-height: calc(100vh - 76px - 1rem) !important;
+  margin: 0px auto !important;
   border-top-left-radius: 1rem;
   border-top-right-radius: 1rem;
-  margin: 0px auto;
   width: 528px;
 }
 
@@ -13,7 +13,7 @@
 }
 
 .cheatsheet a {
-  color: inherit;
+  color: inherit !important;
 }
 
 .cheatsheet-list-item {

--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -3,6 +3,7 @@ import * as rb from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { routes } from '../constants/routes'
+import styles from './Cheatsheet.module.css'
 
 interface CheatsheetProps {
   show: boolean
@@ -14,13 +15,13 @@ type NumberedProps = {
   className?: string
 }
 
-function Numbered({ number }: { number: number }) {
-  return <div className="numbered">{number}</div>
+function Numbered({ number }: NumberedProps) {
+  return <div className={styles.numbered}>{number}</div>
 }
 
 function ListItem({ number, children, ...props }: PropsWithChildren<NumberedProps>) {
   return (
-    <rb.Stack className={`cheatsheet-list-item ${props.className || ''}`} direction="horizontal" gap={3}>
+    <rb.Stack className={`${styles['cheatsheet-list-item']} ${props.className || ''}`} direction="horizontal" gap={3}>
       <Numbered number={number} />
       <rb.Stack gap={0}>{children}</rb.Stack>
     </rb.Stack>
@@ -31,7 +32,7 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
   const { t } = useTranslation()
 
   return (
-    <rb.Offcanvas className="cheatsheet" show={show} onHide={onHide} placement="bottom" onClick={onHide}>
+    <rb.Offcanvas className={styles.cheatsheet} show={show} onHide={onHide} placement="bottom" onClick={onHide}>
       <rb.Offcanvas.Header closeButton>
         <rb.Stack>
           <rb.Offcanvas.Title>{t('cheatsheet.title')}</rb.Offcanvas.Title>
@@ -83,7 +84,7 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
             </h6>
             <div className="small text-secondary">{t('cheatsheet.item_2.description')}</div>
           </ListItem>
-          <ListItem number={3} className="upcoming-feature">
+          <ListItem number={3} className={styles['upcoming-feature']}>
             <h6>
               <Trans i18nKey="cheatsheet.item_3.title">
                 Optional: <Link to={routes.earn}>Lock</Link> funds in a fidelity bond.

--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -116,6 +116,14 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
             </h6>
             <div className="small text-secondary">{t('cheatsheet.item_4.description')}</div>
           </ListItem>
+          <ListItem number={5}>
+            <h6>
+              <Trans i18nKey="cheatsheet.item_5.title">
+                <Link to={routes.send}>Send</Link> a collaborative transaction to yourself.
+              </Trans>
+            </h6>
+            <div className="small text-secondary">{t('cheatsheet.item_5.description')}</div>
+          </ListItem>
           <ListItem number={'last'}>
             <h6>{t('cheatsheet.item_last.title')}</h6>
             <div className="small text-secondary">

--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -3,6 +3,7 @@ import * as rb from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { routes } from '../constants/routes'
+import Sprite from './Sprite'
 import styles from './Cheatsheet.module.css'
 
 interface CheatsheetProps {
@@ -11,12 +12,22 @@ interface CheatsheetProps {
 }
 
 type NumberedProps = {
-  number: number
+  number: number | 'last'
   className?: string
 }
 
 function Numbered({ number }: NumberedProps) {
-  return <div className={styles.numbered}>{number}</div>
+  return (
+    <div className={styles.numbered}>
+      {number === 'last' ? (
+        <>
+          <Sprite symbol="checkmark" width="24" height="24" />
+        </>
+      ) : (
+        <>{number}</>
+      )}
+    </div>
+  )
 }
 
 function ListItem({ number, children, ...props }: PropsWithChildren<NumberedProps>) {
@@ -105,10 +116,10 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
             </h6>
             <div className="small text-secondary">{t('cheatsheet.item_4.description')}</div>
           </ListItem>
-          <ListItem number={5}>
-            <h6>{t('cheatsheet.item_5.title')}</h6>
+          <ListItem number={'last'}>
+            <h6>{t('cheatsheet.item_last.title')}</h6>
             <div className="small text-secondary">
-              <Trans i18nKey="cheatsheet.item_5.description">
+              <Trans i18nKey="cheatsheet.item_last.description">
                 Still confused?{' '}
                 <a
                   href="https://github.com/openoms/bitcoin-tutorials/blob/master/joinmarket/joinmarket_private_flow.md#a-private-flow-through-joinmarket"

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -251,7 +251,7 @@
       "title": "<0>Earn</0> yield by providing liquidity.",
       "description": "Offer your sats to the marketplace. No trust or custody required—you are always in full control of your funds."
     },
-    "item_5": {
+    "item_last": {
       "title": "Go to step one and repeat.",
       "description": "Still confused? Dig into the <2>documentation</2>."
     }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -251,6 +251,10 @@
       "title": "<0>Earn</0> yield by providing liquidity.",
       "description": "Offer your sats to the marketplace. No trust or custody required—you are always in full control of your funds."
     },
+    "item_5": {
+      "title": "<0>Send</0> a collaborative transaction to yourself.",
+      "description": "Collaborative transactions increase the privacy of yourself and others."
+    },
     "item_last": {
       "title": "Go to step one and repeat.",
       "description": "Still confused? Dig into the <2>documentation</2>."

--- a/src/index.css
+++ b/src/index.css
@@ -357,59 +357,14 @@ main {
   }
 }
 
-/* Cheatsheet Styles */
-.cheatsheet {
-  height: auto;
-  /* page height - navbar height - some spacing*/
-  max-height: calc(100vh - 76px - 1rem);
-  border-top-left-radius: 1rem;
-  border-top-right-radius: 1rem;
-  margin: 0px auto;
-  width: 528px;
-}
-
-.cheatsheet .offcanvas-header .btn-close {
-  margin-bottom: auto;
-}
-
-.cheatsheet .cheatsheet-list-item {
-  align-items: start;
-}
-
-.cheatsheet .cheatsheet-list-item.upcoming-feature {
-  opacity: 0.25;
-}
-
-.cheatsheet .cheatsheet-list-item h6 {
-  margin-bottom: 0.1rem;
-}
-.cheatsheet a {
-  color: inherit;
-}
-
-.cheatsheet .numbered {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-width: 2rem;
-  height: 2rem;
-  border-radius: 50%;
-  background-color: rgb(0, 0, 0);
-  color: white;
-}
-
-:root[data-theme='dark'] .cheatsheet .numbered {
-  color: rgb(0, 0, 0);
-  background-color: white;
-}
-
-.cheatsheet-link.nav-link {
+footer .cheatsheet-link.nav-link {
   color: var(--bs-gray-900);
 }
 
-:root[data-theme='dark'] .cheatsheet-link.nav-link {
+:root[data-theme='dark'] footer .cheatsheet-link.nav-link {
   color: var(--bs-gray-400);
 }
+
 /* Blurred Text Styles */
 
 .blurred-text {


### PR DESCRIPTION
Closes #290 (?)

Changed:
- Use "tick" as last item in the list
- Re-add link to Send screen
- Move cheatsheet styles to own module
- Add `box-shadow` style to cheatsheet overlay

Not changed:
- The figma designs has other wordings than chosen in https://github.com/joinmarket-webui/joinmarket-webui/pull/211#issuecomment-1096706454 . This wording has not been changed.

Let me know if this is okay for you @editwentyone!

## 📸
<img src="https://user-images.githubusercontent.com/3358649/170486598-fe5a664b-fb73-40df-8975-c4a008364c90.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/170486620-09689020-07c5-4b72-b1f2-d61d014b272a.png" width=400 />

(Screenshots slightly outdated: aligned numbered items to start position, as it was before)

