### PR TITLE
Fetch config values only once per wallet session

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -8,7 +8,7 @@ import Sprite from './Sprite'
 import Balance from './Balance'
 import { useReloadCurrentWalletInfo, useCurrentWallet, useCurrentWalletInfo } from '../context/WalletContext'
 import { useServiceInfo, useReloadServiceInfo } from '../context/ServiceInfoContext'
-import { useLoadConfigValueIfAbsent } from '../context/ServiceConfigContext'
+import { useLoadConfigValue } from '../context/ServiceConfigContext'
 import { useSettings } from '../context/SettingsContext'
 import { useBalanceSummary } from '../hooks/BalanceSummary'
 import * as Api from '../libs/JmWalletApi'
@@ -136,7 +136,7 @@ const enhanceDirectPaymentErrorMessageIfNecessary = async (httpStatus, errorMess
 }
 
 const enhanceTakerErrorMessageIfNecessary = async (
-  loadConfigValueIfAbsent,
+  loadConfigValue,
   httpStatus,
   errorMessage,
   onMaxFeeSettingsMissing
@@ -146,7 +146,7 @@ const enhanceTakerErrorMessageIfNecessary = async (
     const abortCtrl = new AbortController()
 
     const configExists = (section, field) =>
-      loadConfigValueIfAbsent({
+      loadConfigValue({
         signal: abortCtrl.signal,
         key: { section, field },
       })
@@ -185,7 +185,7 @@ export default function Send() {
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
   const serviceInfo = useServiceInfo()
   const reloadServiceInfo = useReloadServiceInfo()
-  const loadConfigValueIfAbsent = useLoadConfigValueIfAbsent()
+  const loadConfigValue = useLoadConfigValue()
   const settings = useSettings()
   const location = useLocation()
 
@@ -332,7 +332,7 @@ export default function Send() {
       !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message })
     })
 
-    const loadingMinimumMakerConfig = loadConfigValueIfAbsent({
+    const loadingMinimumMakerConfig = loadConfigValue({
       signal: abortCtrl.signal,
       key: { section: 'POLICY', field: 'minimum_makers' },
     })
@@ -356,7 +356,7 @@ export default function Send() {
     wallet,
     reloadCurrentWalletInfo,
     reloadServiceInfo,
-    loadConfigValueIfAbsent,
+    loadConfigValue,
     t,
   ])
 
@@ -426,7 +426,7 @@ export default function Send() {
       } else {
         const message = await Api.Helper.extractErrorMessage(res)
         const displayMessage = await enhanceTakerErrorMessageIfNecessary(
-          loadConfigValueIfAbsent,
+          loadConfigValue,
           res.status,
           message,
           (errorMessage) => `${errorMessage} ${t('send.taker_error_message_max_fees_config_missing')}`

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -8,6 +8,7 @@ import Sprite from './Sprite'
 import Balance from './Balance'
 import { useReloadCurrentWalletInfo, useCurrentWallet, useCurrentWalletInfo } from '../context/WalletContext'
 import { useServiceInfo, useReloadServiceInfo } from '../context/ServiceInfoContext'
+import { useLoadConfigValueIfAbsent } from '../context/ServiceConfigContext'
 import { useSettings } from '../context/SettingsContext'
 import { useBalanceSummary } from '../hooks/BalanceSummary'
 import * as Api from '../libs/JmWalletApi'
@@ -176,6 +177,7 @@ export default function Send() {
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
   const serviceInfo = useServiceInfo()
   const reloadServiceInfo = useReloadServiceInfo()
+  const loadConfigValueIfAbsent = useLoadConfigValueIfAbsent()
   const settings = useSettings()
   const location = useLocation()
 
@@ -322,11 +324,12 @@ export default function Send() {
       !abortCtrl.signal.aborted && setAlert({ variant: 'danger', message })
     })
 
-    const requestContext = { walletName: wallet.name, token: wallet.token, signal: abortCtrl.signal }
-    const loadingMinimumMakerConfig = Api.postConfigGet(requestContext, { section: 'POLICY', field: 'minimum_makers' })
-      .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res, t('send.error_loading_min_makers_failed'))))
+    const loadingMinimumMakerConfig = loadConfigValueIfAbsent({
+      signal: abortCtrl.signal,
+      key: { section: 'POLICY', field: 'minimum_makers' },
+    })
       .then((data) => {
-        const minimumMakers = parseInt(data.configvalue, 10)
+        const minimumMakers = parseInt(data.value, 10)
         setMinNumCollaborators(minimumMakers)
         setNumCollaborators(initialNumCollaborators(minimumMakers))
       })

--- a/src/context/ServiceConfigContext.tsx
+++ b/src/context/ServiceConfigContext.tsx
@@ -1,0 +1,118 @@
+import React, { createContext, useCallback, useContext, useReducer, useEffect, useState } from 'react'
+// @ts-ignore
+import { useCurrentWallet } from './WalletContext'
+
+import * as Api from '../libs/JmWalletApi'
+
+interface JmConfigData {
+  configvalue: string
+}
+
+type SectionKey = string
+
+interface ServiceConfig {
+  [key: SectionKey]: Record<string, string | null>
+}
+
+interface ConfigKey {
+  section: SectionKey
+  field: string
+}
+
+interface ServiceConfigUpdate {
+  key: ConfigKey
+  value: string
+}
+
+interface ServiceConfigContextEntry {
+  serviceConfig: ServiceConfig | null
+}
+
+const ServiceConfigContext = createContext<ServiceConfigContextEntry | undefined>(undefined)
+
+const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
+  const currentWallet = useCurrentWallet()
+
+  const [serviceConfig, setServiceConfig] = useState<ServiceConfig | null>(null)
+  const [serviceConfig2, dispatchServiceConfig] = useReducer(
+    (state: ServiceConfig | null, obj: ServiceConfigUpdate) => {
+      const data = { ...state }
+      if (data && data[obj.key.section]) {
+        data[obj.key.section] = { ...data[obj.key.section], [obj.key.field]: obj.value }
+      } else {
+        data[obj.key.section] = { [obj.key.field]: obj.value }
+      }
+      return data as ServiceConfig | null
+    },
+    null
+  )
+
+  const reloadServiceConfig = useCallback(
+    async ({ signal }: { signal: AbortSignal }) => {
+      if (!currentWallet) {
+        throw new Error('Cannot load config: Wallet not present')
+      }
+
+      const configKeys: ConfigKey[] = [{ section: 'POLICY', field: 'minimum_makers' }]
+
+      const { name: walletName, token } = currentWallet
+      const fetches: Promise<ServiceConfigUpdate>[] = configKeys.map((configKey) => {
+        return Api.postConfigGet(
+          { walletName, token, signal },
+          { section: configKey.section.toString(), field: configKey.field }
+        )
+          .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
+          .then((data: JmConfigData) => {
+            return {
+              key: configKey,
+              value: data.configvalue,
+            } as ServiceConfigUpdate
+          })
+      })
+
+      return Promise.all(fetches)
+        .then((data) => {
+          return data.reduce((state: ServiceConfig, obj: ServiceConfigUpdate) => {
+            const data = { ...state }
+            if (data && data[obj.key.section]) {
+              data[obj.key.section] = { ...data[obj.key.section], [obj.key.field]: obj.value }
+            } else {
+              data[obj.key.section] = { [obj.key.field]: obj.value }
+            }
+            return data as ServiceConfig
+          }, {} as ServiceConfig)
+        })
+        .then((result) => {
+          if (!signal.aborted) {
+            setServiceConfig(result)
+          }
+          return result
+        })
+    },
+    [currentWallet]
+  )
+
+  useEffect(() => {
+    if (!currentWallet) return
+
+    const abortCtrl = new AbortController()
+
+    reloadServiceConfig({ signal: abortCtrl.signal }).catch((err) => console.error(err))
+
+    return () => {
+      abortCtrl.abort()
+    }
+  }, [currentWallet, reloadServiceConfig])
+
+  return <ServiceConfigContext.Provider value={{ serviceConfig }}>{children}</ServiceConfigContext.Provider>
+}
+
+const useServiceConfig = () => {
+  const context = useContext(ServiceConfigContext)
+  if (context === undefined) {
+    throw new Error('useServiceConfig must be used within a ServiceConfigProvider')
+  }
+  return context.serviceConfig
+}
+
+export { ServiceConfigContext, ServiceConfigProvider, useServiceConfig }

--- a/src/context/ServiceConfigContext.tsx
+++ b/src/context/ServiceConfigContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useRef } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useRef } from 'react'
 // @ts-ignore
 import { useCurrentWallet } from './WalletContext'
 
