### PR TITLE
ui: min-width for jar balances

### DIFF
--- a/src/components/jars/Jar.module.css
+++ b/src/components/jars/Jar.module.css
@@ -14,6 +14,17 @@
 }
 
 .jarBalance {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  /* min width should approximately match width of value "(symbol) 0.00 000 000":
+    - 1ch for the symbol
+    - 9ch chars for all zeros
+    - 1.5ch for the dot and spaces
+  */
+  min-width: 11.5ch;
+
   font-size: 0.8rem;
   padding-bottom: 0.8rem;
 }


### PR DESCRIPTION
`min-width` for jar balances as suggested in https://github.com/joinmarket-webui/joinmarket-webui/pull/357#issuecomment-1169699489.

Approve: It's better than before.
Decline/Close: It's worse.

## :camera_flash:  Before/After
<img src="https://user-images.githubusercontent.com/3358649/176657191-32518786-53a5-4242-a5cc-033fb9e9cc12.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/176656995-d589a93a-c23c-477c-8214-75a6ee9cd7ef.png" width=400 />

