### PR TITLE
ui: tab dividers

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -51,7 +51,7 @@ const CenterNav = ({ makerRunning, cjRunning, onClick }) => {
           {t('navbar.tab_receive')}
         </NavLink>
       </rb.Nav.Item>
-      <div className="d-flex align-items-center center-nav-link-divider">»</div>
+      <div className="d-none d-md-flex align-items-center center-nav-link-divider">»</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.jam}
@@ -66,7 +66,7 @@ const CenterNav = ({ makerRunning, cjRunning, onClick }) => {
           </div>
         </NavLink>
       </rb.Nav.Item>
-      <div className="d-flex align-items-center center-nav-link-divider">/</div>
+      <div className="d-none d-md-flex align-items-center center-nav-link-divider">/</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.earn}
@@ -81,7 +81,7 @@ const CenterNav = ({ makerRunning, cjRunning, onClick }) => {
           </div>
         </NavLink>
       </rb.Nav.Item>
-      <div className="d-flex align-items-center center-nav-link-divider">»</div>
+      <div className="d-none d-md-flex align-items-center center-nav-link-divider">»</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.send}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -51,6 +51,7 @@ const CenterNav = ({ makerRunning, cjRunning, onClick }) => {
           {t('navbar.tab_receive')}
         </NavLink>
       </rb.Nav.Item>
+      <div className="d-flex align-items-center center-nav-link-divider">»</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.jam}
@@ -65,6 +66,7 @@ const CenterNav = ({ makerRunning, cjRunning, onClick }) => {
           </div>
         </NavLink>
       </rb.Nav.Item>
+      <div className="d-flex align-items-center center-nav-link-divider">/</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.earn}
@@ -79,6 +81,7 @@ const CenterNav = ({ makerRunning, cjRunning, onClick }) => {
           </div>
         </NavLink>
       </rb.Nav.Item>
+      <div className="d-flex align-items-center center-nav-link-divider">»</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.send}

--- a/src/index.css
+++ b/src/index.css
@@ -301,13 +301,16 @@ main {
   }
 
   .center-nav-link {
-    min-width: 80px;
-    padding: 8px 0 !important;
+    padding: 8px 1.5rem !important;
   }
 
   .center-nav-link.active {
-    padding: 8px 0 6px 0 !important;
+    padding: 8px 1.5rem 6px 1.5rem !important;
     border-bottom: 2px solid black;
+  }
+
+  .center-nav-link-divider {
+    color: #bbbbbb;
   }
 
   .leading-nav-link {


### PR DESCRIPTION
Adds dividers between the main tabs to hint towards the expected flow a user should/could take.

Trade off is that the tabs won't be of equal length anymore but that is ok imo.

Side note: Eventually we need an "official" color palette. Right now we're mixing colors from bootstrap and Figma screens.

## 📸 

<img width="399" alt="Screenshot 2022-06-09 at 17 25 47" src="https://user-images.githubusercontent.com/10026790/172884820-aa3a99be-8d3f-4e86-a788-4543881e1c6e.png">

