### PR TITLE
ui: add hint about creating wallet duration

### DIFF
--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -144,6 +144,11 @@ const WalletCreationForm = ({ createWallet }) => {
               )}
             </rb.Button>
           </rb.Form>
+          {isSubmitting && (
+            <div className="text-center text-muted small mt-4">
+              <p>{t('create_wallet.hint_duration_text')}</p>
+            </div>
+          )}
         </>
       )}
     </Formik>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -102,7 +102,8 @@
     "back_button": "Back",
     "skip_button": "Skip",
     "next_button": "Next",
-    "placeholder_seed_word_input": "Word"
+    "placeholder_seed_word_input": "Word",
+    "hint_duration_text": "Please be patient, this may take a few minutes."
   },
   "current_wallet": {
     "text_loading": "Loading",


### PR DESCRIPTION
Closes #294.

Adds the following phrase to the `CreateWallet` screen:
> "Please be patient, this may take a few minutes."

## 📸
<img src="https://user-images.githubusercontent.com/3358649/170499986-438233cd-fe83-4ad4-8ec5-7c64f0be0b2b.png" width=400 />

