### PR TITLE
fix: less vertical padding of main container on mobile screens

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -100,7 +100,7 @@ export default function App() {
         </div>
       )}
       <Navbar />
-      <rb.Container as="main" className="py-5">
+      <rb.Container as="main" className="py-3 py-sm-5">
         {sessionConnectionError && (
           <rb.Alert variant="danger">
             {t('app.alert_no_connection', { connectionError: sessionConnectionError.message })}.


### PR DESCRIPTION
Decrease the vertical padding on mobile screens from `py-5` to `py-3`.

## 📸 Before/After
<img src="https://user-images.githubusercontent.com/3358649/171413090-d7717e98-733c-41eb-8c2f-63385ad8421a.png" width=300 /> <img src="https://user-images.githubusercontent.com/3358649/171413179-2793336b-e93a-489b-94c8-a1832cc1f5f4.png" width=300 />

