### PR TITLE
deps: update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.11.0']
+        node-version: ['16.16.0']
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-bootstrap": "^2.5.0-beta.1",
         "react-dom": "^17.0.2",
         "react-i18next": "^11.16.9",
-        "react-router-bootstrap": "^0.26.1",
+        "react-router-bootstrap": "^0.26.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "^5.0.1",
         "typescript": "^4.7.2",
@@ -15210,9 +15210,9 @@
       }
     },
     "node_modules/react-router-bootstrap": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.26.1.tgz",
-      "integrity": "sha512-qgFDfnN2U5RBARTf4L/Xrk0xjNid4wRtBQFrzI2Z2Gu74nlfKT5qZreUxDiYvv4sI+NrWcYacRZEqS5yeLYH0A==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.26.2.tgz",
+      "integrity": "sha512-YlpI9Xi+Uqp6zFAUO8D/wu6P8mr1ujqq+0V5MhJG1kx9dr/95fAMoGk4J+/CsysOkwtR3tYSac4DDWmHwXvC8w==",
       "dev": true,
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -30336,9 +30336,9 @@
       }
     },
     "react-router-bootstrap": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.26.1.tgz",
-      "integrity": "sha512-qgFDfnN2U5RBARTf4L/Xrk0xjNid4wRtBQFrzI2Z2Gu74nlfKT5qZreUxDiYvv4sI+NrWcYacRZEqS5yeLYH0A==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.26.2.tgz",
+      "integrity": "sha512-YlpI9Xi+Uqp6zFAUO8D/wu6P8mr1ujqq+0V5MhJG1kx9dr/95fAMoGk4J+/CsysOkwtR3tYSac4DDWmHwXvC8w==",
       "dev": true,
       "requires": {
         "prop-types": "^15.7.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^17.0.35",
         "@types/react": "^17.0.43",
         "@types/react-dom": "^17.0.14",
-        "bootstrap": "^5.1.3",
+        "bootstrap": "^5.2.0",
         "buffer": "^6.0.3",
         "classnames": "^2.3.1",
         "conventional-changelog": "^3.1.25",
@@ -4953,15 +4953,22 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.1.3",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
+        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/boxen": {
@@ -22703,8 +22710,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.1.3",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "jest-watch-typeahead": "^0.6.5",
         "jest-websocket-mock": "^2.3.0",
         "lint-staged": "^12.4.2",
-        "moving-letters": "^1.0.1",
         "prettier": "^2.6.2",
         "qrcode": "^1.5.0",
         "react": "^17.0.2",
@@ -4220,11 +4219,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
-      "dev": true
-    },
-    "node_modules/animejs": {
-      "version": "3.2.1",
-      "integrity": "sha512-sWno3ugFryK5nhiDm/2BKeFCpZv7vzerWUcUPyAZLDhMek3+S/p418ldZJbJXo5ZUOpfm2kP2XRO4NJcULMy9A==",
       "dev": true
     },
     "node_modules/ansi-align": {
@@ -12680,23 +12674,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/moving-letters": {
-      "version": "1.0.1",
-      "integrity": "sha512-819kOfUHOY1VNtlF7pjHik84EEiMow3kC0fETGe+y1L6iaj7QAJrVepurDDWulosdzY3prbvhFedOL3z5qNLLg==",
-      "dev": true,
-      "dependencies": {
-        "animejs": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.4",
-        "react": "^15.0.0 || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/ms": {
@@ -22170,11 +22147,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "animejs": {
-      "version": "3.2.1",
-      "integrity": "sha512-sWno3ugFryK5nhiDm/2BKeFCpZv7vzerWUcUPyAZLDhMek3+S/p418ldZJbJXo5ZUOpfm2kP2XRO4NJcULMy9A==",
-      "dev": true
-    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -28627,14 +28599,6 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
-    },
-    "moving-letters": {
-      "version": "1.0.1",
-      "integrity": "sha512-819kOfUHOY1VNtlF7pjHik84EEiMow3kC0fETGe+y1L6iaj7QAJrVepurDDWulosdzY3prbvhFedOL3z5qNLLg==",
-      "dev": true,
-      "requires": {
-        "animejs": "^3.1.0"
-      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "prettier": "^2.6.2",
         "qrcode": "^1.5.0",
         "react": "^17.0.2",
-        "react-bootstrap": "^2.4.0",
+        "react-bootstrap": "^2.5.0-beta.1",
         "react-dom": "^17.0.2",
         "react-i18next": "^11.16.9",
         "react-router-bootstrap": "^0.26.1",
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -2737,21 +2737,21 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.2.tgz",
-      "integrity": "sha512-amXY11ImpokvkTMeKRHjsSsG7v1yzzs6yeqArCyBIk60J3Yhgxwx9Cah+Uu/804ATFwqzN22AXIo7SdtIaMP+g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.2.0.tgz",
+      "integrity": "sha512-wwJFdkl+Q8NU5yJ4NvdAOqx5LM3QtUVoSjuK7Ey8jZ4WS4bB0EqT3Kr3IInBs257HzZ5nXCiKXKE4NGXXuIRWA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@restart/hooks": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.6.tgz",
-      "integrity": "sha512-FzpEzy6QeLB3OpUrC9OQD/lWCluQmilLfRGa/DqbB6OmV05AEt/0Lgn3Jf6l27UIJMK0qFmNcps6p8DNLXa6Pw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
+      "integrity": "sha512-ZbjlEHcG+FQtpDPHd7i4FzNNvJf2enAwZfJbpM8CW7BhmOAbsHpZe3tsHwfQUrBuyrxWqPYp2x5UMnilWcY22A==",
       "dev": true,
       "dependencies": {
         "dequal": "^2.0.2"
@@ -2761,15 +2761,15 @@
       }
     },
     "node_modules/@restart/ui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.2.0.tgz",
-      "integrity": "sha512-oIh2t3tG8drZtZ9SlaV5CY6wGsUViHk8ZajjhcI+74IQHyWy+AnxDv8rJR5wVgsgcgrPBUvGNkC1AEdcGNPaLQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.3.1.tgz",
+      "integrity": "sha512-MYvMs2eeZTHu2dBJHOXKx72vxzEZeWbZx2z1QjeXq62iYjpjIyukBC2ZEy8x+sb9Gl0AiOiHkPXrl1wn95aOGQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.13.16",
-        "@popperjs/core": "^2.10.1",
-        "@react-aria/ssr": "^3.0.1",
-        "@restart/hooks": "^0.4.0",
+        "@babel/runtime": "^7.18.3",
+        "@popperjs/core": "^2.11.5",
+        "@react-aria/ssr": "^3.2.0",
+        "@restart/hooks": "^0.4.7",
         "@types/warning": "^3.0.0",
         "dequal": "^2.0.2",
         "dom-helpers": "^5.2.0",
@@ -3585,7 +3585,7 @@
     "node_modules/@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=",
+      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -6803,9 +6803,9 @@
       }
     },
     "node_modules/dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -14995,14 +14995,14 @@
       }
     },
     "node_modules/react-bootstrap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.4.0.tgz",
