### PR TITLE
fix: prevent unnecessary wallet info requests

### DIFF
--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useCallback, useState, useContext, PropsWithChildren } from 'react'
+import React, { createContext, useEffect, useCallback, useState, useContext, PropsWithChildren, useRef } from 'react'
 
 import { getSession } from '../session'
 import * as Api from '../libs/JmWalletApi'
@@ -118,22 +118,43 @@ const loadWalletInfoData = async ({
 const WalletProvider = ({ children }: PropsWithChildren<any>) => {
   const [currentWallet, setCurrentWallet] = useState(restoreWalletFromSession())
   const [currentWalletInfo, setCurrentWalletInfo] = useState<WalletInfo | null>(null)
+  const fetchWalletInfoInProgress = useRef<Promise<WalletInfo> | null>(null)
 
   const reloadCurrentWalletInfo = useCallback(
     async ({ signal }: { signal: AbortSignal }) => {
       if (!currentWallet) {
         throw new Error('Cannot load wallet info: Wallet not present')
       } else {
-        const { name: walletName, token } = currentWallet
-        return loadWalletInfoData({ walletName, token, signal }).then((walletInfo) => {
-          if (!signal.aborted) {
-            setCurrentWalletInfo(walletInfo)
+        if (fetchWalletInfoInProgress.current !== null) {
+          try {
+            return await fetchWalletInfoInProgress.current
+          } catch (err: unknown) {
+            // If a previous wallet info request was in progress but failed, retry!
+            // This happens e.g. when the in-progress request was aborted.
+            if (!(err instanceof Error) || err.name !== 'AbortError') {
+              console.warn('Previous wallet info request resulted in an unexpected error. Retrying!', err)
+            }
           }
-          return walletInfo
-        })
+        }
+
+        const { name: walletName, token } = currentWallet
+        const fetch = loadWalletInfoData({ walletName, token, signal })
+
+        fetchWalletInfoInProgress.current = fetch
+
+        return fetch
+          .finally(() => {
+            fetchWalletInfoInProgress.current = null
+          })
+          .then((walletInfo) => {
+            if (!signal.aborted) {
+              setCurrentWalletInfo(walletInfo)
+            }
+            return walletInfo
+          })
       }
     },
-    [currentWallet]
+    [currentWallet, fetchWalletInfoInProgress]
   )
 
   useEffect(() => {

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -5,9 +5,9 @@
  *
  * See OpenAPI spec: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/api/wallet-rpc.yaml
  *
- * Because we forward all requests through a proxy, additional functionality
+ * Because all requests are forwarded through a proxy, additional functionality
  * can be provided. One adaptation is to send the Authorization header as
- * 'x-jm-authorization' so that the reverse proxy can apply its own
+ * 'x-jm-authorization' so that any reverse proxy can apply its own
  * authentication mechanism.
  */
 const basePath = () => `${window.JM.PUBLIC_PATH}/api`


### PR DESCRIPTION
This fix prevents unnecessary wallet info requests.
Wallet data is automatically loaded on initial page renderings automatically.
However, if a components needs an up-to-date balance, it always triggers `reloadCurrentWalletInfo`.

Before this commit, this meant that the data is loaded twice when the app is refreshed on a component that needs wallet infos.
After this commit, the `reloadCurrentWalletInfo` method knows that an api request is already performed and will wait for it to be completed.

Before:
![image](https://user-images.githubusercontent.com/3358649/170682254-e8e1ac0b-7ce1-47b6-aad3-7e9181132cec.png)


After:
![image](https://user-images.githubusercontent.com/3358649/170682180-fda1a868-240d-4052-95c2-1e2c1b8d3a95.png)
