### PR TITLE
ui: Receive screen advances

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -245,4 +245,8 @@
         <line x1="10.6642" y1="10.75" x2="20.5637" y2="20.6495" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         <line x1="20.5" y1="10.9142" x2="10.6005" y2="20.8137" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </symbol>
+    <symbol id="refresh" fill="currentColor" viewBox="0 0 24 24" >
+        <path fill-rule="evenodd" d="M6.64 9.788a.75.75 0 01.53.918 5 5 0 007.33 5.624.75.75 0 11.75 1.3 6.501 6.501 0 01-9.529-7.312.75.75 0 01.919-.53zM8.75 6.37a6.5 6.5 0 019.529 7.312.75.75 0 11-1.45-.388A5.001 5.001 0 009.5 7.67a.75.75 0 11-.75-1.3z" clip-rule="evenodd" />
+        <path fill-rule="evenodd" d="M5.72 9.47a.75.75 0 011.06 0l2.5 2.5a.75.75 0 11-1.06 1.06l-1.97-1.97-1.97 1.97a.75.75 0 01-1.06-1.06l2.5-2.5zM14.72 10.97a.75.75 0 011.06 0l1.97 1.97 1.97-1.97a.75.75 0 111.06 1.06l-2.5 2.5a.75.75 0 01-1.06 0l-2.5-2.5a.75.75 0 010-1.06z" clip-rule="evenodd" />
+    </symbol>
 </svg>

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -139,16 +139,23 @@ export default function Receive() {
               )}
               <rb.Form.Group controlId="amountSats">
                 <rb.Form.Label>{t('receive.label_amount')}</rb.Form.Label>
-                <rb.Form.Control
-                  className="slashed-zeroes"
-                  name="amount"
-                  type="number"
-                  placeholder="0"
-                  value={amount}
-                  min={0}
-                  onChange={(e) => setAmount(e.target.value)}
-                  disabled={isLoading}
-                />
+                <rb.InputGroup>
+                  <rb.InputGroup.Text id="amountSats-addon1" className={styles.inputGroupText}>
+                    <Sprite symbol="sats" width="24" height="24" />
+                  </rb.InputGroup.Text>
+                  <rb.Form.Control
+                    aria-label={t('receive.label_amount')}
+                    className="slashed-zeroes"
+                    name="amount"
+                    type="number"
+                    placeholder="0"
+                    value={amount}
+                    disabled={isLoading}
+                    onChange={(e) => setAmount(e.target.value)}
+                    min={0}
+                    step={1}
+                  />
+                </rb.InputGroup>
                 <rb.Form.Control.Feedback type="invalid">
                   {t('receive.feedback_invalid_amount')}
                 </rb.Form.Control.Feedback>

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -164,16 +164,27 @@ export default function Receive() {
           )}
           <hr />
         </div>
-        <rb.Button variant="outline-dark" type="submit" disabled={isLoading} className="mt-2" style={{ width: '100%' }}>
-          {isLoading ? (
-            <div className="d-flex justify-content-center align-items-center">
-              <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
-              {t('receive.text_getting_address')}
-            </div>
-          ) : (
-            t('receive.button_new_address')
-          )}
-        </rb.Button>
+
+        <div className="mt-2 d-flex justify-content-center">
+          <rb.Button
+            variant="outline-dark"
+            type="submit"
+            disabled={isLoading}
+            className="d-flex justify-content-center align-items-center"
+          >
+            {isLoading ? (
+              <>
+                <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+                {t('receive.text_getting_address')}
+              </>
+            ) : (
+              <>
+                <Sprite symbol="refresh" className="me-2" width="24" height="24" />
+                {t('receive.button_new_address')}
+              </>
+            )}
+          </rb.Button>
+        </div>
       </rb.Form>
     </div>
   )

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -44,6 +44,14 @@
   height: 1.5rem;
 }
 
+.inputGroupText {
+  width: 5ch;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.2rem;
+}
+
 .qr-container {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Small adaptions to align the Receive screen with [Figma](https://www.figma.com/file/kfejZJFlwBywvLEnPEmJo1/JoinMarket-UI?node-id=2850%3A71544) designs.

Changes:
- Style submit button according to Figma
  - display "refresh" icon in front of the text
  - Button does not take the whole width
- show sat symbol on `amount` input (not in Figma, but also used on Earn screen)

Not changed:
- The button text in Figma says "Create new address" – "Get new address" feels more appropriate, does it?


## 📸  Before/After

<img src="https://user-images.githubusercontent.com/3358649/175348484-54a5ec43-498a-4dcd-8010-e80b1e0ef4d5.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/175347834-0cf16274-6150-4d4e-befe-d054a01eb5b7.png" width=400 />

