### PR TITLE
fix: mention jar #0 in preconditions

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -318,9 +318,9 @@
     "error_loading_schedule_failed": "Loading schedule progress failed.",
     "error_address_reuse": "Reusing addresses is prohibited. Make sure to use unique and unused addresses.",
     "precondition": {
-      "hint_missing_utxos": "To run the scheduler you need at least one UTXO with <2>{{ minConfirmations }}</2> confirmations. Fund your wallet and wait for <6>{{ minConfirmations }}</6> blocks.",
-      "hint_missing_confirmations": "The scheduler requires one of your UTXOs to have <2>{{ minConfirmations }}</2> or more confirmations. Wait for <6>{{ amountOfMissingConfirmations }}</6> more block(s).",
-      "hint_missing_overall_retries": "You've tried running the scheduler unsuccessfully too many times in a row. For security reasons, you need a fresh UTXO to try again. See <2>the docs</2> for more information."
+      "hint_missing_utxos": "To run the scheduler you need at least one UTXO with <2>{{ minConfirmations }}</2> confirmations in Jar #0. Fund your wallet and wait for <6>{{ minConfirmations }}</6> blocks.",
+      "hint_missing_confirmations": "The scheduler requires one of your UTXOs in Jar #0 to have <2>{{ minConfirmations }}</2> or more confirmations. Wait for <6>{{ amountOfMissingConfirmations }}</6> more block(s).",
+      "hint_missing_overall_retries": "You've tried running the scheduler unsuccessfully too many times in a row. For security reasons, you need a fresh UTXO in Jar #0 to try again. See <2>the docs</2> for more information."
     }
   },
   "modal": {


### PR DESCRIPTION
For now we're limited to starting the scheduler from Jar #0 at least until https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1260 is released server-side.

Since this can be confusing, let's at least mention it to the user. See also https://github.com/joinmarket-webui/joinmarket-webui/issues/391.