### PR TITLE
feat(jars): add receive shortcut if jar 0 is empty

### DIFF
--- a/src/components/CurrentWalletMagic.jsx
+++ b/src/components/CurrentWalletMagic.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 import { useSettings, useSettingsDispatch } from '../context/SettingsContext'
 import { useCurrentWallet, useCurrentWalletInfo, useReloadCurrentWalletInfo } from '../context/WalletContext'
 import Balance from './Balance'
@@ -43,6 +44,8 @@ const WalletHeader = ({ name, balance, unit, showBalance, loading }) => {
 
 export default function CurrentWalletMagic() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+
   const settings = useSettings()
   const settingsDispatch = useSettingsDispatch()
   const currentWallet = useCurrentWallet()
@@ -62,6 +65,15 @@ export default function CurrentWalletMagic() {
   const [isAccountOverlayShown, setIsAccountOverlayShown] = useState(false)
 
   const onJarClicked = (accountIndex) => {
+    if (accountIndex === 0) {
+      const isEmpty = Number(balanceSummary?.accountBalances[accountIndex]?.totalBalance) === 0
+
+      if (isEmpty) {
+        navigate(routes.receive, { state: { account: accountIndex } })
+        return
+      }
+    }
+
     setSelectedAccountIndex(accountIndex)
     setIsAccountOverlayShown(true)
   }

--- a/src/components/Jars.jsx
+++ b/src/components/Jars.jsx
@@ -13,6 +13,8 @@ const Jar = ({ accountIndex, balance, fill, onClick }) => {
   const [jarIsOpen, setJarIsOpen] = useState(false)
   const tooltipTarget = useRef(null)
 
+  const jarIsEmpty = parseInt(balance, 10) === 0
+
   const jarSymbol = ((fill) => {
     switch (fill) {
       case 1:
@@ -48,7 +50,9 @@ const Jar = ({ accountIndex, balance, fill, onClick }) => {
       >
         {(props) => (
           <rb.Tooltip id="jar-tooltip" {...props}>
-            {t('current_wallet.jar_tooltip')}
+            {accountIndex === 0 && jarIsEmpty
+              ? t('current_wallet.jar_tooltip_empty_jar_0')
+              : t('current_wallet.jar_tooltip')}
           </rb.Tooltip>
         )}
       </rb.Overlay>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -116,6 +116,7 @@
     "button_withdraw": "Send",
     "error_loading_failed": "Loading wallet failed.",
     "jar_tooltip": "Look inside",
+    "jar_tooltip_empty_jar_0": "Receive",
     "jars_title": "Wallet distribution",
     "jars_title_popover": "Todo: Description of what Jars (mixdepths) are."
   },


### PR DESCRIPTION
Resolves #343.

Adds a shortcut for receiving by clicking on jar 0 when it's empty. Only applies to jar 0 -- we don't want to encourage receiving on other jars.

 <table>
  <tr>
    <th>Empty</th>
    <th>Non-empty</th>
  </tr>
  <tr>
    <td><img width="133" alt="Screenshot 2022-06-21 at 12 34 37" src="https://user-images.githubusercontent.com/10026790/174779854-afd98a56-5086-470c-9a3f-524dfc4793cb.png"></td>
    <td><img width="158" alt="Screenshot 2022-06-21 at 12 34 08" src="https://user-images.githubusercontent.com/10026790/174779845-d87f99aa-bd08-4bfd-b990-616bfeb6c883.png"></td>
  </tr>
</table> 