### PR TITLE
fix: checked state of ToggleSwitch can be controlled by caller

### DIFF
--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -304,6 +304,7 @@ const WalletCreationConfirmation = ({ createdWallet, walletConfirmed }) => {
           <div className="mb-2">
             <ToggleSwitch
               label={t('create_wallet.confirmation_toggle_reveal_info')}
+              checked={revealSensitiveInfo}
               onToggle={(isToggled) => {
                 setRevealSensitiveInfo(isToggled)
                 setSensitiveInfoWasRevealed(true)
@@ -313,6 +314,7 @@ const WalletCreationConfirmation = ({ createdWallet, walletConfirmed }) => {
           <div className="mb-4">
             <ToggleSwitch
               label={t('create_wallet.confirmation_toggle_info_written_down')}
+              checked={userConfirmed}
               onToggle={(isToggled) => setUserConfirmed(isToggled)}
             />
           </div>

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -304,7 +304,7 @@ const WalletCreationConfirmation = ({ createdWallet, walletConfirmed }) => {
           <div className="mb-2">
             <ToggleSwitch
               label={t('create_wallet.confirmation_toggle_reveal_info')}
-              checked={revealSensitiveInfo}
+              toggledOn={revealSensitiveInfo}
               onToggle={(isToggled) => {
                 setRevealSensitiveInfo(isToggled)
                 setSensitiveInfoWasRevealed(true)
@@ -314,7 +314,7 @@ const WalletCreationConfirmation = ({ createdWallet, walletConfirmed }) => {
           <div className="mb-4">
             <ToggleSwitch
               label={t('create_wallet.confirmation_toggle_info_written_down')}
-              checked={userConfirmed}
+              toggledOn={userConfirmed}
               onToggle={(isToggled) => setUserConfirmed(isToggled)}
             />
           </div>

--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -457,7 +457,7 @@ export default function Jam() {
                           <ToggleSwitch
                             label={t('scheduler.toggle_internal_destination_title')}
                             subtitle={t('scheduler.toggle_internal_destination_subtitle')}
-                            checked={destinationIsExternal}
+                            toggledOn={destinationIsExternal}
                             onToggle={async (isToggled) => {
                               if (!isToggled) {
                                 try {
@@ -489,7 +489,7 @@ export default function Jam() {
                               subtitle={
                                 "This is completely insecure but makes testing the schedule much faster. This option won't be available in production."
                               }
-                              checked={useInsecureTestingSettings}
+                              toggledOn={useInsecureTestingSettings}
                               onToggle={(isToggled) => setUseInsecureTestingSettings(isToggled)}
                               disabled={isSubmitting}
                             />

--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -457,7 +457,7 @@ export default function Jam() {
                           <ToggleSwitch
                             label={t('scheduler.toggle_internal_destination_title')}
                             subtitle={t('scheduler.toggle_internal_destination_subtitle')}
-                            initialValue={destinationIsExternal}
+                            checked={destinationIsExternal}
                             onToggle={async (isToggled) => {
                               if (!isToggled) {
                                 try {
@@ -489,7 +489,7 @@ export default function Jam() {
                               subtitle={
                                 "This is completely insecure but makes testing the schedule much faster. This option won't be available in production."
                               }
-                              initialValue={useInsecureTestingSettings}
+                              checked={useInsecureTestingSettings}
                               onToggle={(isToggled) => setUseInsecureTestingSettings(isToggled)}
                               disabled={isSubmitting}
                             />

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -704,7 +704,7 @@ export default function Send() {
             <ToggleSwitch
               label={t('send.toggle_coinjoin')}
               subtitle={t('send.toggle_coinjoin_subtitle')}
-              initialValue={isCoinjoin}
+              checked={isCoinjoin}
               onToggle={(isToggled) => setIsCoinjoin(isToggled)}
               disabled={isLoading || isOperationDisabled}
             />

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -704,7 +704,7 @@ export default function Send() {
             <ToggleSwitch
               label={t('send.toggle_coinjoin')}
               subtitle={t('send.toggle_coinjoin_subtitle')}
-              checked={isCoinjoin}
+              toggledOn={isCoinjoin}
               onToggle={(isToggled) => setIsCoinjoin(isToggled)}
               disabled={isLoading || isOperationDisabled}
             />

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -74,7 +74,7 @@ function SeedModal({ show = false, onHide }) {
                 <div className="mb-2">
                   <ToggleSwitch
                     label={t('settings.reveal_seed')}
-                    checked={revealSeed}
+                    toggledOn={revealSeed}
                     onToggle={(isToggled) => setRevealSeed(isToggled)}
                   />
                 </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -72,7 +72,11 @@ function SeedModal({ show = false, onHide }) {
               </rb.Row>
               <div className="d-flex justify-content-center align-items-center">
                 <div className="mb-2">
-                  <ToggleSwitch label={t('settings.reveal_seed')} onToggle={(isToggled) => setRevealSeed(isToggled)} />
+                  <ToggleSwitch
+                    label={t('settings.reveal_seed')}
+                    checked={revealSeed}
+                    onToggle={(isToggled) => setRevealSeed(isToggled)}
+                  />
                 </div>
               </div>
             </>

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -5,7 +5,7 @@ interface ToggleSwitchProps {
   label: string
   subtitle?: string
   onToggle: (isToggled: boolean) => void
-  checked: boolean
+  toggledOn: boolean
   disabled?: boolean
 }
 
@@ -13,7 +13,7 @@ export default function ToggleSwitch({
   label,
   subtitle = undefined,
   onToggle,
-  checked,
+  toggledOn,
   disabled = false,
 }: ToggleSwitchProps) {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -27,7 +27,7 @@ export default function ToggleSwitch({
         type="checkbox"
         className={`${styles['peer']} ${styles['toggle-switch-input']}`}
         onChange={onChange}
-        checked={checked}
+        checked={toggledOn}
         disabled={disabled}
       />
       <span className={styles['toggle-switch']}></span>

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -5,7 +5,7 @@ interface ToggleSwitchProps {
   label: string
   subtitle?: string
   onToggle: (isToggled: boolean) => void
-  initialValue?: boolean
+  checked: boolean
   disabled?: boolean
 }
 
@@ -13,10 +13,10 @@ export default function ToggleSwitch({
   label,
   subtitle = undefined,
   onToggle,
-  initialValue = false,
+  checked,
   disabled = false,
 }: ToggleSwitchProps) {
-  const onClick = (e: React.MouseEvent<HTMLInputElement>) => {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation()
     onToggle(e.currentTarget.checked)
   }
@@ -26,8 +26,8 @@ export default function ToggleSwitch({
       <input
         type="checkbox"
         className={`${styles['peer']} ${styles['toggle-switch-input']}`}
-        onClick={onClick}
-        defaultChecked={initialValue}
+        onChange={onChange}
+        checked={checked}
         disabled={disabled}
       />
       <span className={styles['toggle-switch']}></span>

--- a/src/components/fidelity_bond/FidelityBondDetailsSetupForm.tsx
+++ b/src/components/fidelity_bond/FidelityBondDetailsSetupForm.tsx
@@ -148,12 +148,11 @@ const ConfirmationStep = ({
       </rb.Card>
 
       <div className="my-4 ps-1">
-        {/* TODO: reset the toggle value (once that is implemented) when a user leaves the page, e.g. "Back" button */}
         <ToggleSwitch
           label={t('fidelity_bond.create_form.confirmation_toggle_title')}
           subtitle={t('fidelity_bond.create_form.confirmation_toggle_subtitle')}
-          initialValue={confirmed}
-          onToggle={(isToggled: boolean) => onChange(isToggled)}
+          checked={confirmed}
+          onToggle={(isToggled) => onChange(isToggled)}
         />
       </div>
     </>

--- a/src/components/fidelity_bond/FidelityBondDetailsSetupForm.tsx
+++ b/src/components/fidelity_bond/FidelityBondDetailsSetupForm.tsx
@@ -151,7 +151,7 @@ const ConfirmationStep = ({
         <ToggleSwitch
           label={t('fidelity_bond.create_form.confirmation_toggle_title')}
           subtitle={t('fidelity_bond.create_form.confirmation_toggle_subtitle')}
-          checked={confirmed}
+          toggledOn={confirmed}
           onToggle={(isToggled) => onChange(isToggled)}
         />
       </div>


### PR DESCRIPTION
Fixes #309.

Small change to control the `checked` value by the parent component.
Previously a state change in the calling component was not visually displayed by the `ToggleSwitch` component.
After this change the `ToggleSwitch` will reflect the actual value correctly.