### PR TITLE
feat: Add support for 24-word mnemonic phrases and fix API headers

### DIFF
--- a/src/components/ImportWallet.tsx
+++ b/src/components/ImportWallet.tsx
@@ -29,6 +29,7 @@ type ImportWalletDetailsFormValues = {
   mnemonicPhrase: MnemonicPhrase
   blockheight: number
   gaplimit: number
+  phraseLength: number
 }
 
 const GAPLIMIT_SUGGESTIONS = {
@@ -69,11 +70,13 @@ const initialImportWalletDetailsFormValues: ImportWalletDetailsFormValues = isDe
       mnemonicPhrase: new Array<string>(12).fill(''),
       blockheight: MIN_BLOCKHEIGHT_VALUE,
       gaplimit: GAPLIMIT_SUGGESTIONS.heavy,
+      phraseLength: 12,
     }
   : {
       mnemonicPhrase: new Array<string>(12).fill(''),
       blockheight: SEGWIT_ACTIVATION_BLOCK,
       gaplimit: GAPLIMIT_SUGGESTIONS.normal,
+      phraseLength: 12,
     }
 
 interface ImportWalletDetailsFormProps {
@@ -100,7 +103,11 @@ const ImportWalletDetailsForm = ({
     (values: ImportWalletDetailsFormValues) => {
       const errors = {} as FormikErrors<ImportWalletDetailsFormValues>
       const isMnemonicPhraseValid = values.mnemonicPhrase.every((it) => it.length > 0)
-      if (!isMnemonicPhraseValid) {
+      if (
+        !values.mnemonicPhrase ||
+        values.mnemonicPhrase.length !== values.phraseLength ||
+        values.mnemonicPhrase.some((w) => !w || w.trim().length === 0)
+      ) {
         errors.mnemonicPhrase = t('import_wallet.import_details.feedback_invalid_menmonic_phrase')
       }
 
@@ -145,6 +152,27 @@ const ImportWalletDetailsForm = ({
         const showGaplimitWarning = !errors.gaplimit && values.gaplimit > GAPLIMIT_WARN_THRESHOLD
         return (
           <rb.Form onSubmit={handleSubmit} noValidate lang={i18n.resolvedLanguage || i18n.language}>
+            <rb.Form.Group className="mb-3">
+              <rb.Form.Label>Seed phrase length</rb.Form.Label>
+              <div>
+                {[12, 24].map((len) => (
+                  <rb.Form.Check
+                    inline
+                    key={len}
+                    type="radio"
+                    id={`phrase-length-${len}`}
+                    name="phraseLength"
+                    label={`${len} words`}
+                    checked={values.phraseLength === len}
+                    onChange={() => {
+                      setFieldValue('phraseLength', len, true)
+                      setFieldValue('mnemonicPhrase', new Array(len).fill(''), true)
+                    }}
+                    disabled={isSubmitting}
+                  />
+                ))}
+              </div>
+            </rb.Form.Group>
             <MnemonicPhraseInput
               mnemonicPhrase={values.mnemonicPhrase}
               onChange={(val) => setFieldValue('mnemonicPhrase', val, true)}
@@ -165,7 +193,12 @@ const ImportWalletDetailsForm = ({
               <rb.Button
                 variant="outline-dark"
                 className="w-100 mb-4 position-relative"
-                onClick={() => setFieldValue('mnemonicPhrase', DUMMY_MNEMONIC_PHRASE, true)}
+                onClick={() => {
+                  const dummy = Array(values.phraseLength)
+                    .fill('')
+                    .map((_, i) => DUMMY_MNEMONIC_PHRASE[i % DUMMY_MNEMONIC_PHRASE.length])
+                  setFieldValue('mnemonicPhrase', dummy, true)
+                }}
                 disabled={isSubmitting}
               >
                 Fill with dummy mnemonic phrase
@@ -457,7 +490,10 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
 
       try {
         // Step #1: recover wallet
-        const recoverResponse = await Api.postWalletRecover({ signal }, { walletname, password, seedphrase })
+        const recoverResponse = await Api.postWalletRecover(
+          { signal },
+          { walletname, password, seedphrase, wallettype: 'sw-fb' },
+        )
         const recoverBody = await (recoverResponse.ok ? recoverResponse.json() : Api.Helper.throwError(recoverResponse))
 
         const { walletname: walletFileName } = recoverBody

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -263,7 +263,7 @@ const getSession = async ({ token, signal }: ApiRequestContext & { token?: ApiTo
 
 const postToken = async ({ signal, token }: AuthApiRequestContext, req: TokenRequest) => {
   return await fetch(`${basePath()}/v1/token`, {
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     method: 'POST',
     body: JSON.stringify(req),
     signal,
@@ -300,6 +300,7 @@ const postWalletCreate = async ({ signal }: ApiRequestContext, req: CreateWallet
 
   return await fetch(`${basePath()}/v1/wallet/create`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...req, walletname, wallettype: req.wallettype || 'sw-fb' }),
     signal,
   })
@@ -310,6 +311,7 @@ const postWalletRecover = async ({ signal }: ApiRequestContext, req: RecoverWall
 
   return await fetch(`${basePath()}/v1/wallet/recover`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...req, walletname, wallettype: req.wallettype || 'sw-fb' }),
     signal,
   })
@@ -348,6 +350,7 @@ const postWalletUnlock = async (
 ) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/unlock`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ password }),
     signal,
   })
@@ -363,7 +366,7 @@ const getWalletUtxos = async ({ token, signal, walletFileName }: WalletRequestCo
 const postMakerStart = async ({ token, signal, walletFileName }: WalletRequestContext, req: StartMakerRequest) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/maker/start`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify({
       ...req,
       // We enforce type-safety for the following properties, but their values must actually be passed as string!
@@ -391,7 +394,7 @@ const getMakerStop = async ({ token, signal, walletFileName }: WalletRequestCont
 const postDirectSend = async ({ token, signal, walletFileName }: WalletRequestContext, req: DirectSendRequest) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/taker/direct-send`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify(req),
     signal,
   })
@@ -400,7 +403,7 @@ const postDirectSend = async ({ token, signal, walletFileName }: WalletRequestCo
 const postCoinjoin = async ({ token, signal, walletFileName }: WalletRequestContext, req: DoCoinjoinRequest) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/taker/coinjoin`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify(req),
     signal,
   })
@@ -440,7 +443,7 @@ const postFreeze = async (
 ) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/freeze`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify({
       'utxo-string': utxo,
       freeze,
@@ -455,7 +458,7 @@ const postSchedulerStart = async (
 ) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/taker/schedule`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify({ ...req }),
     signal,
   })
@@ -481,7 +484,7 @@ const getSchedule = async ({ token, signal, walletFileName }: WalletRequestConte
 const postConfigSet = async ({ token, signal, walletFileName }: WalletRequestContext, req: ConfigSetRequest) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/configset`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify(req),
     signal,
   })
@@ -495,7 +498,7 @@ const postConfigSet = async ({ token, signal, walletFileName }: WalletRequestCon
 const postConfigGet = async ({ token, signal, walletFileName }: WalletRequestContext, req: ConfigGetRequest) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/configget`, {
     method: 'POST',
-    headers: { ...Helper.buildAuthHeader(token) },
+    headers: { 'Content-Type': 'application/json', ...Helper.buildAuthHeader(token) },
     body: JSON.stringify(req),
     signal,
   })


### PR DESCRIPTION
## Summary

This PR adds support for importing wallets using 24-word mnemonic phrases (in addition to the existing 12-word support) and fixes missing `Content-Type` headers in API requests that were causing 400 Bad Request errors.

## Changes

### 1. **24-Word Mnemonic Support** (`ImportWallet.tsx`)
- Added a radio button selector to choose between 12-word and 24-word mnemonic phrases
- Added `phraseLength` field to form state to track the selected phrase length
- Updated mnemonic validation to properly validate variable-length phrases
- Improved dummy mnemonic generation to work with both 12 and 24-word phrases
- Added `wallettype: 'sw-fb'` parameter to the wallet recovery API call

### 2. **API Header Fixes** (`JmWalletApi.ts`)
- Added missing `Content-Type: application/json` headers to all POST requests:
  - `/v1/token`
  - `/v1/wallet/create`
  - `/v1/wallet/recover`
  - `/v1/wallet/{walletFileName}/unlock`
  - `/v1/wallet/{walletFileName}/maker/start`
  - `/v1/wallet/{walletFileName}/taker/direct-send`
  - `/v1/wallet/{walletFileName}/taker/coinjoin`
  - `/v1/wallet/{walletFileName}/freeze`
  - `/v1/wallet/{walletFileName}/taker/schedule`
  - `/v1/wallet/{walletFileName}/configset`
  - `/v1/wallet/{walletFileName}/configget`

## Motivation

- **24-word support**: BIP39 standard supports both 12 and 24-word mnemonic phrases. Users with 24-word phrases were unable to import their wallets.
- **API headers**: The JoinMarket API expects `Content-Type: application/json` headers for POST requests with JSON bodies. Missing headers were causing 400 Bad Request errors during wallet operations.

## Testing

- [x] Manually tested importing wallet with 12-word mnemonic phrase
- [x] Manually tested importing wallet with 24-word mnemonic phrase
- [x] Verified API requests now include proper Content-Type headers
- [x] Code formatted with Prettier (pre-commit hook)

