### PR TITLE
fix: link to new fidelity bonds form in Cheatsheet component

### DIFF
--- a/src/components/Cheatsheet.tsx
+++ b/src/components/Cheatsheet.tsx
@@ -98,7 +98,7 @@ export default function Cheatsheet({ show = false, onHide }: CheatsheetProps) {
           <ListItem number={3}>
             <h6>
               <Trans i18nKey="cheatsheet.item_3.title">
-                Optional: <Link to={routes.fidelityBonds}>Lock</Link> funds in a fidelity bond.
+                Optional: <Link to={routes.earn}>Lock</Link> funds in a fidelity bond.
               </Trans>
             </h6>
             <div className="small text-secondary">{t('cheatsheet.item_3.description')}</div>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -6,7 +6,6 @@ export const routes = {
   receive: '/receive',
   earn: '/earn',
   settings: '/settings',
-  fidelityBonds: '/fidelity-bonds',
   wallet: '/wallet',
   createWallet: '/create-wallet',
 }


### PR DESCRIPTION
Fix the link from old home of Fidelity Bonds `/fidelity-bonds` to new location on `/earn`.