### PR TITLE
feat: show address reuse warning

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -266,7 +266,7 @@ export default function Send() {
   const [isSweep, setIsSweep] = useState(false)
   const [destinationJarPickerShown, setDestinationJarPickerShown] = useState(false)
   const [destinationJar, setDestinationJar] = useState(null)
-  const [destinationIsReusedAddress, setDesitnationIsReusedAddress] = useState(false)
+  const [destinationIsReusedAddress, setDestinationIsReusedAddress] = useState(false)
 
   const [waitForUtxosToBeSpent, setWaitForUtxosToBeSpent] = useState([])
   const [paymentSuccessfulInfoAlert, setPaymentSuccessfulInfoAlert] = useState(null)
@@ -429,12 +429,12 @@ export default function Send() {
   useEffect(() => {
     if (walletInfo?.addressSummary[destination]) {
       if (walletInfo?.addressSummary[destination].status !== 'new') {
-        setDesitnationIsReusedAddress(true)
+        setDestinationIsReusedAddress(true)
         return
       }
     }
 
-    setDesitnationIsReusedAddress(false)
+    setDestinationIsReusedAddress(false)
   }, [walletInfo, destination])
 
   const sendPayment = async (account, destination, amount_sats) => {

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -310,6 +310,7 @@ export default function Send() {
   useEffect(() => {
     if (
       isValidAddress(destination) &&
+      !destinationIsReusedAddress &&
       isValidAccount(account) &&
       isValidAmount(amount, isSweep) &&
       (isCoinjoin ? isValidNumCollaborators(numCollaborators, minNumCollaborators) : true) &&
@@ -328,6 +329,7 @@ export default function Send() {
     isCoinjoin,
     isSweep,
     coinjoinPreconditionSummary,
+    destinationIsReusedAddress,
   ])
 
   useEffect(() => {

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -427,7 +427,7 @@ export default function Send() {
   }, [isOperationDisabled, wallet, reloadCurrentWalletInfo, reloadServiceInfo, loadConfigValue, t])
 
   useEffect(() => {
-    if (walletInfo?.addressSummary[destination]) {
+    if (destination !== null && walletInfo?.addressSummary[destination]) {
       if (walletInfo?.addressSummary[destination].status !== 'new') {
         setDestinationIsReusedAddress(true)
         return

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -185,7 +185,7 @@
     "text_coinjoin_already_running": "A collaborative transaction is currently in progress.",
     "label_recipient": "Recipient",
     "placeholder_recipient": "Enter address or choose jar from wallet...",
-    "feedback_invalid_recipient": "Please provide a recipient address.",
+    "feedback_reused_address": "This address is already used. To preserve your privacy please chose another one.",
     "label_account": "Send from",
     "label_account_dev_mode": "Account to send from",
     "account_selector_option": "Jar {{ number }}",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -185,7 +185,7 @@
     "text_coinjoin_already_running": "A collaborative transaction is currently in progress.",
     "label_recipient": "Recipient",
     "placeholder_recipient": "Enter address or choose jar from wallet...",
-    "feedback_reused_address": "This address is already used. To preserve your privacy please chose another one.",
+    "feedback_reused_address": "This address is already used. To preserve your privacy please choose another one.",
     "label_account": "Send from",
     "label_account_dev_mode": "Account to send from",
     "account_selector_option": "Jar {{ number }}",


### PR DESCRIPTION
Resolves #404.

Warns the user in case a destination address on the Send screen is a known "internal" address that's not labelled as `new`.

Edit: Currently, we'd not allow sending to that address. Alternatively, we could also just show the warning but allow sending Any preferences @dergigi @theborakompanioni?

## 📸 

<img width="640" alt="Screenshot 2022-07-20 at 11 17 05" src="https://user-images.githubusercontent.com/10026790/179946638-7c548291-f970-4c7c-8be1-9de2e216ac46.png">