-      "integrity": "sha512-dn599jNK1Fg5GGjJH+lQQDwELVzigh/MdusKpB/0el+sCjsO5MZDH5gRMmBjRhC+vb7VlCDr6OXffPIDSkNMLw==",
+      "version": "2.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.5.0-beta.1.tgz",
+      "integrity": "sha512-brHUvpjJrNmShg2xjT3qNfZ7mKLEUyGvh+wp+IgxcFKrh7BPKzpbAtJYa2S1QJx5MuPBT/D0ywMFbz1LBY0Qvg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
-        "@restart/ui": "^1.2.0",
+        "@restart/ui": "^1.3.0",
         "@types/react-transition-group": "^4.4.4",
         "classnames": "^2.3.1",
         "dom-helpers": "^5.2.1",
@@ -20348,9 +20348,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -20986,33 +20986,33 @@
       "dev": true
     },
     "@react-aria/ssr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.2.tgz",
-      "integrity": "sha512-amXY11ImpokvkTMeKRHjsSsG7v1yzzs6yeqArCyBIk60J3Yhgxwx9Cah+Uu/804ATFwqzN22AXIo7SdtIaMP+g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.2.0.tgz",
+      "integrity": "sha512-wwJFdkl+Q8NU5yJ4NvdAOqx5LM3QtUVoSjuK7Ey8jZ4WS4bB0EqT3Kr3IInBs257HzZ5nXCiKXKE4NGXXuIRWA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.2"
       }
     },
     "@restart/hooks": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.6.tgz",
