### PR TITLE
refactor: move filtering for Fidelity Bonds to `WalletContext`

### DIFF
--- a/src/components/CurrentWalletAdvanced.tsx
+++ b/src/components/CurrentWalletAdvanced.tsx
@@ -39,12 +39,9 @@ export default function CurrentWalletAdvanced() {
 
     reloadCurrentWalletInfo({ signal: abortCtrl.signal })
       .then((info) => {
-        if (info && !abortCtrl.signal.aborted) {
-          const unspentOutputs = info.data.utxos.utxos
-          setUtxos(unspentOutputs)
-
-          const fbOutputs = unspentOutputs.filter((utxo) => utxo.locktime)
-          setFidelityBonds(fbOutputs)
+        if (!abortCtrl.signal.aborted) {
+          setFidelityBonds(info.fidelityBondSummary.fbOutputs)
+          setUtxos(info.data.utxos.utxos)
         }
       })
       .catch((err) => {

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -157,10 +157,8 @@ export default function Earn() {
 
     const reloadingServiceInfo = reloadServiceInfo({ signal: abortCtrl.signal })
     const reloadingCurrentWalletInfo = reloadCurrentWalletInfo({ signal: abortCtrl.signal }).then((info) => {
-      if (info && !abortCtrl.signal.aborted) {
-        const unspentOutputs = info.data.utxos.utxos
-        const fbOutputs = unspentOutputs.filter((utxo) => utxo.locktime)
-        setFidelityBonds(fbOutputs)
+      if (!abortCtrl.signal.aborted) {
+        setFidelityBonds(info.fidelityBondSummary.fbOutputs)
       }
     })
 
@@ -206,13 +204,7 @@ export default function Earn() {
         resolve(reloadCurrentWalletInfo({ signal: abortCtrl.signal }))
       }, delay)
     })
-      .then((info) => {
-        if (info) {
-          const unspentOutputs = info.data.utxos.utxos
-          const fbOutputs = unspentOutputs.filter((utxo) => utxo.locktime)
-          setFidelityBonds(fbOutputs)
-        }
-      })
+      .then((info) => setFidelityBonds(info.fidelityBondSummary.fbOutputs))
       .catch((err) => {
         setAlert({ variant: 'danger', message: err.message })
       })

--- a/src/components/fb/CreateFidelityBond.jsx
+++ b/src/components/fb/CreateFidelityBond.jsx
@@ -178,7 +178,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, accountBalances, totalBal
             // Note that two fidelity bonds with the same locktime will end up on the same address.
             // Therefore, this might not actually be the UTXO we just created.
             // Since we're using it only for displaying locktime and address, this should be fine though.
-            const fbUtxo = walletInfo.data.utxos.utxos.find((utxo) => utxo.address === timelockedAddress)
+            const fbUtxo = walletInfo.fidelityBondSummary.fbOutputs.find((utxo) => utxo.address === timelockedAddress)
 
             if (fbUtxo !== undefined) {
               setCreatedFidelityBondUtxo(fbUtxo)

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -83,8 +83,13 @@ type AddressSummary = {
   [key: Api.BitcoinAddress]: AddressInfo
 }
 
+type FidenlityBondSummary = {
+  fbOutputs: Utxos
+}
+
 export interface WalletInfo {
   addressSummary: AddressSummary
+  fidelityBondSummary: FidenlityBondSummary
   data: CombinedRawWalletData
 }
 
@@ -104,6 +109,13 @@ const toAddressSummary = (data: CombinedRawWalletData): AddressSummary => {
       acc[address] = { address, status }
       return acc
     }, {} as AddressSummary)
+}
+
+const toFidelityBondSummary = (data: CombinedRawWalletData): FidenlityBondSummary => {
+  const fbOutputs = data.utxos.utxos.filter((utxo) => utxo.locktime)
+  return {
+    fbOutputs,
+  }
 }
 
 const WalletContext = createContext<WalletContextEntry | undefined>(undefined)
@@ -140,9 +152,11 @@ const loadWalletInfoData = async ({
 
 const toWalletInfo = (data: CombinedRawWalletData): WalletInfo => {
   const addressSummary = toAddressSummary(data)
+  const fidelityBondSummary = toFidelityBondSummary(data)
 
   return {
     addressSummary,
+    fidelityBondSummary,
     data,
   }
 }

--- a/src/hooks/BalanceSummary.test.tsx
+++ b/src/hooks/BalanceSummary.test.tsx
@@ -37,6 +37,7 @@ describe('BalanceSummary', () => {
       balanceSummary = setup(
         {
           addressSummary: {},
+          fidelityBondSummary: { fbOutputs: [] },
           data: {
             utxos: {
               utxos: [],
@@ -67,6 +68,7 @@ describe('BalanceSummary', () => {
       balanceSummary = setup(
         {
           addressSummary: {},
+          fidelityBondSummary: { fbOutputs: [] },
           data: {
             utxos: {
               utxos: [
@@ -129,6 +131,7 @@ describe('BalanceSummary', () => {
       balanceSummary = setup(
         {
           addressSummary: {},
+          fidelityBondSummary: { fbOutputs: [] },
           data: {
             utxos: {
               utxos: [


### PR DESCRIPTION
Part of #381.

Moves filtering utxos for Fidelity Bonds from multiple components into `WalletContext`.

Instead of just holding the filtered utxo array, a new "summary" dictionary holding a single attribute `fbOutputs` is introduced, in case additional information comes up. e.g. if two outputs are present, the most valuable and hence "active" fb can be determined (this is not done at the moment), the human readable "expiry time" or other stats and metrics we do not yet present to the user.

Hope I have found any component that uses FBs and adapted it to use the newly introduced approach.