### PR TITLE
ui: evenly spacing between jars in select modal

### DIFF
--- a/src/components/JarSelectorModal.module.css
+++ b/src/components/JarSelectorModal.module.css
@@ -58,7 +58,7 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
   gap: 2rem;
   color: var(--bs-body-color);


### PR DESCRIPTION
Add more spacing to the jar selector modal.

Approve: Yes, looks better.
Decline: Let's keep it how it is.

## :camera_flash: Before/After
<img src="https://user-images.githubusercontent.com/3358649/176190386-3a0f94d3-a27c-42cc-a248-8748f882cd9b.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/176190644-46ce35df-5e6b-456a-b2b4-d34339338d8b.png" width=400 />