-      "integrity": "sha512-FzpEzy6QeLB3OpUrC9OQD/lWCluQmilLfRGa/DqbB6OmV05AEt/0Lgn3Jf6l27UIJMK0qFmNcps6p8DNLXa6Pw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
+      "integrity": "sha512-ZbjlEHcG+FQtpDPHd7i4FzNNvJf2enAwZfJbpM8CW7BhmOAbsHpZe3tsHwfQUrBuyrxWqPYp2x5UMnilWcY22A==",
       "dev": true,
       "requires": {
         "dequal": "^2.0.2"
       }
     },
     "@restart/ui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.2.0.tgz",
-      "integrity": "sha512-oIh2t3tG8drZtZ9SlaV5CY6wGsUViHk8ZajjhcI+74IQHyWy+AnxDv8rJR5wVgsgcgrPBUvGNkC1AEdcGNPaLQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.3.1.tgz",
+      "integrity": "sha512-MYvMs2eeZTHu2dBJHOXKx72vxzEZeWbZx2z1QjeXq62iYjpjIyukBC2ZEy8x+sb9Gl0AiOiHkPXrl1wn95aOGQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.13.16",
-        "@popperjs/core": "^2.10.1",
-        "@react-aria/ssr": "^3.0.1",
-        "@restart/hooks": "^0.4.0",
+        "@babel/runtime": "^7.18.3",
+        "@popperjs/core": "^2.11.5",
+        "@react-aria/ssr": "^3.2.0",
+        "@restart/hooks": "^0.4.7",
         "@types/warning": "^3.0.0",
         "dequal": "^2.0.2",
         "dom-helpers": "^5.2.0",
@@ -21667,7 +21667,7 @@
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=",
+      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==",
       "dev": true
     },
     "@types/ws": {
@@ -24076,9 +24076,9 @@
       "dev": true
     },
     "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true
     },
     "destroy": {
@@ -30180,14 +30180,14 @@
       }
     },
     "react-bootstrap": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.4.0.tgz",
-      "integrity": "sha512-dn599jNK1Fg5GGjJH+lQQDwELVzigh/MdusKpB/0el+sCjsO5MZDH5gRMmBjRhC+vb7VlCDr6OXffPIDSkNMLw==",
+      "version": "2.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.5.0-beta.1.tgz",
+      "integrity": "sha512-brHUvpjJrNmShg2xjT3qNfZ7mKLEUyGvh+wp+IgxcFKrh7BPKzpbAtJYa2S1QJx5MuPBT/D0ywMFbz1LBY0Qvg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@restart/hooks": "^0.4.6",
-        "@restart/ui": "^1.2.0",
+        "@restart/ui": "^1.3.0",
         "@types/react-transition-group": "^4.4.4",
         "classnames": "^2.3.1",
         "dom-helpers": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "^2.6.2",
     "qrcode": "^1.5.0",
     "react": "^17.0.2",
-    "react-bootstrap": "^2.4.0",
+    "react-bootstrap": "^2.5.0-beta.1",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.16.9",
     "react-router-bootstrap": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-bootstrap": "^2.5.0-beta.1",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.16.9",
