### PR TITLE
fix: fidelity bonds jar selecotor spacing

### DIFF
--- a/src/components/Balance.jsx
+++ b/src/components/Balance.jsx
@@ -19,7 +19,7 @@ const BalanceComponent = ({ symbol, value, symbolIsPrefix }) => {
   return (
     <span className="d-inline-flex align-items-center">
       {symbolIsPrefix && symbol}
-      <span className="d-inline-flex align-items-center slashed-zeroes">{value}</span>
+      <span className="d-inline-flex align-items-center slashed-zeroes balance-value">{value}</span>
       {!symbolIsPrefix && symbol}
     </span>
   )
@@ -101,8 +101,12 @@ export default function Balance({
     // Treat decimal numbers as btc.
     const valueIsBtc = !valueIsSats && !Number.isNaN(Number.parseFloat(valueString)) && valueString.indexOf('.') > -1
 
-    const btcSymbol = <span style={{ paddingRight: '0.1em' }}>{'\u20BF'}</span>
-    const satSymbol = <Sprite symbol="sats" width="1.2em" height="1.2em" />
+    const btcSymbol = (
+      <span className="balance-symbol" style={{ paddingRight: '0.1em' }}>
+        {'\u20BF'}
+      </span>
+    )
+    const satSymbol = <Sprite className="balance-symbol" symbol="sats" width="1.2em" height="1.2em" />
 
     if (valueIsBtc && displayMode === DISPLAY_MODE_BTC)
       return <BalanceComponent symbol={btcSymbol} value={formatBtc(valueString)} symbolIsPrefix={true} />

--- a/src/components/fb/FidelityBondSteps.module.css
+++ b/src/components/fb/FidelityBondSteps.module.css
@@ -3,6 +3,31 @@
   color: var(--bs-gray-600);
 }
 
+.jarsContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+}
+
+.jarsContainer :global .balance-value {
+  font-size: 0.7rem;
+}
+
+.jarsContainer :global .balance-symbol {
+  font-size: 0.7rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .jarsContainer {
+    flex-direction: row;
+    justify-content: space-around;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+}
+
 .utxoCard {
   display: flex;
   align-items: center;

--- a/src/components/fb/FidelityBondSteps.tsx
+++ b/src/components/fb/FidelityBondSteps.tsx
@@ -90,7 +90,7 @@ const SelectJar = ({ accountBalances, totalBalance, utxos, selectedJar, onJarSel
   return (
     <div className="d-flex flex-column gap-4">
       <div className={styles.stepDescription}>{t('earn.fidelity_bond.select_jar.description')}</div>
-      <div className="d-flex justify-content-between">
+      <div className={styles.jarsContainer}>
         {sortedAccountBalances.map((account, index) => (
           <SelectableJar
             key={index}


### PR DESCRIPTION
Resolves #400.

Stacks the jars on mobile, decreases the balance font size a little bit and wraps the jars onto a new line on bigger screens if space runs out.

## 📸 
<img width="605" alt="Screenshot 2022-07-21 at 11 00 49" src="https://user-images.githubusercontent.com/10026790/180175059-7784eb53-d3ec-48fe-b7ce-bbc325c7d500.png">
<img width="458" alt="Screenshot 2022-07-21 at 11 01 06" src="https://user-images.githubusercontent.com/10026790/180175068-ac395344-49b4-4eba-8e9f-ad07b8a23bed.png">

