### PR TITLE
fidelity bond auto select jar

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog.tsx
+++ b/src/components/earn/CreateFidelityBondDialog.tsx
@@ -224,8 +224,8 @@ export const CreateFidelityBondDialog = ({ open, onOpenChange, walletFileName }:
         setStep('select_date')
         break
       case 'select_utxos':
-        setStep('select_jar')
         setSelectedUtxos([])
+        setStep('select_jar')
         break
       case 'freeze_utxos':
         setStep('select_utxos')
@@ -244,7 +244,12 @@ export const CreateFidelityBondDialog = ({ open, onOpenChange, walletFileName }:
     setError(undefined)
     switch (step) {
       case 'select_date':
-        setStep('select_jar')
+        if (jarsWithUtxos.length === 1) {
+          setSelectedJarIndex(jarsWithUtxos[0].jarIndex)
+          setStep('select_utxos')
+        } else {
+          setStep('select_jar')
+        }
         break
       case 'select_jar':
         setStep('select_utxos')


### PR DESCRIPTION
#1023 
when user clicks next after selecting lockdate, if only one jar has UTXOs, it auto selects that jar and skips directly to UTXO selection
When user clicks Back from UTXO selection with auto selected jar, returns to date selection (not jar selection)