-    "react-router-bootstrap": "^0.26.1",
+    "react-router-bootstrap": "^0.26.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
     "typescript": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jest-watch-typeahead": "^0.6.5",
     "jest-websocket-mock": "^2.3.0",
     "lint-staged": "^12.4.2",
-    "moving-letters": "^1.0.1",
     "prettier": "^2.6.2",
     "qrcode": "^1.5.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^17.0.35",
     "@types/react": "^17.0.43",
     "@types/react-dom": "^17.0.14",
-    "bootstrap": "^5.1.3",
+    "bootstrap": "^5.2.0",
     "buffer": "^6.0.3",
     "classnames": "^2.3.1",
     "conventional-changelog": "^3.1.25",

--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -91,7 +91,7 @@ export default function Earn() {
   const serviceInfo = useServiceInfo()
   const reloadServiceInfo = useReloadServiceInfo()
 
-  const [showAdvancedSettings, setShowAdvancedSettings] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
   const [alert, setAlert] = useState(null)
   const [serviceInfoAlert, setServiceInfoAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -333,17 +333,17 @@ export default function Earn() {
                       <rb.Button
                         variant={`${settings.theme}`}
                         className={`${styles['settings-btn']} d-flex align-items-center`}
-                        onClick={() => setShowAdvancedSettings((current) => !current)}
+                        onClick={() => setShowSettings((current) => !current)}
                       >
                         {t('earn.button_settings')}
                         <Sprite
-                          symbol={`caret-${showAdvancedSettings ? 'up' : 'down'}`}
+                          symbol={`caret-${showSettings ? 'up' : 'down'}`}
                           className="ms-1"
                           width="20"
                           height="20"
                         />
                       </rb.Button>
-                      {showAdvancedSettings && (
+                      {showSettings && (
                         <div className="my-4">
                           <rb.Form.Group className="mb-4 d-flex justify-content-center" controlId="offertype">
                             <SegmentedTabs
@@ -482,33 +482,35 @@ export default function Earn() {
                       <hr className="m-0" />
                     </div>
                   )}
-                  <rb.Button
-                    variant="dark"
-                    type="submit"
-                    className="mt-4"
-                    disabled={isLoading || isSubmitting || isWaitingMakerStart || isWaitingMakerStop}
-                  >
-                    <div className="d-flex justify-content-center align-items-center">
-                      {(isWaitingMakerStart || isWaitingMakerStop) && (
-                        <rb.Spinner
-                          as="span"
-                          animation="border"
-                          size="sm"
-                          role="status"
-                          aria-hidden="true"
-                          className="me-2"
-                        />
-                      )}
-                      {isWaitingMakerStart || isWaitingMakerStop ? (
-                        <>
-                          {isWaitingMakerStart && t('earn.text_starting')}
-                          {isWaitingMakerStop && t('earn.text_stopping')}
-                        </>
-                      ) : (
-                        <>{serviceInfo?.makerRunning === true ? t('earn.button_stop') : t('earn.button_start')}</>
-                      )}
-                    </div>
-                  </rb.Button>
+                  <div class="mt-4">
+                    <rb.Button
+                      variant="dark"
+                      type="submit"
+                      className={styles['earn-btn']}
+                      disabled={isLoading || isSubmitting || isWaitingMakerStart || isWaitingMakerStop}
+                    >
+                      <div className="d-flex justify-content-center align-items-center">
+                        {(isWaitingMakerStart || isWaitingMakerStop) && (
+                          <rb.Spinner
+                            as="span"
+                            animation="border"
+                            size="sm"
+                            role="status"
+                            aria-hidden="true"
+                            className="me-2"
+                          />
+                        )}
+                        {isWaitingMakerStart || isWaitingMakerStop ? (
+                          <>
+                            {isWaitingMakerStart && t('earn.text_starting')}
+                            {isWaitingMakerStop && t('earn.text_stopping')}
+                          </>
+                        ) : (
+                          <>{serviceInfo?.makerRunning === true ? t('earn.button_stop') : t('earn.button_start')}</>
+                        )}
+                      </div>
+                    </rb.Button>
+                  </div>
                 </rb.Form>
               )}
             </Formik>

--- a/src/components/Earn.module.css
+++ b/src/components/Earn.module.css
@@ -37,11 +37,11 @@
 }
 
 .earn hr {
-  background-color: rgba(222, 222, 222, 1);
+  border-color: rgba(222, 222, 222, 1);
   opacity: 100%;
 }
 
 :root[data-theme='dark'] .earn hr {
-  background-color: var(--bs-gray-800);
+  border-color: var(--bs-gray-800);
   opacity: 100%;
 }

--- a/src/components/Earn.module.css
+++ b/src/components/Earn.module.css
@@ -12,7 +12,7 @@
   height: 3.5rem;
 }
 
-.earn form button {
+.earn .earn-btn {
   height: 3rem;
   width: 100%;
 }
@@ -25,7 +25,8 @@
   background-color: transparent !important;
   border: none;
   padding-left: 0;
-  font-weight: 500;
+  height: 3rem;
+  width: 100%;
 }
 
 .settings-container .input-group-text {

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -112,7 +112,7 @@ export default function Receive() {
           <rb.Button
             variant={`${settings.theme}`}
             className={`${styles['settings-btn']} d-flex align-items-center`}
-            onClick={() => setShowSettings(!showSettings)}
+            onClick={() => setShowSettings((current) => !current)}
           >
             {t('receive.button_settings')}
             <Sprite symbol={`caret-${showSettings ? 'up' : 'down'}`} className="ms-1" width="20" height="20" />
@@ -163,10 +163,10 @@ export default function Receive() {
               </rb.Form.Group>
             </div>
           )}
-          <hr />
+          <hr className="m-0" />
         </div>
 
-        <div className="mt-2 d-flex justify-content-center">
+        <div className="mt-4 d-flex justify-content-center">
           <rb.Button
             variant="outline-dark"
             type="submit"

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -22,6 +22,8 @@
   background-color: transparent !important;
   border: none;
   padding-left: 0;
+  height: 3rem;
+  width: 100%;
 }
 
 .receive form input {

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -1,10 +1,10 @@
 .receive hr {
-  background-color: rgba(222, 222, 222, 1);
+  border-color: rgba(222, 222, 222, 1);
   opacity: 100%;
 }
 
 :root[data-theme='dark'] .receive hr {
-  background-color: var(--bs-gray-800);
+  border-color: var(--bs-gray-800);
   opacity: 100%;
 }
 

--- a/src/components/Send.module.css
+++ b/src/components/Send.module.css
@@ -95,7 +95,7 @@ input[type='number'] {
   color: var(--bs-white) !important;
 }
 
-:root[data-theme='dark'] .sweep-breakdoown-paragraph {
+:root[data-theme='dark'] .sweep-breakdown-paragraph {
   color: var(--bs-white) !important;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -609,7 +609,7 @@ h2 {
 }
 
 :root[data-theme='dark'] .link-dark {
-  color: var(--bs-white);
+  color: var(--bs-white) !important;
 }
 
 :root[data-theme='dark'] .toast {


### PR DESCRIPTION
Fixes #348.

Updates dependencies. Jam now successfully builds with node `v16.15.1` (and also latest LTS `v16.16.0`) and npm `v8.11.0`.

Updated dependencies:
- react-bootstrap from `v2.4.0` to [`v2.5.0-beta.1`](https://github.com/react-bootstrap/react-bootstrap/releases/tag/v2.5.0-beta.1)
- react-router-bootstrap from `v0.26.1` to [`v0.26.2`](https://github.com/react-bootstrap/react-router-bootstrap/blob/master/CHANGELOG.md#0262-2022-07-11)
- bootstrap from `v5.1.3` to [`v5.2.0`](https://github.com/twbs/bootstrap/releases/tag/v5.2.0)

Removed dependencies:
- moving-letters `v1.0.1` (unused)
