### PR TITLE
Add log viewer overlay

### DIFF
--- a/src/components/LogsContent.tsx
+++ b/src/components/LogsContent.tsx
@@ -1,0 +1,212 @@
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
+import { AlertTriangleIcon, Loader2Icon, RefreshCwIcon, DownloadIcon, ArrowDownIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useStore } from 'zustand'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { isDevMode } from '@/constants/debugFeatures'
+import { fetchLog } from '@/lib/api/logs'
+import { cn, delayedPromise } from '@/lib/utils'
+import { authStore } from '@/store/authStore'
+
+const JMWALLETD_LOG_FILE_NAME = 'jmwalletd_stdout.log'
+
+interface SimpleAlert {
+  variant: React.ComponentProps<typeof Alert>['variant']
+  message: string
+}
+
+interface LogViewerProps {
+  value: string
+  refresh: (signal: AbortSignal) => Promise<void>
+}
+
+function LogViewer({ value, refresh }: LogViewerProps) {
+  const { t } = useTranslation()
+  const logContentRef = useRef<HTMLPreElement>(null)
+  const [isLoadingRefresh, setIsLoadingRefresh] = useState(false)
+  const [logScrollProgress, setLogScrollProgress] = useState(0)
+  const isScrolledToLogBottom = useMemo(() => logScrollProgress >= 0.995, [logScrollProgress])
+
+  const scrollToLogBottom = () => {
+    logContentRef.current?.scrollTo({
+      top: logContentRef.current.scrollHeight,
+      behavior: 'smooth',
+    })
+  }
+
+  const logScrollHandler = (event: React.UIEvent<HTMLPreElement>) => {
+    const containerHeight = event.currentTarget.clientHeight
+    const scrollHeight = event.currentTarget.scrollHeight
+
+    const scrollTop = event.currentTarget.scrollTop
+    setLogScrollProgress((scrollTop + containerHeight) / scrollHeight)
+  }
+
+  useEffect(() => {
+    if (!value) return
+    scrollToLogBottom()
+  }, [value])
+
+  const handleRefresh = useCallback(async () => {
+    if (isLoadingRefresh) return
+
+    setIsLoadingRefresh(true)
+    const abortCtrl = new AbortController()
+
+    try {
+      await refresh(abortCtrl.signal).then(() => delayedPromise(210))
+    } finally {
+      setIsLoadingRefresh(false)
+    }
+  }, [isLoadingRefresh, refresh])
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([value], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = JMWALLETD_LOG_FILE_NAME
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    setTimeout(() => {
+      URL.revokeObjectURL(url)
+    }, 0)
+  }, [value])
+
+  return (
+    <Card className="flex flex-1 flex-col overflow-hidden pb-0">
+      <CardHeader className="flex flex-col justify-center gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <CardTitle className="font-mono break-all">{JMWALLETD_LOG_FILE_NAME}</CardTitle>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            className="hover:[&>svg]:motion-safe:animate-bounce"
+            variant="outline"
+            onClick={handleDownload}
+            disabled={!value || isLoadingRefresh}
+            title={t('global.download')}
+          >
+            <DownloadIcon className="group/download" />
+            {t('global.download')}
+          </Button>
+          <Button variant="outline" onClick={handleRefresh} disabled={isLoadingRefresh} title={t('global.refresh')}>
+            <RefreshCwIcon
+              className={cn({
+                'animate-spin': isLoadingRefresh,
+              })}
+            />
+            {t('global.refresh')}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="relative flex-1 overflow-hidden rounded-b-xl p-0">
+        <pre
+          onScrollEnd={logScrollHandler}
+          ref={logContentRef}
+          className="bg-muted/90 absolute inset-0 overflow-auto rounded-b-xl px-2 py-2 font-mono text-sm break-words whitespace-pre-wrap"
+        >
+          {value}
+        </pre>
+        <Button
+          className={cn('absolute top-2 right-2 size-12', {
+            'opacity-25 hover:opacity-50': !isScrolledToLogBottom,
+            hidden: isScrolledToLogBottom,
+          })}
+          variant={isScrolledToLogBottom ? 'ghost' : 'default'}
+          disabled={isScrolledToLogBottom}
+          size="icon"
+          onClick={scrollToLogBottom}
+          title={/* TODO: i18n */ 'Scroll to bottom'}
+        >
+          <ArrowDownIcon />
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface LogsContentProps {
+  className?: string
+  enabled: boolean
+}
+
+export const LogsContent = ({ enabled, className }: LogsContentProps) => {
+  const authState = useStore(authStore, (state) => state.state)
+  const { t } = useTranslation()
+  const [alert, setAlert] = useState<SimpleAlert>()
+  const [isInitialized, setIsInitialized] = useState(false)
+  const [logFileContent, setLogFileContent] = useState<string>()
+
+  const refresh = useCallback(
+    async (signal: AbortSignal) => {
+      if (!authState?.auth?.token) {
+        setAlert({
+          variant: 'destructive',
+          message: 'No authentication token available. Please login again.',
+        })
+        return Promise.reject(new Error('No authentication token'))
+      }
+
+      return fetchLog({
+        token: authState.auth.token,
+        fileName: JMWALLETD_LOG_FILE_NAME,
+        signal,
+      })
+        .then((res) => (res.ok ? res.text() : Promise.reject(new Error(`HTTP ${res.status}`))))
+        .then((data) => {
+          if (signal.aborted) return
+          setAlert(undefined)
+          setLogFileContent(data)
+        })
+        .catch((e) => {
+          if (signal.aborted) return
+
+          const errorMessage = t('logs.error_loading_logs_failed', {
+            reason: e.message || t('global.errors.reason_unknown'),
+          })
+
+          if (isDevMode()) {
+            setLogFileContent(`${errorMessage}\n`.repeat(1_000))
+          }
+
+          setAlert({
+            variant: 'warning',
+            message: errorMessage,
+          })
+        })
+    },
+    [t, authState],
+  )
+
+  if (enabled && !isInitialized) {
+    const abortCtrl = new AbortController()
+    refresh(abortCtrl.signal).finally(() => {
+      if (abortCtrl.signal.aborted) return
+      setIsInitialized(true)
+    })
+  }
+
+  if (!isInitialized) {
+    return (
+      <div className={cn('flex items-center justify-center gap-2', className)}>
+        <Loader2Icon className="h-4 w-4 animate-spin motion-reduce:hidden" />
+        {t('global.loading')}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      {alert && (
+        <Alert variant={alert.variant}>
+          <AlertTriangleIcon />
+          <AlertDescription>{alert.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {logFileContent && <LogViewer value={logFileContent} refresh={refresh} />}
+    </div>
+  )
+}

--- a/src/components/LogsOverlay.tsx
+++ b/src/components/LogsOverlay.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import PageTitle from '@/components/ui/jam/PageTitle'
+import type { WithRequiredProperty } from '@/types/global'
+import { LogsContent } from './LogsContent'
+
+type LogsOverlayProps = WithRequiredProperty<Omit<ComponentProps<typeof Dialog>, 'children'>, 'open' | 'onOpenChange'>
+
+export function LogsOverlay({ open, onOpenChange }: LogsOverlayProps) {
+  const { t } = useTranslation()
+  return (
+    <Dialog open={open} onOpenChange={() => onOpenChange(false)}>
+      <DialogContent className="data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom flex h-screen max-w-screen! flex-col rounded-none border-none">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <PageTitle title={t('logs.title')} />
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="overflow-hidden">
+          <LogsContent enabled={open} className="flex h-full flex-col" />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -1,5 +1,5 @@
 import { useState, type ComponentProps } from 'react'
-import { AlertTriangleIcon, BlocksIcon, BookOpenIcon, FileQuestionMarkIcon } from 'lucide-react'
+import { AlertTriangleIcon, BlocksIcon, BookOpenIcon, FileQuestionMarkIcon, ScrollTextIcon } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
 import { useStore } from 'zustand'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -50,6 +50,7 @@ type AppFooterProps = Pick<BetaWarningModalProps, 'jamVersion' | 'joinmarketVers
   websocketInfo?: JmWebsocketInfo
   onClickCheatsheet: () => void
   onClickOrderbook: () => void
+  onClickLogs: () => void
 }
 
 export function AppFooter({
@@ -58,6 +59,7 @@ export function AppFooter({
   joinmarketVersion,
   onClickCheatsheet,
   onClickOrderbook,
+  onClickLogs,
 }: AppFooterProps) {
   const { t } = useTranslation()
 
@@ -89,6 +91,10 @@ export function AppFooter({
           <Button variant="outline" size="sm" onClick={onClickOrderbook} title={t('footer.orderbook')}>
             <BookOpenIcon />
             <span className="hidden sm:inline-block">{t('footer.orderbook')}</span>
+          </Button>
+          <Button variant="outline" size="sm" onClick={onClickLogs} title={t('footer.logs')}>
+            <ScrollTextIcon />
+            <span className="hidden sm:inline-block">{t('footer.logs')}</span>
           </Button>
         </div>
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -17,6 +17,7 @@ import { useJmWebsocket } from '@/hooks/useJmWebsocket'
 import { useQueryJmInfo } from '@/hooks/useQueryJmInfo'
 import type { WalletFileName } from '@/lib/utils'
 import { jmSessionStore } from '@/store/jmSessionStore'
+import { LogsOverlay } from '../LogsOverlay'
 import { OrderbookOverlay } from '../orderbook/OrderbookOverlay'
 import { Cheatsheet } from '../ui/jam/Cheatsheet'
 import { AppSidebar } from './AppSidebar'
@@ -49,6 +50,7 @@ export function LayoutInner({ onLogout, onLockWallet, children }: LayoutInnerPro
 
   const cheatsheet = useCheatsheet()
   const [isOrderbookOverlayOpen, setIsOrderbookOverlayOpen] = useState(false)
+  const [isLogsOverlayOpen, setIsLogsOverlayOpen] = useState(false)
 
   return (
     <div className="light:bg-white light:text-black flex min-h-screen flex-1 flex-col bg-[#181b20] text-white transition-colors duration-300">
@@ -74,10 +76,12 @@ export function LayoutInner({ onLogout, onLockWallet, children }: LayoutInnerPro
         joinmarketVersion={joinmarketVersion}
         onClickCheatsheet={() => cheatsheet.onOpenChange(true)}
         onClickOrderbook={() => setIsOrderbookOverlayOpen(true)}
+        onClickLogs={() => setIsLogsOverlayOpen(true)}
       />
 
       <Cheatsheet open={cheatsheet.open} onOpenChange={cheatsheet.onOpenChange} />
       <OrderbookOverlay open={isOrderbookOverlayOpen} onOpenChange={setIsOrderbookOverlayOpen} />
+      <LogsOverlay open={isLogsOverlayOpen} onOpenChange={setIsLogsOverlayOpen} />
     </div>
   )
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -62,7 +62,8 @@
     "cheatsheet": "Cheatsheet",
     "websocket_connected": "Websocket connected",
     "websocket_disconnected": "Websocket disconnected",
-    "orderbook": "Orderbook"
+    "orderbook": "Orderbook",
+    "logs": "Logs"
   },
   "onboarding": {
     "splashscreen_title": "Jam",

--- a/src/stories/jam/AppFooter.stories.tsx
+++ b/src/stories/jam/AppFooter.stories.tsx
@@ -28,6 +28,7 @@ export const Default: Story = {
       joinmarketVersion={toSemVer('0.9.12')}
       onClickCheatsheet={() => alert('Cheatsheet clicked!')}
       onClickOrderbook={() => alert('Orderbook clicked!')}
+      onClickLogs={() => alert('Logs clicked!')}
     />
   ),
 }


### PR DESCRIPTION
Adds a logs button in the footer that opens a full-screen overlay to view jmwalletd logs. Follows the same pattern as the orderbook overlay