### PR TITLE
fix: Check preconditions before send request

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -22,6 +22,20 @@ const IS_COINJOIN_DEFAULT_VAL = true
 // initial value for `minimum_makers` from the default joinmarket.cfg (last check on 2022-02-20 of v0.9.5)
 const MINIMUM_MAKERS_DEFAULT_VAL = 4
 
+const INITIAL_DESTINATION = null
+const INITIAL_ACCOUNT = 0
+const INITIAL_AMOUNT = null
+
+const initialNumCollaborators = (minValue) => {
+  const defaultNumber = pseudoRandomNumber(8, 10)
+
+  if (minValue > 8) {
+    return minValue + pseudoRandomNumber(0, 2)
+  }
+
+  return defaultNumber
+}
+
 // not cryptographically random. returned number is in range [min, max] (both inclusive).
 const pseudoRandomNumber = (min, max) => {
   return Math.round(Math.random() * (max - min)) + min
@@ -220,22 +234,9 @@ export default function Send() {
     setTakerStartedInfoAlert((current) => (isCoinjoinInProgress ? current : null))
   }, [isCoinjoinInProgress])
 
-  const initialDestination = null
-  const initialAccount = 0
-  const initialAmount = null
-  const initialNumCollaborators = (minValue) => {
-    const defaultNumber = pseudoRandomNumber(8, 10)
-
-    if (minValue > 8) {
-      return minValue + pseudoRandomNumber(0, 2)
-    }
-
-    return defaultNumber
-  }
-
-  const [destination, setDestination] = useState(initialDestination)
-  const [account, setAccount] = useState(parseInt(location.state?.account, 10) || initialAccount)
-  const [amount, setAmount] = useState(initialAmount)
+  const [destination, setDestination] = useState(INITIAL_DESTINATION)
+  const [account, setAccount] = useState(parseInt(location.state?.account, 10) || INITIAL_ACCOUNT)
+  const [amount, setAmount] = useState(INITIAL_AMOUNT)
   // see https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/USAGE.md#try-out-a-coinjoin-using-sendpaymentpy
   const [numCollaborators, setNumCollaborators] = useState(initialNumCollaborators(minNumCollaborators))
   const [formIsValid, setFormIsValid] = useState(false)
