### PR TITLE
fix: Correctly fetch status for fidelity bond UTXOs

### DIFF
--- a/src/components/fb/CreateFidelityBond.jsx
+++ b/src/components/fb/CreateFidelityBond.jsx
@@ -155,6 +155,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, accountBalances, totalBal
       case steps.selectUtxos:
         return (
           <SelectUtxos
+            walletInfo={walletInfo}
             jar={selectedJar}
             utxos={utxos[selectedJar]}
             selectedUtxos={selectedUtxos}
@@ -165,6 +166,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, accountBalances, totalBal
       case steps.freezeUtxos:
         return (
           <FreezeUtxos
+            walletInfo={walletInfo}
             jar={selectedJar}
             utxos={utxos[selectedJar]}
             selectedUtxos={selectedUtxos}

--- a/src/components/fb/utils.test.ts
+++ b/src/components/fb/utils.test.ts
@@ -172,7 +172,7 @@ describe('utils', () => {
       it('should detect timelocked utxo as locked', () => {
         const utxo = {
           // timelocked, not yet expired
-          locktime: 'any',
+          locktime: '2009-01',
           path: `m/84'/1'/0'/0/1:${now / 1_000 + 1}`,
         } as Utxo
         expect(fb.utxo.isLocked(utxo, now)).toBe(true)
@@ -181,7 +181,7 @@ describe('utils', () => {
       it('should detect expired timelocked utxo as unlocked', () => {
         const utxo = {
           // timelocked, but expired
-          locktime: 'any',
+          locktime: '2009-01',
           path: `m/84'/1'/0'/0/1:${now / 1_000 - 1}`,
         } as Utxo
         expect(fb.utxo.isLocked(utxo, now)).toBe(false)

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -10,7 +10,7 @@ export interface CurrentWallet {
 
 // TODO: move these interfaces to JmWalletApi, once distinct types are used as return value instead of plain "Response"
 export type Utxo = {
-  address: string
+  address: Api.BitcoinAddress
   path: string
   label: string
   value: Api.AmountSats
@@ -21,7 +21,7 @@ export type Utxo = {
   confirmations: number
   frozen: boolean
   utxo: Api.UtxoId
-  locktime?: string
+  locktime?: Api.Lockdate
 }
 
 export type Utxos = Utxo[]
@@ -57,12 +57,14 @@ export interface Branch {
   entries: BranchEntry[]
 }
 
+export type AddressStatus = 'new' | 'used' | 'reused' | 'cj-out' | 'change-out' | 'non-cj-change' | 'deposit'
+
 export interface BranchEntry {
   hd_path: string
-  address: string
+  address: Api.BitcoinAddress
   amount: BalanceString
   available_balance: BalanceString
-  status: string
+  status: AddressStatus
   label: string
   extradata: string
 }

--- a/src/hooks/AddressSummary.ts
+++ b/src/hooks/AddressSummary.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react'
+import { WalletInfo, AddressStatus } from '../context/WalletContext'
+import { BitcoinAddress } from '../libs/JmWalletApi'
+
+type AddressInfo = {
+  status: AddressStatus
+  address: BitcoinAddress
+}
+
+type AddressSummary = {
+  [key: BitcoinAddress]: AddressInfo
+}
+
+const useAddressSummary = (currentWalletInfo: WalletInfo | null): AddressSummary | null => {
+  return useMemo(() => {
+    if (!currentWalletInfo) {
+      return null
+    }
+
+    const accounts = currentWalletInfo.data.display.walletinfo.accounts
+    return accounts
+      .flatMap((it) => it.branches)
+      .flatMap((it) => it.entries)
+      .reduce((acc, { address, status }) => {
+        acc[address] = { address, status }
+        return acc
+      }, {} as AddressSummary)
+  }, [currentWalletInfo])
+}
+
+export { useAddressSummary, AddressSummary, AddressInfo }

--- a/src/hooks/BalanceSummary.test.tsx
+++ b/src/hooks/BalanceSummary.test.tsx
@@ -92,7 +92,7 @@ describe('BalanceSummary', () => {
                   mixdepth: 0,
                   // unfrozen and expired
                   frozen: false,
-                  locktime: '1970-01',
+                  locktime: '2009-01',
                   path: `m/84'/1'/0'/0/2:${now / 1_000 - 1}`,
                 } as Utxo,
               ],


### PR DESCRIPTION
Resolves #375.

Displays the "correct" status in the "utxo selection" step when creating a fidelity bond.

Please note that in https://github.com/joinmarket-webui/joinmarket-webui/pull/383, contents of `hooks/AddressSummary.ts` are moved to `context/WalletContext.tsx` and data placed into type `WalletInfo`. But the approach needs to be agreed upon (and might eventually not be merged). This PR can either be merged independently or closed in favor of #383.

##### Addendum
The mapping is not `utxo -> label`, but rather `address -> label` which leads to the following thinking:
Maybe "reused" addresses can be handled differently.. Should only partly spending from reused addresses be prevented somehow or discouraged? If there are multiple outputs controlled by the same pubkey, they probably should be spent together, meaning, they also shouldn't be frozen independently. Should an utxo selector really be an "address selector", or at least behave like one?
