### PR TITLE
chore: Use `routes` where applicable

### DIFF
--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -364,7 +364,7 @@ export default function CreateWallet({ startWallet }) {
   const walletConfirmed = () => {
     if (createdWallet.name && createdWallet.token) {
       startWallet(createdWallet.name, createdWallet.token)
-      navigate('/wallet')
+      navigate(routes.wallet)
     } else {
       setAlert({ variant: 'danger', message: t('alert_confirmation_failed') })
     }

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -143,7 +143,7 @@ export default function Wallet({
 
         const { walletname: unlockedWalletName, token } = body
         startWallet(unlockedWalletName, token)
-        navigate('/wallet')
+        navigate(routes.wallet)
       } catch (e) {
         const message = e.message.replace('Wallet', walletName)
         setAlert({ variant: 'danger', dismissible: false, message })


### PR DESCRIPTION
Small changes in `Wallets`, `Wallet` and `CreateWallet`:
- Simplify handling in `Wallets` components – code "should" be a little bit more readable
- Do not use hardcoded link to `/wallet` string in `Wallet` and `CreateWallet`: use values from global `routes` 