@@ -338,6 +339,8 @@ export default function Send() {
       key: { section: 'POLICY', field: 'minimum_makers' },
     })
       .then((data) => {
+        if (abortCtrl.signal.aborted) return
+
         const minimumMakers = parseInt(data.value, 10)
         setMinNumCollaborators(minimumMakers)
         setNumCollaborators(initialNumCollaborators(minimumMakers))
@@ -458,8 +461,8 @@ export default function Send() {
         : await sendPayment(account, destination, amount)
 
       if (success) {
-        setDestination(initialDestination)
-        setAmount(initialAmount)
+        setDestination(INITIAL_DESTINATION)
+        setAmount(INITIAL_AMOUNT)
         setNumCollaborators(initialNumCollaborators(minNumCollaborators))
         setIsCoinjoin(IS_COINJOIN_DEFAULT_VAL)
         setIsSweep(false)
@@ -741,7 +744,7 @@ export default function Send() {
                     onClick={() => {
                       if (destinationJar !== null) {
                         setDestinationJar(null)
-                        setDestination(initialDestination)
+                        setDestination(INITIAL_DESTINATION)
                       } else {
                         setDestinationJarPickerShown(true)
                       }

--- a/src/hooks/CoinjoinPrecondition.test.tsx
+++ b/src/hooks/CoinjoinPrecondition.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { render } from '../testUtils'
+import { act } from 'react-dom/test-utils'
+
+import {
+  COINJOIN_PRECONDITIONS,
+  CoinjoinPreconditionSummary,
+  useCoinjoinPreconditionSummary,
+} from './CoinjoinPrecondition'
+import { Utxos, Utxo } from '../context/WalletContext'
+
+describe('useCoinjoinPreconditionSummary', () => {
+  function setup(utxos: Utxos) {
+    const returnVal: { data: CoinjoinPreconditionSummary | undefined } = { data: undefined }
+    const TestComponent: React.FunctionComponent = () => {
+      returnVal.data = useCoinjoinPreconditionSummary(utxos)
+      return <></>
+    }
+
+    render(<TestComponent />)
+
+    return returnVal
+  }
+
+  it('should NOT be fulfilled on empty utxos', () => {
+    let preconditionSummary: CoinjoinPreconditionSummary | undefined
+
+    act(() => {
+      preconditionSummary = setup([]).data
+    })
+
+    expect(preconditionSummary).toEqual({
+      isFulfilled: false,
+      numberOfMissingUtxos: COINJOIN_PRECONDITIONS.MIN_NUMBER_OF_UTXOS,
+      amountOfMissingConfirmations: COINJOIN_PRECONDITIONS.MIN_CONFIRMATIONS_OF_SINGLE_UTXO,
+      amountOfMissingOverallRetries: COINJOIN_PRECONDITIONS.MIN_OVERALL_REMAINING_RETRIES,
+    })
+  })
+
+  it('should be fulfilled on suitable utxos', () => {
+    let preconditionSummary: CoinjoinPreconditionSummary | undefined
+
+    act(() => {
+      preconditionSummary = setup([
+        {
+          frozen: false,
+          confirmations: COINJOIN_PRECONDITIONS.MIN_CONFIRMATIONS_OF_SINGLE_UTXO,
+          tries_remaining: COINJOIN_PRECONDITIONS.MIN_OVERALL_REMAINING_RETRIES,
+        } as Utxo,
+      ]).data
+    })
+
+    expect(preconditionSummary).toEqual({
+      isFulfilled: true,
+      numberOfMissingUtxos: 0,
+      amountOfMissingConfirmations: 0,
+      amountOfMissingOverallRetries: 0,
+    })
+  })
+
+  it('should NOT be fulfilled on utxos with to little confirmations', () => {
+    let preconditionSummary: CoinjoinPreconditionSummary | undefined
+
+    act(() => {
+      preconditionSummary = setup([
+        {
+          frozen: false,
+          confirmations: COINJOIN_PRECONDITIONS.MIN_CONFIRMATIONS_OF_SINGLE_UTXO - 1,
+          tries_remaining: COINJOIN_PRECONDITIONS.MIN_OVERALL_REMAINING_RETRIES,
+        } as Utxo,
+        {
+          frozen: false,
+          confirmations: 0,
+          tries_remaining: COINJOIN_PRECONDITIONS.MIN_OVERALL_REMAINING_RETRIES,
+        } as Utxo,
+      ]).data
+    })
+
+    expect(preconditionSummary).toEqual({
+      isFulfilled: false,
+      numberOfMissingUtxos: 0,
+      amountOfMissingConfirmations: 1,
+      amountOfMissingOverallRetries: 0,
+    })
+  })
+
+  it('should NOT be fulfilled on utxos with to little remaining retries', () => {
+    let preconditionSummary: CoinjoinPreconditionSummary | undefined
+
+    act(() => {
+      preconditionSummary = setup([
+        {
+          frozen: false,
+          confirmations: COINJOIN_PRECONDITIONS.MIN_CONFIRMATIONS_OF_SINGLE_UTXO,
+          tries_remaining: COINJOIN_PRECONDITIONS.MIN_OVERALL_REMAINING_RETRIES - 1,
+        } as Utxo,
+        {
+          frozen: false,
+          confirmations: COINJOIN_PRECONDITIONS.MIN_CONFIRMATIONS_OF_SINGLE_UTXO,
+          tries_remaining: 0,
+        } as Utxo,
+      ]).data
+    })
+
+    expect(preconditionSummary).toEqual({
+      isFulfilled: false,
+      numberOfMissingUtxos: 0,
+      amountOfMissingConfirmations: 0,
+      amountOfMissingOverallRetries: 1,
+    })
+  })
+})

--- a/src/hooks/CoinjoinPrecondition.ts
+++ b/src/hooks/CoinjoinPrecondition.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react'
+import { isLocked } from '../hooks/BalanceSummary'
+import { Utxos } from '../context/WalletContext'
+
+export const COINJOIN_PRECONDITIONS = {
+  MIN_NUMBER_OF_UTXOS: 1, // min amount of utxos available
+  // https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.6/docs/SOURCING-COMMITMENTS.md#wait-for-at-least-5-confirmations
+  MIN_CONFIRMATIONS_OF_SINGLE_UTXO: 5, // at least one utxo needs X confirmations
+  MIN_OVERALL_REMAINING_RETRIES: 1, // amount of overall retries available
+}
+
+export interface CoinjoinPreconditionSummary {
+  isFulfilled: boolean
+  numberOfMissingUtxos: number
+  amountOfMissingConfirmations: number
+  amountOfMissingOverallRetries: number
+}
+
+export const useCoinjoinPreconditionSummary = (utxos: Utxos): CoinjoinPreconditionSummary => {
+  const eligibleUtxos = useMemo(() => {
+    return utxos.filter((it) => !it.frozen).filter((it) => !isLocked(it))
+  }, [utxos])
+
+  return useMemo(() => {
+    const numberOfMissingUtxos = Math.max(0, COINJOIN_PRECONDITIONS.MIN_NUMBER_OF_UTXOS - eligibleUtxos.length)
+
+    const overallRetriesRemaining = eligibleUtxos.reduce((acc, utxo) => acc + utxo.tries_remaining, 0)
+    const amountOfMissingOverallRetries = Math.max(
+      0,
+      COINJOIN_PRECONDITIONS.MIN_OVERALL_REMAINING_RETRIES - overallRetriesRemaining
+    )
+
+    const maxConfirmations =
+      eligibleUtxos.length === 0 ? 0 : eligibleUtxos.reduce((acc, utxo) => Math.max(acc, utxo.confirmations), 0)
+    const amountOfMissingConfirmations = Math.max(
+      0,
+      COINJOIN_PRECONDITIONS.MIN_CONFIRMATIONS_OF_SINGLE_UTXO - maxConfirmations
+    )
+
+    const isFulfilled =
+      numberOfMissingUtxos === 0 && amountOfMissingOverallRetries === 0 && amountOfMissingConfirmations === 0
+
+    return {
+      isFulfilled,
+      numberOfMissingUtxos,
+      amountOfMissingConfirmations,
+      amountOfMissingOverallRetries,
+    }
+  }, [eligibleUtxos])
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -204,7 +204,12 @@
     "sweep_amount_breakdown_total_balance": "Total balance",
     "sweep_amount_breakdown_frozen_balance": "Frozen or locked balance",
     "sweep_amount_breakdown_estimated_amount": "Estimated amount to be sent",
-    "sweep_amount_breakdown_explanation": "A sweep transaction will consume all UTXOs of a mixdepth leaving no coins behind except those that have been <1>frozen</1> or <3>time-locked</3>. Onchain transaction fees and market maker fees will be deducted from the amount so as to leave zero change. The exact transaction amount can only be calculated by JoinMarket at the point when the transaction is made. Therefore the estimated amount shown might deviate from the actually sent amount. Refer to the <5>JoinMarket documentation</5> for more details."
+    "sweep_amount_breakdown_explanation": "A sweep transaction will consume all UTXOs of a mixdepth leaving no coins behind except those that have been <1>frozen</1> or <3>time-locked</3>. Onchain transaction fees and market maker fees will be deducted from the amount so as to leave zero change. The exact transaction amount can only be calculated by JoinMarket at the point when the transaction is made. Therefore the estimated amount shown might deviate from the actually sent amount. Refer to the <5>JoinMarket documentation</5> for more details.",
+    "coinjoin_precondition": {
+      "hint_missing_utxos": "To execute a collaborative transaction you need at least one UTXO with <2>{{ minConfirmations }}</2>  in the source jar. Select another jar to send from or fund this jar and wait for <6>{{ minConfirmations }}</6> blocks.",
+      "hint_missing_confirmations": "A collaborative transaction requires one of your UTXOs to have <2>{{ minConfirmations }}</2> or more confirmations. Select another jar to send from or wait for <6>{{ amountOfMissingConfirmations }}</6> more block(s).",
+      "hint_missing_overall_retries": "You've tried executing a collaborative transaction from this jar unsuccessfully too many times in a row. For security reasons, you need a fresh UTXO to try again. See <2>the docs</2> for more information."
+    }
   },
   "receive": {
     "title": "Receive",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -206,7 +206,7 @@
     "sweep_amount_breakdown_estimated_amount": "Estimated amount to be sent",
     "sweep_amount_breakdown_explanation": "A sweep transaction will consume all UTXOs of a mixdepth leaving no coins behind except those that have been <1>frozen</1> or <3>time-locked</3>. Onchain transaction fees and market maker fees will be deducted from the amount so as to leave zero change. The exact transaction amount can only be calculated by JoinMarket at the point when the transaction is made. Therefore the estimated amount shown might deviate from the actually sent amount. Refer to the <5>JoinMarket documentation</5> for more details.",
     "coinjoin_precondition": {
-      "hint_missing_utxos": "To execute a collaborative transaction you need at least one UTXO with <2>{{ minConfirmations }}</2>  in the source jar. Select another jar to send from or fund this jar and wait for <6>{{ minConfirmations }}</6> blocks.",
+      "hint_missing_utxos": "To execute a collaborative transaction you need at least one UTXO with <2>{{ minConfirmations }}</2> confirmations in the source jar. Select another jar to send from or fund this jar and wait for <6>{{ minConfirmations }}</6> blocks.",
       "hint_missing_confirmations": "A collaborative transaction requires one of your UTXOs to have <2>{{ minConfirmations }}</2> or more confirmations. Select another jar to send from or wait for <6>{{ amountOfMissingConfirmations }}</6> more block(s).",
       "hint_missing_overall_retries": "You've tried executing a collaborative transaction from this jar unsuccessfully too many times in a row. For security reasons, you need a fresh UTXO to try again. See <2>the docs</2> for more information."
     }


### PR DESCRIPTION
Closes #155.

Before this commit, the `Send` page did not validate minimal preconditions that must be met before executing a collaborative transaction. Only the `Jam` page (invoking the scheduler, hence multiple collaborative transactions) displays a warning with further information.

In this commit, the minimal preconditions currently in place (min. 1 spendable utxo [not frozen, not timelocked], min. 5 confirmations of at least one utxo, at least 1 retry left) are externalized to `hooks/CoinjoinPrecondition.tsx`. These prerequisites are currently not very well verified and tested, and can probably be improved a lot – this _is not part_ of this PR.

After this commit these preconditions are also used on the `Send` page when a collaborative transaction is attempted, and if not met, a warning is displayed and the submit button disabled.

Currently `Send` and `Jam` will show different messages, maybe the wording can be harmonized to reuse the warning text across all components in a follow-up PR.

## :camera_flash: 

<img src="https://user-images.githubusercontent.com/3358649/175949581-0fe0133d-255c-406c-895d-36cc1c6fe398.png" width=400 />