@@ -107,6 +107,13 @@ const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
     },
     [currentWallet, reloadServiceConfig]
   )
+
+  useEffect(() => {
+    if (!currentWallet) {
+      // reset service config if wallet changed
+      serviceConfig.current = null
+    }
+  }, [currentWallet])
 
   return <ServiceConfigContext.Provider value={{ loadConfigValueIfAbsent }}>{children}</ServiceConfigContext.Provider>
 }

--- a/src/context/ServiceConfigContext.tsx
+++ b/src/context/ServiceConfigContext.tsx
@@ -30,7 +30,7 @@ type LoadConfigValueProps = {
 }
 
 interface ServiceConfigContextEntry {
-  loadConfigValueIfAbsent: (props: LoadConfigValueProps) => Promise<ServiceConfigUpdate>
+  loadConfigValue: (props: LoadConfigValueProps) => Promise<ServiceConfigUpdate>
 }
 
 const ServiceConfigContext = createContext<ServiceConfigContextEntry | undefined>(undefined)
@@ -115,15 +115,19 @@ const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
     }
   }, [currentWallet])
 
-  return <ServiceConfigContext.Provider value={{ loadConfigValueIfAbsent }}>{children}</ServiceConfigContext.Provider>
+  return (
+    <ServiceConfigContext.Provider value={{ loadConfigValue: loadConfigValueIfAbsent }}>
+      {children}
+    </ServiceConfigContext.Provider>
+  )
 }
 
