### PR TITLE
feat: fast theme toggle in navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,6 @@ import { CurrentWallet, useCurrentWallet, useCurrentWalletInfo } from '../contex
 import { useServiceInfo, useSessionConnectionError } from '../context/ServiceInfoContext'
 import { routes } from '../constants/routes'
 import { AmountSats } from '../libs/JmWalletApi'
-import { isDebugFeatureEnabled } from '../constants/debugFeatures'
 
 import styles from './Navbar.module.css'
 
@@ -197,11 +196,9 @@ const TrailingNav = ({ joiningRoute, onClick }: TrailingNavProps) => {
           </NavLink>
         </rb.Nav.Item>
       )}
-      {isDebugFeatureEnabled('fastThemeToggle') && (
-        <rb.Nav.Item className="d-none d-md-flex align-items-stretch">
-          <FastThemeToggle />
-        </rb.Nav.Item>
-      )}
+      <rb.Nav.Item className="d-none d-md-flex align-items-stretch">
+        <FastThemeToggle />
+      </rb.Nav.Item>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
           to={routes.settings}
@@ -309,11 +306,9 @@ export default function Navbar() {
                     <span>{t('navbar.menu')}</span>
                   </rb.Navbar.Toggle>
                 </div>
-                {isDebugFeatureEnabled('fastThemeToggle') && (
-                  <rb.Nav.Item className="d-none d-md-flex align-items-center pe-2">
-                    <FastThemeToggle />
-                  </rb.Nav.Item>
-                )}
+                <rb.Nav.Item className="d-none d-md-flex align-items-center pe-2">
+                  <FastThemeToggle />
+                </rb.Nav.Item>
                 <rb.Navbar.Offcanvas className={`navbar-offcanvas navbar-${settings.theme}`} placement="end">
                   <rb.Offcanvas.Header>
                     <rb.Offcanvas.Title>{t('navbar.title')}</rb.Offcanvas.Title>

--- a/src/constants/debugFeatures.ts
+++ b/src/constants/debugFeatures.ts
@@ -7,7 +7,6 @@ interface DebugFeatures {
   importDummyMnemonicPhrase: boolean
   rescanChainPage: boolean
   allowFeeValuesReset: boolean
-  fastThemeToggle: boolean
   enableDemoEarnReport: boolean
   enableDemoOrderbook: boolean
 }
@@ -23,7 +22,6 @@ const debugFeatures: DebugFeatures = {
   importDummyMnemonicPhrase: devMode,
   rescanChainPage: devMode,
   allowFeeValuesReset: devMode,
-  fastThemeToggle: devMode,
   enableDemoEarnReport: devMode,
   enableDemoOrderbook: devMode,
 }


### PR DESCRIPTION
The fast theme toggle button has been present in dev mode for a while now.
@editwentyone What do you think of making it available by default?

![image](https://github.com/user-attachments/assets/d462d09a-d331-49b3-9e50-1636c35db3d3)
![image](https://github.com/user-attachments/assets/b363848d-66ae-475b-abe6-520a26daf041)
