### PR TITLE
refactor: currency symbol and amount format

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ function App() {
               element={
                 <ProtectedRoute authenticated={authenticated}>
                   <Layout>
-                    <JamLanding />
+                    <JamLanding walletFileName={walletFileName!} />
                   </Layout>
                 </ProtectedRoute>
               }

--- a/src/components/CurrencySymbol.tsx
+++ b/src/components/CurrencySymbol.tsx
@@ -1,19 +1,29 @@
 import { EyeOff } from 'lucide-react'
 import type { Currency } from '@/hooks/useDisplaySettings'
+import { cn } from '@/lib/utils'
 
-type DisplayLogoProps = {
+type CurrencySymbolProps = {
   currency: Currency
   isPrivate?: boolean
   size?: 'sm' | 'lg'
 }
 
-export function DisplayLogo({ currency, isPrivate, size = 'lg' }: DisplayLogoProps) {
+export function CurrencySymbol({ currency, isPrivate, size = 'lg' }: CurrencySymbolProps) {
   if (isPrivate) {
     return <EyeOff size={size === 'sm' ? 16 : 24} className="inline-block align-middle" />
   }
 
   if (currency === 'btc') {
-    return <span className={`px-1 ${size === 'sm' ? 'text-md' : 'text-4xl'}`}>₿</span>
+    return (
+      <span
+        className={cn('px-1', {
+          'text-md': size === 'sm',
+          'text-4xl': size === 'lg',
+        })}
+      >
+        ₿
+      </span>
+    )
   }
 
   return (

--- a/src/components/CurrencySymbol.tsx
+++ b/src/components/CurrencySymbol.tsx
@@ -29,8 +29,8 @@ export function CurrencySymbol({ currency, isPrivate, size = 'lg' }: CurrencySym
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width={size === 'sm' ? '16px' : '30px'}
-      height={size === 'sm' ? '18px' : '40px'}
+      width={size === 'sm' ? '16px' : '48px'}
+      height={size === 'sm' ? '18px' : '48px'}
       viewBox="0 0 24 24"
       fill="none"
       style={{

--- a/src/components/CurrencySymbol.tsx
+++ b/src/components/CurrencySymbol.tsx
@@ -10,13 +10,13 @@ type CurrencySymbolProps = {
 
 export function CurrencySymbol({ currency, isPrivate, size = 'lg' }: CurrencySymbolProps) {
   if (isPrivate) {
-    return <EyeOff size={size === 'sm' ? 16 : 24} className="inline-block align-middle" />
+    return <EyeOff size={size === 'sm' ? 14 : 24} className="mx-1 inline-block align-middle" />
   }
 
   if (currency === 'btc') {
     return (
       <span
-        className={cn('px-1', {
+        className={cn('mx-1', {
           'text-md': size === 'sm',
           'text-4xl': size === 'lg',
         })}
@@ -30,12 +30,13 @@ export function CurrencySymbol({ currency, isPrivate, size = 'lg' }: CurrencySym
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={size === 'sm' ? '16px' : '48px'}
-      height={size === 'sm' ? '18px' : '48px'}
+      height={size === 'sm' ? '16px' : '48px'}
       viewBox="0 0 24 24"
       fill="none"
       style={{
         display: 'inline',
         verticalAlign: 'middle',
+        margin: size === 'sm' ? '0 -1px' : '0 -8px',
       }}
     >
       <path d="M7 7.90906H17" stroke="currentColor" />

--- a/src/components/JamLanding.tsx
+++ b/src/components/JamLanding.tsx
@@ -6,8 +6,14 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { WalletFileName } from '@/lib/utils'
+import { walletDisplayName } from '@/lib/utils'
 
-export default function JamLanding() {
+interface JamLandingProps {
+  walletFileName: WalletFileName
+}
+
+export default function JamLanding({ walletFileName }: JamLandingProps) {
   const { t } = useTranslation()
 
   const {
@@ -26,21 +32,16 @@ export default function JamLanding() {
   return (
     <div className="flex flex-col items-center justify-center py-8">
       <div className="mb-8 text-center">
-        <div className="text-lg text-gray-400 opacity-80">{currency === 'btc' ? 'Bitcoin' : 'Satoshi'}</div>
+        <div className="text-lg text-gray-400 opacity-80">{walletDisplayName(walletFileName)}</div>
         <div className="mb-2 flex min-h-[56px] items-center justify-center text-4xl font-light tracking-wider select-none">
           {isLoading ? (
             <div className="flex min-h-[56px] items-center justify-center">
               <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
             </div>
           ) : (
-            <div onClick={() => toggleDisplayMode()} className="flex cursor-pointer items-center gap-2">
-              <span
-                title={currency === 'btc' ? t('settings.use_sats') : t('settings.use_btc')}
-                className="text-center tabular-nums"
-              >
-                {formatAmount(totalBalance)}{' '}
-              </span>
-              <span className="flex min-h-[48px] items-center">{currencySymbol('lg')}</span>
+            <div onClick={() => toggleDisplayMode()} className="flex cursor-pointer items-center gap-1">
+              <span className="tabular-nums">{formatAmount(totalBalance)} </span>
+              <span className="flex items-center">{currencySymbol('lg')}</span>
             </div>
           )}
         </div>

--- a/src/components/JamLanding.tsx
+++ b/src/components/JamLanding.tsx
@@ -15,7 +15,7 @@ export default function JamLanding() {
     toggleDisplayMode,
     isPrivate,
     formatAmount,
-    getLogo,
+    currencySymbol,
     jars,
     totalBalance,
     isLoading,
@@ -40,7 +40,7 @@ export default function JamLanding() {
               >
                 {formatAmount(totalBalance)}{' '}
               </span>
-              <span className="flex min-h-[48px] items-center">{getLogo('lg')}</span>
+              <span className="flex min-h-[48px] items-center">{currencySymbol('lg')}</span>
             </div>
           )}
         </div>

--- a/src/components/JamLanding.tsx
+++ b/src/components/JamLanding.tsx
@@ -16,18 +16,8 @@ interface JamLandingProps {
 export default function JamLanding({ walletFileName }: JamLandingProps) {
   const { t } = useTranslation()
 
-  const {
-    currency,
-    toggleDisplayMode,
-    isPrivate,
-    formatAmount,
-    currencySymbol,
-    jars,
-    totalBalance,
-    isLoading,
-    error,
-    refetchWalletData,
-  } = useJamDisplayContext()
+  const { toggleDisplayMode, formatAmount, currencySymbol, jars, totalBalance, isLoading, error, refetchWalletData } =
+    useJamDisplayContext()
 
   return (
     <div className="flex flex-col items-center justify-center py-8">
@@ -39,7 +29,7 @@ export default function JamLanding({ walletFileName }: JamLandingProps) {
               <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
             </div>
           ) : (
-            <div onClick={() => toggleDisplayMode()} className="flex cursor-pointer items-center gap-1">
+            <div onClick={() => toggleDisplayMode()} className="flex cursor-pointer items-center">
               <span className="tabular-nums">{formatAmount(totalBalance)} </span>
               <span className="flex items-center">{currencySymbol('lg')}</span>
             </div>
@@ -93,8 +83,7 @@ export default function JamLanding({ walletFileName }: JamLandingProps) {
                       name={jar.name}
                       amount={jar.balance}
                       color={jar.color}
-                      currency={currency}
-                      isPrivate={isPrivate}
+                      currencySymbol={currencySymbol}
                       formatAmount={formatAmount}
                       totalBalance={totalBalance}
                     />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import { useStore } from 'zustand'
 import type { Jar } from '@/components/layout/display-mode-context'
 import { Button } from '@/components/ui/button'
 import { isDevMode } from '@/constants/debugFeatures'
-import { cn } from '@/lib/utils'
+import { cn, walletDisplayName } from '@/lib/utils'
 import { authStore } from '@/store/authStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
 import { DevBadge } from './ui/DevBadge'
@@ -41,9 +41,11 @@ export function Navbar({ theme, toggleTheme, formatAmount, currencySymbol, jars,
   const { t } = useTranslation()
   const navigate = useNavigate()
   const jmSessionState = useStore(jmSessionStore, (state) => state.state)
+  const { state: authState, clear: clearAuth } = useStore(authStore, (state) => state)
+  const walletFileName = useMemo(() => authState?.walletFileName, [authState])
 
   const handleLogout = async () => {
-    authStore.getState().clear()
+    clearAuth()
     await navigate('/login')
   }
 
@@ -62,7 +64,9 @@ export function Navbar({ theme, toggleTheme, formatAmount, currencySymbol, jars,
           </div>
           <div className="flex flex-col">
             <div className="flex items-center gap-2">
-              <div className="font-semibold tracking-tight">Satoshi</div>
+              <div className="font-semibold tracking-tight">
+                {walletFileName ? walletDisplayName(walletFileName) : '...'}
+              </div>
               {isDevMode() && <DevBadge />}
             </div>
             <div className="flex min-h-6 min-w-[150px] items-center">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -70,7 +70,7 @@ export function Navbar({ theme, toggleTheme, formatAmount, currencySymbol, jars,
                 <Skeleton className="h-4 w-full bg-neutral-200 dark:bg-neutral-600" />
               ) : (
                 <>
-                  <div className="tabular-nums">{formatAmount(totalBalance)}</div>
+                  <span className="tabular-nums">{formatAmount(totalBalance)}</span>
                   {currencySymbol('sm')}
                 </>
               )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -17,7 +17,7 @@ interface NavbarProps {
   theme: string
   toggleTheme: () => void
   formatAmount: (amount: number) => string
-  getLogo: (size: 'sm' | 'lg') => React.ReactNode
+  currencySymbol: (size: 'sm' | 'lg') => React.ReactNode
   jars: Jar[]
   isLoading?: boolean
 }
@@ -37,7 +37,7 @@ const WithActivityIndicator = ({ active, children }: PropsWithChildren<{ active:
   )
 }
 
-export function Navbar({ theme, toggleTheme, formatAmount, getLogo, jars, isLoading = false }: NavbarProps) {
+export function Navbar({ theme, toggleTheme, formatAmount, currencySymbol, jars, isLoading = false }: NavbarProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const jmSessionState = useStore(jmSessionStore, (state) => state.state)
@@ -71,7 +71,7 @@ export function Navbar({ theme, toggleTheme, formatAmount, getLogo, jars, isLoad
               ) : (
                 <>
                   <div className="tabular-nums">{formatAmount(totalBalance)}</div>
-                  {getLogo('sm')}
+                  {currencySymbol('sm')}
                 </>
               )}
             </div>

--- a/src/components/layout/Jar.tsx
+++ b/src/components/layout/Jar.tsx
@@ -1,27 +1,25 @@
-import type { Currency } from '@/hooks/useDisplaySettings'
-import { CurrencySymbol } from '../CurrencySymbol'
 import { JarIcon } from '../ui/JarIcon'
 
 interface JarProps {
   name: string
   amount: number
   color: '#e2b86a' | '#3b5ba9' | '#c94f7c' | '#a67c52' | '#7c3fa6'
-  currency: Currency
-  isPrivate: boolean
   formatAmount: (amount: number) => string
+  currencySymbol: (size: 'sm' | 'lg') => React.ReactNode
   totalBalance?: number
 }
 
-export function Jar({ name, amount, color, currency, isPrivate, formatAmount, totalBalance = 0 }: JarProps) {
+export function Jar({ name, amount, color, currencySymbol, formatAmount, totalBalance = 0 }: JarProps) {
   return (
     <div className="flex cursor-pointer flex-col items-center transition-all duration-300 hover:scale-105">
       <div className="mb-2">
         <JarIcon amount={amount} totalBalance={totalBalance} color={color} />
       </div>
       <p className="text-center text-sm">{name}</p>
-      <p className="min-w-[110px] text-center text-xs tabular-nums">
-        {formatAmount(amount)} <CurrencySymbol currency={currency} isPrivate={isPrivate} size="sm" />
-      </p>
+      <div className="flex min-w-[110px] items-center justify-center text-sm">
+        <span className="tabular-nums">{formatAmount(amount)}</span>
+        {currencySymbol('sm')}
+      </div>
     </div>
   )
 }

--- a/src/components/layout/Jar.tsx
+++ b/src/components/layout/Jar.tsx
@@ -1,5 +1,5 @@
 import type { Currency } from '@/hooks/useDisplaySettings'
-import { DisplayLogo } from '../DisplayLogo'
+import { CurrencySymbol } from '../CurrencySymbol'
 import { JarIcon } from '../ui/JarIcon'
 
 interface JarProps {
@@ -20,7 +20,7 @@ export function Jar({ name, amount, color, currency, isPrivate, formatAmount, to
       </div>
       <p className="text-center text-sm">{name}</p>
       <p className="min-w-[110px] text-center text-xs tabular-nums">
-        {formatAmount(amount)} <DisplayLogo currency={currency} isPrivate={isPrivate} size="sm" />
+        {formatAmount(amount)} <CurrencySymbol currency={currency} isPrivate={isPrivate} size="sm" />
       </p>
     </div>
   )

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from 'next-themes'
-import { DisplayLogo } from '@/components/DisplayLogo'
+import { CurrencySymbol } from '@/components/CurrencySymbol'
 import { Footer } from '@/components/Footer'
 import { Navbar } from '@/components/Navbar'
 import { useDisplaySettings } from '@/hooks/useDisplaySettings'
@@ -26,7 +26,7 @@ export function Layout({ children }: LayoutProps) {
     togglePrivacyMode,
     toggleDisplayMode,
     formatAmount,
-    getLogo: (size: 'sm' | 'lg' = 'lg') => <DisplayLogo currency={currency} isPrivate={isPrivate} size={size} />,
+    getLogo: (size: 'sm' | 'lg' = 'lg') => <CurrencySymbol currency={currency} isPrivate={isPrivate} size={size} />,
     jars,
     totalBalance,
     walletName,
@@ -42,7 +42,7 @@ export function Layout({ children }: LayoutProps) {
           theme={resolvedTheme || 'dark'}
           toggleTheme={toggleTheme}
           formatAmount={formatAmount}
-          getLogo={(size) => <DisplayLogo currency={currency} isPrivate={isPrivate} size={size} />}
+          getLogo={(size) => <CurrencySymbol currency={currency} isPrivate={isPrivate} size={size} />}
           jars={jars}
           isLoading={isLoading}
         />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -26,7 +26,9 @@ export function Layout({ children }: LayoutProps) {
     togglePrivacyMode,
     toggleDisplayMode,
     formatAmount,
-    getLogo: (size: 'sm' | 'lg' = 'lg') => <CurrencySymbol currency={currency} isPrivate={isPrivate} size={size} />,
+    currencySymbol: (size: 'sm' | 'lg' = 'lg') => (
+      <CurrencySymbol currency={currency} isPrivate={isPrivate} size={size} />
+    ),
     jars,
     totalBalance,
     walletName,
@@ -42,7 +44,7 @@ export function Layout({ children }: LayoutProps) {
           theme={resolvedTheme || 'dark'}
           toggleTheme={toggleTheme}
           formatAmount={formatAmount}
-          getLogo={(size) => <CurrencySymbol currency={currency} isPrivate={isPrivate} size={size} />}
+          currencySymbol={displayModeValue.currencySymbol}
           jars={jars}
           isLoading={isLoading}
         />

--- a/src/components/layout/display-mode-context.ts
+++ b/src/components/layout/display-mode-context.ts
@@ -29,7 +29,7 @@ export interface DisplayModeContextType {
   togglePrivacyMode: () => void
   toggleDisplayMode: () => void
   formatAmount: (amount: number) => string
-  getLogo: (size?: 'sm' | 'lg') => ReactNode
+  currencySymbol: (size?: 'sm' | 'lg') => ReactNode
   jars: Jar[]
   totalBalance: number
   walletName: string | null

--- a/src/components/receive/BitcoinAmountInput.tsx
+++ b/src/components/receive/BitcoinAmountInput.tsx
@@ -1,6 +1,6 @@
 import { ArrowUpDown } from 'lucide-react'
 import type { Currency } from '@/hooks/useDisplaySettings'
-import { DisplayLogo } from '../DisplayLogo'
+import { CurrencySymbol } from '../CurrencySymbol'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 
@@ -30,7 +30,7 @@ export const BitcoinAmountInput = ({
         <div className="relative flex-1">
           <div onClick={toggleCurrencyUnit} className="absolute inset-y-0 left-0 flex items-center px-1">
             <span className="px-1 text-gray-500">
-              <DisplayLogo currency={currency} isPrivate={isPrivate} size="sm" />
+              <CurrencySymbol currency={currency} isPrivate={isPrivate} size="sm" />
             </span>
           </div>
           <Input

--- a/src/components/settings/TxFeeInputField.tsx
+++ b/src/components/settings/TxFeeInputField.tsx
@@ -4,7 +4,7 @@ import { BlocksIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Input } from '@/components/ui/input'
 import { txFeeUnit, type TxFeeUnit } from '@/constants/jm'
-import { DisplayLogo } from '../DisplayLogo'
+import { CurrencySymbol } from '../CurrencySymbol'
 
 export interface TxFeeInputFieldProps {
   value: string
@@ -79,7 +79,7 @@ export const TxFeeInputField = ({
             <BlocksIcon className="h4 w-4" />
           ) : (
             <>
-              <DisplayLogo currency="sats" size="sm" />
+              <CurrencySymbol currency="sats" size="sm" />
               <span className="text-xs text-nowrap">/&nbsp;vB</span>
             </>
           )}

--- a/src/components/ui/Balance.tsx
+++ b/src/components/ui/Balance.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { DisplayLogo } from '@/components/DisplayLogo'
+import { CurrencySymbol } from '@/components/CurrencySymbol'
 import { useJamDisplayContext } from '@/components/layout/display-mode-context'
 import type { Currency } from '@/hooks/useDisplaySettings'
 import { cn, satsToBtc, btcToSats, isValidNumber, formatBtc, formatSats, SATS, BTC } from '@/lib/utils'
@@ -24,9 +24,9 @@ const getDisplayMode = (
   return currency
 }
 
-const BTC_SYMBOL = <DisplayLogo currency="btc" size="sm" />
+const BTC_SYMBOL = <CurrencySymbol currency="btc" size="sm" />
 
-const SAT_SYMBOL = <DisplayLogo currency="sats" size="sm" />
+const SAT_SYMBOL = <CurrencySymbol currency="sats" size="sm" />
 
 const FROZEN_SYMBOL = (
   <span data-testid="frozen-symbol" className="ml-1 text-blue-400">
@@ -34,7 +34,7 @@ const FROZEN_SYMBOL = (
   </span>
 )
 
-const HIDE_SYMBOL = <DisplayLogo currency="sats" isPrivate={true} size="sm" />
+const HIDE_SYMBOL = <CurrencySymbol currency="sats" isPrivate={true} size="sm" />
 
 interface BalanceComponentProps {
   symbol?: React.ReactNode

--- a/src/components/ui/SelectableJar.tsx
+++ b/src/components/ui/SelectableJar.tsx
@@ -1,4 +1,4 @@
-import { DisplayLogo } from '../DisplayLogo'
+import { CurrencySymbol } from '../CurrencySymbol'
 import { JarIcon } from './JarIcon'
 
 interface SelectableJarProps {
@@ -23,7 +23,7 @@ export const SelectableJar = ({ name, color, balance, totalBalance, isSelected, 
 
       <span className="text-xs">{name}</span>
       <div className="flex items-center font-mono text-[10px] text-gray-500">
-        <DisplayLogo currency="sats" size="sm" />
+        <CurrencySymbol currency="sats" size="sm" />
         <span>{balance.toLocaleString()}</span>
       </div>
       <div className="flex items-center">

--- a/src/hooks/useDisplaySettings.ts
+++ b/src/hooks/useDisplaySettings.ts
@@ -64,7 +64,7 @@ export function useDisplaySettings() {
   const formatAmount = useCallback(
     (amount: number): string => {
       if (isPrivate) {
-        return '****'
+        return '■■■■'
       }
 
       if (currency === 'btc') {

--- a/src/stories/Jar.stories.tsx
+++ b/src/stories/Jar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CurrencySymbol } from '@/components/CurrencySymbol'
 import { Jar } from '@/components/layout/Jar'
 import type { Currency } from '@/hooks/useDisplaySettings'
 
@@ -27,8 +28,7 @@ export const Sats: Story = {
     name: 'Savings Jar',
     amount: 15000000,
     color: '#e2b86a',
-    currency: 'sats',
-    isPrivate: false,
+    currencySymbol: (size: 'sm' | 'lg') => <CurrencySymbol size={size} currency="sats" />,
     formatAmount: () => formatAmount(15000000, 'sats'),
     totalBalance: 50000000,
   },
@@ -39,8 +39,7 @@ export const BTC: Story = {
     name: 'Main Jar',
     amount: 20000000,
     color: '#3b5ba9',
-    currency: 'btc',
-    isPrivate: false,
+    currencySymbol: (size: 'sm' | 'lg') => <CurrencySymbol size={size} currency="btc" />,
     formatAmount: () => formatAmount(20000000, 'btc'),
     totalBalance: 50000000,
   },
@@ -51,8 +50,7 @@ export const Empty: Story = {
     name: 'Empty Jar',
     amount: 0,
     color: '#c94f7c',
-    currency: 'sats',
-    isPrivate: false,
+    currencySymbol: (size: 'sm' | 'lg') => <CurrencySymbol size={size} currency="sats" />,
     formatAmount: () => formatAmount(0, 'sats'),
     totalBalance: 50000000,
   },
@@ -63,8 +61,7 @@ export const Full: Story = {
     name: 'Full Jar',
     amount: 50000000,
     color: '#a67c52',
-    currency: 'sats',
-    isPrivate: false,
+    currencySymbol: (size: 'sm' | 'lg') => <CurrencySymbol size={size} currency="sats" />,
     formatAmount: () => formatAmount(50000000, 'sats'),
     totalBalance: 100000000,
   },

--- a/src/stories/Navbar.stories.tsx
+++ b/src/stories/Navbar.stories.tsx
@@ -21,7 +21,7 @@ export default meta
 type Story = StoryObj<typeof Navbar>
 
 const mockFormatAmount = (amount: number) => `${amount} sats`
-const mockGetLogo = (size: 'sm' | 'lg') => <Bitcoin size={size === 'sm' ? 18 : 32} />
+const mockCurrencySymbol = (size: 'sm' | 'lg') => <Bitcoin size={size === 'sm' ? 18 : 32} />
 const mockJars = [
   { name: 'Apricot', balance: 12345, color: '#e2b86a' as JarColor },
   { name: 'Blueberry', balance: 67890, color: '#3b5ba9' as JarColor },
@@ -32,7 +32,7 @@ export const Default: Story = {
     theme: 'light',
     toggleTheme: () => alert('Theme toggled!'),
     formatAmount: mockFormatAmount,
-    getLogo: mockGetLogo,
+    currencySymbol: mockCurrencySymbol,
     jars: mockJars,
   },
 }


### PR DESCRIPTION
Small refactoring:
- proper names for currency symbol (`DisplayLogo` -> `CurrencySymbol`, `getLogo` -> `currencySymbol`)
- small improvements to formatting (e.g. vertically centered smybol for "private" balance) -> still needs love
- display wallet name on landing page and navbar