### PR TITLE
feat: added feeconfig handling error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { Logs } from './components/Logs'
 import { Orderbook } from './components/Orderbook'
 import { EarnPage } from './components/earn/EarnPage'
 import { Receive } from './components/receive/Receive'
+import { SendPage } from './components/send/SendPage'
 import { RescanChain } from './components/settings/RescanChain'
 import { Settings } from './components/settings/Settings'
 import { SweepPage } from './components/sweep/SweepPage'
@@ -66,6 +67,16 @@ function App() {
                 <ProtectedRoute authenticated={authenticated}>
                   <Layout>
                     <Receive walletFileName={walletFileName} />
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/send"
+              element={
+                <ProtectedRoute authenticated={authenticated}>
+                  <Layout>
+                    <SendPage walletFileName={walletFileName} />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/src/components/JamLanding.tsx
+++ b/src/components/JamLanding.tsx
@@ -1,14 +1,25 @@
+import { useState } from 'react'
 import { Info, Loader2, RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useStore } from 'zustand'
 import { Jar } from '@/components/layout/Jar'
 import { useJamDisplayContext } from '@/components/layout/display-mode-context'
+import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
+import { FeeConfigErrorAlert } from '@/components/ui/FeeConfigErrorAlert'
+import { FeeConfigTestComponent } from '@/components/ui/FeeConfigTestComponent'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import { authStore } from '@/store/authStore'
 
 export default function JamLanding() {
   const { t } = useTranslation()
+  const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
+  const authState = useStore(authStore, (state) => state.state)
+  const { maxFeesConfigMissing } = useFeeConfigValidation()
+
   const {
     displayMode,
     toggleDisplayMode,
@@ -49,6 +60,12 @@ export default function JamLanding() {
           </Button>
         </div>
       </div>
+
+      {/* Fee Config Error Alert */}
+      {maxFeesConfigMissing && (
+        <FeeConfigErrorAlert onOpenFeeConfig={() => setShowFeeConfigDialog(true)} className="mb-4 max-w-2xl" />
+      )}
+
       {error && (
         <Alert variant="destructive" className="mb-4 max-w-2xl">
           <AlertDescription>
@@ -111,6 +128,18 @@ export default function JamLanding() {
           {t('global.refresh')}
         </Button>
       </div>
+
+      {import.meta.env.DEV && (
+        <div className="mt-8">
+          <FeeConfigTestComponent />
+        </div>
+      )}
+
+      <FeeLimitDialog
+        open={showFeeConfigDialog}
+        onOpenChange={setShowFeeConfigDialog}
+        walletFileName={authState?.walletFileName || ''}
+      />
     </div>
   )
 }

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
+import { FeeConfigErrorAlert } from '@/components/ui/FeeConfigErrorAlert'
+import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 
 interface EarnPageProps {
   walletFileName: string
@@ -7,6 +11,8 @@ interface EarnPageProps {
 
 export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   const { t } = useTranslation()
+  const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
+  const { maxFeesConfigMissing } = useFeeConfigValidation()
 
   if (!walletFileName) {
     return (
@@ -21,6 +27,11 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
       <h1 className="my-2 text-2xl font-semibold tracking-tight">{t('earn.title')}</h1>
       <p className="text-muted-foreground mb-4 text-sm">{t('earn.subtitle')}</p>
 
+      {/* Fee Config Error Alert */}
+      {maxFeesConfigMissing && (
+        <FeeConfigErrorAlert onOpenFeeConfig={() => setShowFeeConfigDialog(true)} className="mb-4" />
+      )}
+
       <div className="light:border-yellow-800 light:bg-yellow-50 rounded-lg border border-yellow-200 bg-yellow-900/20 p-2">
         <div className="flex items-start gap-2">
           <div className="light:text-yellow-800 text-sm text-yellow-200">
@@ -28,10 +39,24 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
               <AlertTriangle className="light:text-yellow-500 m-1 h-4 w-4 shrink-0 text-yellow-200" />
               <p className="text-md font-medium">Under construction</p>
             </div>
-            <p className="p-1 text-xs">Not yet implemented.</p>
+            <p className="p-1 text-xs">
+              Not yet implemented.
+              {maxFeesConfigMissing && (
+                <span className="mt-2 block">
+                  <strong>Note:</strong> Fee configuration is required before earning with collaborative transactions.
+                </span>
+              )}
+            </p>
           </div>
         </div>
       </div>
+
+      {/* Fee Configuration Dialog */}
+      <FeeLimitDialog
+        open={showFeeConfigDialog}
+        onOpenChange={setShowFeeConfigDialog}
+        walletFileName={walletFileName}
+      />
     </div>
   )
 }

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
+import { FeeConfigErrorAlert } from '@/components/ui/FeeConfigErrorAlert'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+
+interface SendPageProps {
+  walletFileName: string
+}
+
+export const SendPage = ({ walletFileName }: SendPageProps) => {
+  const { t } = useTranslation()
+  const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
+
+  const { maxFeesConfigMissing, isLoading, error } = useFeeConfigValidation()
+
+  if (!walletFileName) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center px-4 pt-6">
+        <h1 className="mb-2 text-left text-2xl font-bold">{t('send.title')}</h1>
+        <p className="text-muted-foreground mb-4">{t('current_wallet.error_loading_failed')}</p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center px-4 pt-6">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+        <p className="text-muted-foreground mt-4">{t('send.loading')}</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-3 p-4">
+        <h1 className="my-2 text-2xl font-semibold tracking-tight">{t('send.title')}</h1>
+        <Alert variant="destructive">
+          <AlertDescription>
+            {t('global.errors.error_loading_wallet_failed', {
+              reason: error.message || t('global.errors.reason_unknown'),
+            })}
+          </AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-3 p-4">
+      <h1 className="my-2 text-2xl font-semibold tracking-tight">{t('send.title')}</h1>
+      <p className="text-muted-foreground mb-4 text-sm">{t('send.subtitle')}</p>
+
+      {/* Fee Config Error Alert */}
+      {maxFeesConfigMissing && (
+        <FeeConfigErrorAlert onOpenFeeConfig={() => setShowFeeConfigDialog(true)} className="mb-4" />
+      )}
+
+      {/* Send Form Placeholder */}
+      <Card className="border-0 shadow-sm">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base font-medium">
+            <AlertTriangle className="h-4 w-4 text-yellow-500" />
+            Send Functionality
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="light:border-yellow-800 light:bg-yellow-50 rounded-lg border border-yellow-200 bg-yellow-900/20 p-4">
+            <div className="flex items-start gap-2">
+              <div className="light:text-yellow-800 text-sm text-yellow-200">
+                <div className="flex items-center">
+                  <AlertTriangle className="light:text-yellow-500 m-1 h-4 w-4 shrink-0 text-yellow-200" />
+                  <p className="text-md font-medium">Under construction</p>
+                </div>
+                <p className="p-1 text-xs">
+                  The Send functionality is not yet implemented in this version.
+                  {maxFeesConfigMissing && (
+                    <span className="mt-2 block">
+                      <strong>Note:</strong> Fee configuration is required before sending collaborative transactions.
+                    </span>
+                  )}
+                </p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Fee Configuration Dialog */}
+      <FeeLimitDialog
+        open={showFeeConfigDialog}
+        onOpenChange={setShowFeeConfigDialog}
+        walletFileName={walletFileName}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/FeeConfigErrorAlert.tsx
+++ b/src/components/ui/FeeConfigErrorAlert.tsx
@@ -1,0 +1,25 @@
+import { Settings } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+interface FeeConfigErrorAlertProps {
+  onOpenFeeConfig: () => void
+  className?: string
+}
+
+export const FeeConfigErrorAlert = ({ onOpenFeeConfig, className }: FeeConfigErrorAlertProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Alert variant="destructive" className={className}>
+      <AlertDescription className="flex items-center justify-between">
+        <span>{t('send.taker_error_message_max_fees_config_missing')}</span>
+        <Button variant="outline" size="sm" onClick={onOpenFeeConfig} className="ml-4 shrink-0">
+          <Settings className="mr-2 h-4 w-4" />
+          {t('settings.show_fee_config')}
+        </Button>
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/src/components/ui/FeeConfigTestComponent.tsx
+++ b/src/components/ui/FeeConfigTestComponent.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { useStore } from 'zustand'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { authStore } from '@/store/authStore'
+import { FeeLimitDialog } from '../settings/FeeLimitDialog'
+import { FeeConfigErrorAlert } from './FeeConfigErrorAlert'
+
+export const FeeConfigTestComponent = () => {
+  const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
+  const [forceError, setForceError] = useState(false)
+  const authState = useStore(authStore, (state) => state.state)
+
+  return (
+    <Card className="border-2 border-dashed border-yellow-500 bg-yellow-50 dark:bg-yellow-900/20">
+      <CardHeader>
+        <CardTitle className="text-yellow-700 dark:text-yellow-300">🧪 Fee Config Error Test Component</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-yellow-600 dark:text-yellow-400">
+          This component allows you to test the fee config error handling.
+        </p>
+
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setForceError(!forceError)}
+            className="border-yellow-500 text-yellow-700 hover:bg-yellow-100 dark:text-yellow-300 dark:hover:bg-yellow-800"
+          >
+            {forceError ? 'Hide Error' : 'Show Error'}
+          </Button>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowFeeConfigDialog(true)}
+            className="border-blue-500 text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-800"
+          >
+            Open Fee Config Dialog
+          </Button>
+        </div>
+
+        {/* Force Error Display */}
+        {forceError && <FeeConfigErrorAlert onOpenFeeConfig={() => setShowFeeConfigDialog(true)} className="mt-4" />}
+
+        {/* Fee Configuration Dialog */}
+        <FeeLimitDialog
+          open={showFeeConfigDialog}
+          onOpenChange={setShowFeeConfigDialog}
+          walletFileName={authState?.walletFileName || ''}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/hooks/useFeeConfigValidation.ts
+++ b/src/hooks/useFeeConfigValidation.ts
@@ -1,0 +1,139 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useStore } from 'zustand'
+import { FEE_CONFIG_KEYS } from '@/constants/jm'
+import { useApiClient } from '@/hooks/useApiClient'
+import { configgetOptions } from '@/lib/jm-api/generated/client/@tanstack/react-query.gen'
+import { authStore } from '@/store/authStore'
+
+export interface FeeConfigValues {
+  max_cj_fee_abs?: string
+  max_cj_fee_rel?: string
+  tx_fees?: string
+  tx_fees_factor?: string
+  max_sweep_fee_change?: string
+}
+
+export const useFeeConfigValidation = () => {
+  const client = useApiClient()
+  const authState = useStore(authStore, (state) => state.state)
+  const walletFileName = authState?.walletFileName
+
+  // Debug flag to force fee config missing error for testing
+  const forceFeeConfigMissing = import.meta.env.DEV && import.meta.env.VITE_FORCE_FEE_CONFIG_MISSING === 'true'
+
+  const commonQueryOptions = {
+    enabled: !!walletFileName,
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+  }
+
+  const createConfigQuery = (configKey: keyof typeof FEE_CONFIG_KEYS) => ({
+    ...configgetOptions({
+      client,
+      path: { walletname: walletFileName || '' },
+      body: FEE_CONFIG_KEYS[configKey],
+    }),
+    ...commonQueryOptions,
+  })
+
+  const maxCjFeeAbsQuery = useQuery(createConfigQuery('max_cj_fee_abs'))
+  const maxCjFeeRelQuery = useQuery(createConfigQuery('max_cj_fee_rel'))
+  const txFeesQuery = useQuery(createConfigQuery('tx_fees'))
+  const txFeesFactorQuery = useQuery(createConfigQuery('tx_fees_factor'))
+  const maxSweepFeeChangeQuery = useQuery(createConfigQuery('max_sweep_fee_change'))
+
+  const feeConfigValues = useMemo<FeeConfigValues | undefined>(() => {
+    if (
+      !maxCjFeeAbsQuery.data &&
+      !maxCjFeeRelQuery.data &&
+      !txFeesQuery.data &&
+      !txFeesFactorQuery.data &&
+      !maxSweepFeeChangeQuery.data
+    ) {
+      return undefined
+    }
+
+    return {
+      max_cj_fee_abs: maxCjFeeAbsQuery.data?.configvalue,
+      max_cj_fee_rel: maxCjFeeRelQuery.data?.configvalue,
+      tx_fees: txFeesQuery.data?.configvalue,
+      tx_fees_factor: txFeesFactorQuery.data?.configvalue,
+      max_sweep_fee_change: maxSweepFeeChangeQuery.data?.configvalue,
+    }
+  }, [
+    maxCjFeeAbsQuery.data,
+    maxCjFeeRelQuery.data,
+    txFeesQuery.data,
+    txFeesFactorQuery.data,
+    maxSweepFeeChangeQuery.data,
+  ])
+
+  const maxFeesConfigMissing = useMemo(() => {
+    // Debug: Force the error for testing
+    if (forceFeeConfigMissing) {
+      return true
+    }
+
+    return (
+      feeConfigValues && (feeConfigValues.max_cj_fee_abs === undefined || feeConfigValues.max_cj_fee_rel === undefined)
+    )
+  }, [feeConfigValues, forceFeeConfigMissing])
+
+  const isLoading = useMemo(() => {
+    return (
+      maxCjFeeAbsQuery.isLoading ||
+      maxCjFeeRelQuery.isLoading ||
+      txFeesQuery.isLoading ||
+      txFeesFactorQuery.isLoading ||
+      maxSweepFeeChangeQuery.isLoading
+    )
+  }, [
+    maxCjFeeAbsQuery.isLoading,
+    maxCjFeeRelQuery.isLoading,
+    txFeesQuery.isLoading,
+    txFeesFactorQuery.isLoading,
+    maxSweepFeeChangeQuery.isLoading,
+  ])
+
+  const error = useMemo(() => {
+    return (
+      maxCjFeeAbsQuery.error ||
+      maxCjFeeRelQuery.error ||
+      txFeesQuery.error ||
+      txFeesFactorQuery.error ||
+      maxSweepFeeChangeQuery.error
+    )
+  }, [
+    maxCjFeeAbsQuery.error,
+    maxCjFeeRelQuery.error,
+    txFeesQuery.error,
+    txFeesFactorQuery.error,
+    maxSweepFeeChangeQuery.error,
+  ])
+
+  const refetchAll = () => {
+    maxCjFeeAbsQuery.refetch()
+    maxCjFeeRelQuery.refetch()
+    txFeesQuery.refetch()
+    txFeesFactorQuery.refetch()
+    maxSweepFeeChangeQuery.refetch()
+  }
+
+  return {
+    feeConfigValues,
+    maxFeesConfigMissing,
+    isLoading,
+    error,
+    refetchAll,
+    queries: {
+      maxCjFeeAbsQuery,
+      maxCjFeeRelQuery,
+      txFeesQuery,
+      txFeesFactorQuery,
+      maxSweepFeeChangeQuery,
+    },
+  }
+}


### PR DESCRIPTION
currently I added it on landing page to check because send is under construction and comment the function to understand implemention.
## To test
comment out 
```
jmenv['max_cj_fee_abs']=${jmenv['max_cj_fee_abs']:-"$(shuf -i 5000-10000 -n1)"}
# `max_cj_fee_rel` between 0.01 - 0.03% if not provided
jmenv['max_cj_fee_rel']=${jmenv['max_cj_fee_rel']:-"0.000$((RANDOM%3+1))"}
```

https://github.com/user-attachments/assets/8703e2eb-f530-49ff-9b1d-302500d90401

fix: #959 