-const useLoadConfigValueIfAbsent = () => {
+const useLoadConfigValue = () => {
   const context = useContext(ServiceConfigContext)
   if (context === undefined) {
-    throw new Error('useLoadConfigValueIfAbsent must be used within a ServiceConfigProvider')
+    throw new Error('useLoadConfigValue must be used within a ServiceConfigProvider')
   }
-  return context.loadConfigValueIfAbsent
+  return context.loadConfigValue
 }
 
-export { ServiceConfigContext, ServiceConfigProvider, useLoadConfigValueIfAbsent }
+export { ServiceConfigContext, ServiceConfigProvider, useLoadConfigValue }

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useEffect, useCallback, useState, useContext, Pro
 import { getSession } from '../session'
 import * as Api from '../libs/JmWalletApi'
 
-interface CurrentWallet {
+export interface CurrentWallet {
   name: string
   token: string
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,11 +6,11 @@ import App from './components/App'
 // @ts-ignore
 import { SettingsProvider } from './context/SettingsContext'
 // @ts-ignore
-import { WalletProvider } from './context/WalletContext'
-// @ts-ignore
 import { WebsocketProvider } from './context/WebsocketContext'
-// @ts-ignore
 import { ServiceInfoProvider } from './context/ServiceInfoContext'
+import { WalletProvider } from './context/WalletContext'
+import { ServiceConfigProvider } from './context/ServiceConfigContext'
+
 import reportWebVitals from './reportWebVitals'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './index.css'
@@ -31,11 +31,13 @@ ReactDOM.render(
     <BrowserRouter basename={window.JM.PUBLIC_PATH}>
       <SettingsProvider>
         <WalletProvider>
-          <WebsocketProvider>
-            <ServiceInfoProvider>
-              <App />
-            </ServiceInfoProvider>
-          </WebsocketProvider>
+          <ServiceConfigProvider>
+            <WebsocketProvider>
+              <ServiceInfoProvider>
+                <App />
+              </ServiceInfoProvider>
+            </WebsocketProvider>
+          </ServiceConfigProvider>
         </WalletProvider>
       </SettingsProvider>
     </BrowserRouter>

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
 import { WalletProvider } from './context/WalletContext'
 import { ServiceInfoProvider } from './context/ServiceInfoContext'
+import { ServiceConfigProvider } from './context/ServiceConfigContext'
 // @ts-ignore
 import { SettingsProvider } from './context/SettingsContext'
 // @ts-ignore
@@ -17,9 +18,11 @@ const AllTheProviders = ({ children }: { children: React.ReactElement }) => {
         <I18nextProvider i18n={i18n}>
           <SettingsProvider>
             <WalletProvider>
-              <WebsocketProvider>
-                <ServiceInfoProvider>{children}</ServiceInfoProvider>
-              </WebsocketProvider>
+              <ServiceConfigProvider>
+                <WebsocketProvider>
+                  <ServiceInfoProvider>{children}</ServiceInfoProvider>
+                </WebsocketProvider>
+              </ServiceConfigProvider>
             </WalletProvider>
           </SettingsProvider>
         </I18nextProvider>


### PR DESCRIPTION
Closes #279 

Before: Config values were fetched individually on every send page.
After: Config values will be loaded only once, then stored and reused for the entire wallet session.

Only the `Send` component currently needs a config value for form validation (`minimum_makers`).
Others are loaded conditionally in case of an error (`max_cj_fee_rel` and `max_cj_fee_abs`)).

There are also other potential worthwhile solutions.. this seems to be a very straightforward one. Let me know, what you think.

The config update are logged to console in development mode:
```js
service config updated Object { 
  POLICY: Object { minimum_makers: "1",  max_cj_fee_rel: "0.0003", max_cj_fee_abs: "300000" }
​​}
```