### PR TITLE
feat(jars): destination jar selector on receive screen

### DIFF
--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -127,8 +127,7 @@ export default function Receive() {
                     </rb.Placeholder>
                   ) : (
                     <div className={styles.jarsContainer}>
-                      {sortedAccountBalances.map((it) => {
-                        return (
+                      {sortedAccountBalances.map((it) => (
                           <SelectableJar
                             key={it.accountIndex}
                             index={it.accountIndex}
@@ -138,8 +137,7 @@ export default function Receive() {
                             fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
                             onClick={() => setSelectedJarIndex(it.accountIndex)}
                           />
-                        )
-                      })}
+                        ))}
                     </div>
                   )}
                 </>

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -28,7 +28,7 @@ export default function Receive() {
   const [isLoading, setIsLoading] = useState(false)
   const [address, setAddress] = useState('')
   const [amount, setAmount] = useState('')
-  const [account, setAccount] = useState(parseInt(location.state?.account, 10) || 0)
+  const [selectedJarIndex, setSelectedJarIndex] = useState(parseInt(location.state?.account, 10) || 0)
   const [addressCount, setAddressCount] = useState(0)
   const [showSettings, setShowSettings] = useState(false)
 
@@ -44,7 +44,7 @@ export default function Receive() {
     setAlert(null)
     setIsLoading(true)
 
-    Api.getAddressNew({ walletName, mixdepth: account, token, signal: abortCtrl.signal })
+    Api.getAddressNew({ walletName, mixdepth: selectedJarIndex, token, signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res, t('receive.error_loading_address_failed'))))
       .then((data) => setAddress(data.address))
       .catch((err) => {
@@ -55,7 +55,7 @@ export default function Receive() {
       .finally(() => !abortCtrl.signal.aborted && setIsLoading(false))
 
     return () => abortCtrl.abort()
-  }, [account, currentWallet, addressCount, t])
+  }, [selectedJarIndex, currentWallet, addressCount, t])
 
   const onSubmit = (e) => {
     e.preventDefault()
@@ -134,9 +134,9 @@ export default function Receive() {
                             index={it.accountIndex}
                             balance={it.totalBalance}
                             isSelectable={true}
-                            isSelected={it.accountIndex === account}
+                            isSelected={it.accountIndex === selectedJarIndex}
                             fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
-                            onClick={() => setAccount(it.accountIndex)}
+                            onClick={() => setSelectedJarIndex(it.accountIndex)}
                           />
                         )
                       })}

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -119,28 +119,24 @@ export default function Receive() {
           </rb.Button>
           {showSettings && (
             <div className="my-4">
-              {settings.useAdvancedWalletMode && (
-                <>
-                  {!balanceSummary || sortedAccountBalances.length === 0 ? (
-                    <rb.Placeholder as="div" animation="wave">
-                      <rb.Placeholder className={styles.jarsPlaceholder} />
-                    </rb.Placeholder>
-                  ) : (
-                    <div className={styles.jarsContainer}>
-                      {sortedAccountBalances.map((it) => (
-                        <SelectableJar
-                          key={it.accountIndex}
-                          index={it.accountIndex}
-                          balance={it.totalBalance}
-                          isSelectable={true}
-                          isSelected={it.accountIndex === selectedJarIndex}
-                          fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
-                          onClick={() => setSelectedJarIndex(it.accountIndex)}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </>
+              {!balanceSummary || sortedAccountBalances.length === 0 ? (
+                <rb.Placeholder as="div" animation="wave">
+                  <rb.Placeholder className={styles.jarsPlaceholder} />
+                </rb.Placeholder>
+              ) : (
+                <div className={styles.jarsContainer}>
+                  {sortedAccountBalances.map((it) => (
+                    <SelectableJar
+                      key={it.accountIndex}
+                      index={it.accountIndex}
+                      balance={it.totalBalance}
+                      isSelectable={true}
+                      isSelected={it.accountIndex === selectedJarIndex}
+                      fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
+                      onClick={() => setSelectedJarIndex(it.accountIndex)}
+                    />
+                  ))}
+                </div>
               )}
               <rb.Form.Group controlId="amountSats">
                 <rb.Form.Label>{t('receive.label_amount')}</rb.Form.Label>

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -120,21 +120,29 @@ export default function Receive() {
           {showSettings && (
             <div className="my-4">
               {settings.useAdvancedWalletMode && (
-                <div className={styles.jarsContainer}>
-                  {sortedAccountBalances.map((it) => {
-                    return (
-                      <SelectableJar
-                        key={it.accountIndex}
-                        index={it.accountIndex}
-                        balance={it.totalBalance}
-                        isSelectable={true}
-                        isSelected={it.accountIndex === account}
-                        fillLevel={calculateFillLevel(it.totalBalance, balanceSummary?.totalBalance || 0)}
-                        onClick={() => setAccount(it.accountIndex)}
-                      />
-                    )
-                  })}
-                </div>
+                <>
+                  {!balanceSummary || sortedAccountBalances.length === 0 ? (
+                    <rb.Placeholder as="div" animation="wave">
+                      <rb.Placeholder className={styles.jarsPlaceholder} />
+                    </rb.Placeholder>
+                  ) : (
+                    <div className={styles.jarsContainer}>
+                      {sortedAccountBalances.map((it) => {
+                        return (
+                          <SelectableJar
+                            key={it.accountIndex}
+                            index={it.accountIndex}
+                            balance={it.totalBalance}
+                            isSelectable={true}
+                            isSelected={it.accountIndex === account}
+                            fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
+                            onClick={() => setAccount(it.accountIndex)}
+                          />
+                        )
+                      })}
+                    </div>
+                  )}
+                </>
               )}
               <rb.Form.Group controlId="amountSats">
                 <rb.Form.Label>{t('receive.label_amount')}</rb.Form.Label>

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -128,16 +128,16 @@ export default function Receive() {
                   ) : (
                     <div className={styles.jarsContainer}>
                       {sortedAccountBalances.map((it) => (
-                          <SelectableJar
-                            key={it.accountIndex}
-                            index={it.accountIndex}
-                            balance={it.totalBalance}
-                            isSelectable={true}
-                            isSelected={it.accountIndex === selectedJarIndex}
-                            fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
-                            onClick={() => setSelectedJarIndex(it.accountIndex)}
-                          />
-                        ))}
+                        <SelectableJar
+                          key={it.accountIndex}
+                          index={it.accountIndex}
+                          balance={it.totalBalance}
+                          isSelectable={true}
+                          isSelected={it.accountIndex === selectedJarIndex}
+                          fillLevel={calculateFillLevel(it.totalBalance, balanceSummary.totalBalance)}
+                          onClick={() => setSelectedJarIndex(it.accountIndex)}
+                        />
+                      ))}
                     </div>
                   )}
                 </>

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -84,7 +84,7 @@
 
 .jarsPlaceholder {
   width: 100%;
-  height: 7.75rem;
+  height: 8.5rem;
   margin-bottom: 2rem;
 }
 

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -71,9 +71,23 @@
   padding: 1rem 0 1rem;
 }
 
+.jarsContainer {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  color: var(--bs-body-color);
+  margin-bottom: 2rem;
+}
+
 @media only screen and (min-width: 768px) {
   .address {
     font-size: var(--bs-body-font-size);
     padding: 0;
+  }
+  .jarsContainer {
+    gap: 1.5rem;
   }
 }

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -94,8 +94,8 @@
     padding: 0;
   }
   .jarsContainer {
-   gap: 1.5rem;
-   flex-wrap: nowrap;
-   justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: nowrap;
+    justify-content: space-between;
   }
 }

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -82,6 +82,12 @@
   margin-bottom: 2rem;
 }
 
+.jarsPlaceholder {
+  width: 100%;
+  height: 7.75rem;
+  margin-bottom: 2rem;
+}
+
 @media only screen and (min-width: 768px) {
   .address {
     font-size: var(--bs-body-font-size);

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -79,7 +79,7 @@
   align-items: center;
   gap: 2rem;
   color: var(--bs-body-color);
-  margin-bottom: 2rem;
+  margin-bottom: 3rem;
 }
 
 .jarsPlaceholder {

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -94,6 +94,8 @@
     padding: 0;
   }
   .jarsContainer {
-    gap: 1.5rem;
+   gap: 1.5rem;
+   flex-wrap: nowrap;
+   justify-content: space-between;
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -214,8 +214,6 @@
     "button_copy_address": "Copy",
     "text_copy_address_confirmed": "Copied",
     "button_settings": "Advanced",
-    "label_choose_account": "Choose account",
-    "account_selector_option_dev_mode": "Account {{ number }}",
     "label_amount": "Amount to request in sats",
     "feedback_invalid_amount": "Please provide a valid amount.",
     "button_new_address": "Get new address",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -193,8 +193,6 @@
     "button_copy_address": "Copier",
     "text_copy_address_confirmed": "Copié",
     "button_settings": "Paramètres",
-    "label_choose_account": "Choisissez un compte",
-    "account_selector_option_dev_mode": "Compte {{ number }}",
     "label_amount": "Montant à demander en sats",
     "feedback_invalid_amount": "Veuillez fournir un montant valide.",
     "button_new_address": "Obtenir une nouvelle adresse",


### PR DESCRIPTION
Closes #328.

Not changed / Differences to [Figma](https://www.figma.com/file/kfejZJFlwBywvLEnPEmJo1/JoinMarket-UI?node-id=2850%3A71544) screen:
- Balance is shown directly beneath jars (using the `SelectableJar` component)
- No simple/advanced view toggle on top of page:
  - Jars are displayed in the "Advanced dropdown" section
  - Q: This is still shown in "advanced mode" only (Must be enabled on the Settings page).. Refrained from always showing it since this might encourage directly funding other jars: Okay for now? 

## 📸 
<img src="https://user-images.githubusercontent.com/3358649/175333865-961cc90e-13b8-4427-a8c3-74c19075993a.png" width=400 />

