### PR TITLE
fix: color of selected collaborators-selector-input

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -95,13 +95,20 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCo
               <rb.Button
                 key={number}
                 variant={settings.theme === 'light' ? 'white' : 'dark'}
-                className={`${styles['collaborators-selector-button']} p-2 border border-1 rounded text-center${
-                  !usesCustomNumCollaborators && numCollaborators === number
-                    ? settings.theme === 'light'
-                      ? ' border-dark'
-                      : ` ${styles['selected-dark']}`
-                    : ''
-                }`}
+                className={classnames(
+                  styles['collaborators-selector-button'],
+                  'p-2',
+                  'border',
+                  'border-1',
+                  'rounded',
+                  'text-center',
+                  {
+                    'border-dark':
+                      !usesCustomNumCollaborators && numCollaborators === number && settings.theme === 'light',
+                    [styles['selected-dark']]:
+                      !usesCustomNumCollaborators && numCollaborators === number && settings.theme !== 'light',
+                  }
+                )}
                 onClick={() => {
                   setUsesCustomNumCollaborators(false)
                   setNumCollaborators(number)
@@ -119,9 +126,18 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCo
             isInvalid={!isValidNumCollaborators(numCollaborators, minNumCollaborators)}
             placeholder={t('send.input_num_collaborators_placeholder')}
             defaultValue=""
-            className={`${styles['collaborators-selector-input']} p-2 border border-1 rounded text-center${
-              usesCustomNumCollaborators ? (settings.theme === 'light' ? ' border-dark' : ' selected-dark') : ''
-            }`}
+            className={classnames(
+              styles['collaborators-selector-input'],
+              'p-2',
+              'border',
+              'border-1',
+              'rounded',
+              'text-center',
+              {
+                'border-dark': usesCustomNumCollaborators && settings.theme === 'light',
+                [styles['selected-dark']]: usesCustomNumCollaborators && settings.theme !== 'light',
+              }
+            )}
             onChange={(e) => {
               setUsesCustomNumCollaborators(true)
               validateAndSetCustomNumCollaborators(e.target.value)


### PR DESCRIPTION
Fixes the background color of the custom collaborative selector input in dark mode.
Problem was that the name of the css class has not been applied properly.

## Before
![image](https://user-images.githubusercontent.com/3358649/179740559-fd1e8920-3f25-4c17-8366-15a91a82e20f.png)

## After
![image](https://user-images.githubusercontent.com/3358649/179740796-5ffa3c7a-40dd-469e-914c-5d58c34d9e93.png)


Edit: Misleading branch name.. wanted to fix something else. Please ignore.