### PR TITLE
chore: wait for utxos to be spent and other small improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,9 @@ import { LockWalletConfirmDialog } from './components/ui/jam/LockWalletConfirmDi
 import { Spinner } from './components/ui/spinner'
 import { WalletJarsDetailsPage } from './components/wallet/WalletJarsDetailsPage'
 import { JamSessionInfoContextProvider } from './context/JamSessionInfoContextProvider'
+import { useJmWebsocket } from './hooks/useJmWebsocket'
 import { jmSessionStore } from './store/jmSessionStore'
+import { jmTxStore, type JmTxInfo } from './store/jmTxStore'
 
 const DevSetupPage = lazy(() => import('@/components/dev/DevSetupPage'))
 const DevPage = lazy(() => import('@/components/dev/DevPage'))
@@ -219,6 +221,7 @@ function App() {
         <QueryClientProvider client={queryClient}>
           <RefreshApiToken />
           <RefreshJmSession />
+          <HandleJmWebsocketMessages />
           {walletFileName && <LoadFeeConfigData walletFileName={walletFileName} />}
           {lockWalletDialogContext && (
             <LockWalletConfirmDialog
@@ -313,6 +316,54 @@ function RefreshJmSession() {
   useRefreshSession({
     enabled: true,
     refetchInterval: JAM_JM_SESSION_REFRESH_INTERVAL,
+  })
+
+  return <></>
+}
+
+type JmTxWebsocketMessage = { txid: string; txdetails: JmTxInfo }
+function isJmTxWebsocketMessage(val: unknown): val is JmTxWebsocketMessage {
+  return (
+    !!val &&
+    typeof val === 'object' &&
+    'txid' in val &&
+    typeof val['txid'] === 'string' &&
+    val['txid']?.length === 64 &&
+    'txdetails' in val &&
+    typeof val['txdetails'] === 'object' &&
+    !!val['txdetails'] &&
+    'txid' in val['txdetails'] &&
+    typeof val['txdetails']['txid'] === 'string' &&
+    val['txdetails']?.['txid'] === val['txid'] &&
+    true
+  )
+}
+
+const onWebsocketMessage = (message: unknown) => {
+  if (isJmTxWebsocketMessage(message)) {
+    jmTxStore.getState().add(message.txdetails)
+  }
+}
+
+function HandleJmWebsocketMessages() {
+  useJmWebsocket({
+    enableHeartbeat: false,
+    options: {
+      onMessage(messageEvent) {
+        const message: unknown = (() => {
+          try {
+            return messageEvent?.data ? (JSON.parse(String(messageEvent.data)) as unknown) : undefined
+          } catch (_ignoredOnPurpose) {
+            console.warn('Error parsing websocket message', messageEvent.data)
+            return undefined
+          }
+        })()
+
+        if (message !== undefined && message !== null) {
+          onWebsocketMessage(message)
+        }
+      },
+    },
   })
 
   return <></>

--- a/src/components/create/CreateWalletForm.tsx
+++ b/src/components/create/CreateWalletForm.tsx
@@ -27,17 +27,17 @@ const createFormSchema = (wallets: WalletFileName[], t: TFunction) => {
         .string()
         .trim()
         .max(MAX_WALLET_NAME_LENGTH)
-        .required()
+        .required(t('create_wallet.feedback_invalid_wallet_name'))
         .test('valid-wallet-name-test', t('create_wallet.feedback_invalid_wallet_name'), (value) => {
           return /^[\w-]+$/.test(value)
         })
         .test('valid-wallet-name-exists-test', t('create_wallet.feedback_wallet_name_already_exists'), (value) => {
           return !wallets.includes((value + JM_WALLET_FILE_EXTENSION) as WalletFileName)
         }),
-      password: yup.string().min(1).required(),
+      password: yup.string().min(1).required(t('create_wallet.feedback_invalid_password')),
       confirmPassword: yup
         .string()
-        .required()
+        .required(t('create_wallet.feedback_invalid_password_confirm'))
         .test(
           'valid-confirm-password-test',
           t('create_wallet.feedback_invalid_password_confirm'),
@@ -133,9 +133,7 @@ export const CreateWalletForm = ({
             </InputGroupAddon>
           </InputGroup>
         </Field>
-        {errors.password && (
-          <div className="text-destructive text-xs">{t('create_wallet.feedback_invalid_password')}</div>
-        )}
+        {errors.password?.message && <div className="text-destructive text-xs">{errors.password.message}</div>}
       </div>
 
       <div className="space-y-2">
@@ -168,8 +166,8 @@ export const CreateWalletForm = ({
             </InputGroupAddon>
           </InputGroup>
         </Field>
-        {errors.confirmPassword && (
-          <div className="text-destructive text-xs">{t('create_wallet.feedback_invalid_password_confirm')}</div>
+        {errors.confirmPassword?.message && (
+          <div className="text-destructive text-xs">{errors.confirmPassword?.message}</div>
         )}
       </div>
 

--- a/src/components/dev/DevPage.tsx
+++ b/src/components/dev/DevPage.tsx
@@ -14,6 +14,7 @@ import { authStore } from '@/store/authStore'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
 import { jmConfigStore } from '@/store/jmConfigStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
+import { jmTxStore } from '@/store/jmTxStore'
 import { DevBadge } from './DevBadge'
 
 interface DevConfigTabContentProps {
@@ -25,6 +26,7 @@ function DevConfigTabContent({ walletFileName }: DevConfigTabContentProps) {
   const jmSession = useStore(jmSessionStore, (state) => state.state)
   const jamSettingsState = useStore(jamSettingsStore, (state) => state.state)
   const jmConfigStoreState = useStore(jmConfigStore, (state) => state.state)
+  const jmTxStoreState = useStore(jmTxStore, (state) => state.state)
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
 
   const feeConfig = useFeeConfigValidation({ walletFileName: walletFileName ?? 'None.jmdat' })
@@ -51,6 +53,10 @@ function DevConfigTabContent({ walletFileName }: DevConfigTabContentProps) {
       <div className="overflow-scroll">
         <code className="light:text-red-700 text-red-800">useStore(jamSettingsStore):</code>
         <pre className="text-xs">{JSON.stringify(jamSettingsState, null, 2)}</pre>
+      </div>
+      <div className="overflow-scroll">
+        <code className="light:text-red-700 text-red-800">useStore(jmTxStore):</code>
+        <pre className="text-xs">{JSON.stringify(jmTxStoreState, null, 2)}</pre>
       </div>
 
       {feeConfig && walletFileName && (

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondDialogSteps.tsx
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondDialogSteps.tsx
@@ -440,7 +440,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                       successText={<CheckIcon className="h-4 w-4 text-green-500" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                       onSuccess={() => toast.success(t('receive.text_copy_address'))}
-                      onError={() => toast.error(t('global.errors.reason_unknown'))}
+                      onError={() => toast.error(t('receive.error_copy_address_failed'))}
                     />
                   </div>
                 </div>
@@ -524,7 +524,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                     successText={<CheckIcon className="h-4 w-4 text-green-500" />}
                     className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                     onSuccess={() => toast.success(t('receive.text_copy_address'))}
-                    onError={() => toast.error(t('global.errors.reason_unknown'))}
+                    onError={() => toast.error(t('receive.error_copy_address_failed'))}
                   />
                 </div>
               </div>
@@ -548,7 +548,10 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                     onSuccess={() =>
                       toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))
                     }
-                    onError={() => toast.error(t('global.errors.reason_unknown'))}
+                    onError={(error) => {
+                      const reason = (error instanceof Error ? error.message : undefined) || t('global.errors.reason_unknown')
+                      toast.error(t('global.errors.error_copy_to_clipboard_failed', { reason }))
+                    }}
                   />
                 </div>
               </div>

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { startmakerMutation, stopmakerOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { ErrorMessage, StartMakerRequest } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -88,59 +88,55 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     refetchDelay: WAIT_FOR_UPDATE_SESSION_POLLING_DELAY,
   })
 
-  const stopMakerQueryOptions = useMemo(
-    () =>
-      stopmakerOptions({
-        client,
-        path: { walletname: encodeURIComponent(walletFileName) },
-      }),
-    [client, walletFileName],
-  )
+  const stopMakerQueryOptions = stopmakerOptions({
+    client,
+    path: { walletname: encodeURIComponent(walletFileName) },
+  })
 
   const stopMakerQuery = useQuery({
     ...stopMakerQueryOptions,
     queryFn: withQueryDelay(stopMakerQueryOptions.queryFn, {
       delayAfter: MAKER_STOP_RESPONSE_DELAY,
     }),
-    staleTime: 1,
-    gcTime: 1,
     enabled: false,
     retry: false,
+  })
+
+  // wrap as mutation manually, as `stopMakerQuery` is a `GET` request
+  const stopMaker = useMutation({
+    mutationFn: async () => {
+      return await stopMakerQuery.refetch({ throwOnError: true })
+    },
+    retry: false,
+    onMutate: () => {
+      setIsWaitingMakerStop(true)
+      toast.info(t('earn.alert_stopping'), { id: 'earn.alert_stopping' })
+    },
+    onError: (error: ErrorMessage) => {
+      setIsWaitingMakerStop(false)
+      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      // TODO: i18n
+      toast.error(`Error while stopping the earn process. Reason: ${reason}`)
+    },
   })
 
   const startMaker = useMutation({
     ...startmakerMutation({ client }),
     retry: false,
-    onSuccess: () => {
+    onMutate: () => {
       setIsWaitingMakerStart(true)
       toast.info(t('earn.alert_starting'), { id: 'earn.alert_starting' })
     },
     onError: (error: ErrorMessage) => {
       setIsWaitingMakerStart(false)
       console.error('StartMaker error:', error)
-      const reason = error.message ?? error.error_description ?? t('global.errors.reason_unknown')
+      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
       toast.error(t('earn.alert_start_failed', { reason }))
     },
   })
 
   const onStop = async () => {
-    try {
-      toast.info(t('earn.alert_stopping'), { id: 'earn.alert_stopping' })
-      await stopMakerService()
-    } catch (error: unknown) {
-      const reason = error instanceof Error ? error.message : undefined
-      toast.error(reason ?? t('global.errors.reason_unknown'))
-    }
-  }
-
-  const stopMakerService = async () => {
-    setIsWaitingMakerStop(true)
-    try {
-      await stopMakerQuery.refetch()
-    } catch (error: unknown) {
-      setIsWaitingMakerStop(false)
-      throw error
-    }
+    await stopMaker.mutateAsync()
   }
 
   const onSubmit: SubmitHandler<EarnFormValues> = async (data) => {
@@ -174,7 +170,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
       scrollToTop()
     }
   } else {
-    if (isWaitingMakerStop && !stopMakerQuery.isFetching) {
+    if (isWaitingMakerStop && !stopMaker.isPending) {
       setIsWaitingMakerStop(false)
       toast.dismiss('earn.alert_stopping')
       toast.dismiss('earn.alert_starting')

--- a/src/components/layout/AppNavbar.tsx
+++ b/src/components/layout/AppNavbar.tsx
@@ -33,6 +33,7 @@ const WithActivityIndicator = ({ active, children }: PropsWithChildren<{ active:
 
 type WalletPreviewProps = {
   isLoading?: boolean
+  isReloading?: boolean
   walletName: string | null
   formatAmount: (AmountSats: number) => string
   currencySymbol: (size: 'sm' | 'lg') => React.ReactNode
@@ -46,6 +47,7 @@ const WalletPreview = ({
   currencySymbol,
   totalBalance,
   isLoading = false,
+  isReloading = false,
   rescanInfo,
 }: WalletPreviewProps) => {
   const { t } = useTranslation()
@@ -55,7 +57,7 @@ const WalletPreview = ({
     <div className="flex flex-1 items-center">
       <Link to={routes.home} className="flex items-center gap-2">
         <div className="flex h-8 w-8 items-center">
-          {isLoading ? (
+          {isLoading || isReloading ? (
             <Spinner className="text-muted-foreground size-6 motion-reduce:hidden" strokeWidth={3} />
           ) : (
             <WalletIcon strokeWidth={1} />
@@ -115,6 +117,7 @@ type AppNavbarProps = WalletPreviewProps & {
 
 export function AppNavbar({
   isLoading = false,
+  isReloading = false,
   walletName,
   totalBalance,
   theme,
@@ -162,6 +165,7 @@ export function AppNavbar({
     <header className="light:bg-gray-100 light:text-black flex items-center justify-between bg-[#23262b] px-4 py-2 text-white transition-colors duration-300">
       <WalletPreview
         isLoading={isLoading}
+        isReloading={isReloading}
         walletName={walletName}
         totalBalance={totalBalance}
         formatAmount={formatAmount}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -47,7 +47,9 @@ export function LayoutInner({ onLogout, onLockWallet, children }: LayoutInnerPro
 
   const sidebarContext = useSidebar()
 
-  const websocket = useJmWebsocket()
+  const websocket = useJmWebsocket({
+    enableHeartbeat: true,
+  })
 
   const cheatsheet = useCheatsheet()
   const [isOrderbookOverlayOpen, setIsOrderbookOverlayOpen] = useState(false)

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -43,7 +43,7 @@ export function LayoutInner({ onLogout, onLockWallet, children }: LayoutInnerPro
   const toggleTheme = () => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
 
   const { formatAmount, currencySymbol } = useJamDisplayContext()
-  const { walletBalanceSummary, walletName, isFetching } = useJamWalletInfoContext()
+  const { walletBalanceSummary, walletName, isLoading, isFetching } = useJamWalletInfoContext()
 
   const sidebarContext = useSidebar()
 
@@ -73,7 +73,8 @@ export function LayoutInner({ onLogout, onLockWallet, children }: LayoutInnerPro
     <div className="light:bg-white light:text-black flex min-h-screen flex-1 flex-col bg-[#181b20] text-white transition-colors duration-300">
       <AppNavbar
         theme={resolvedTheme}
-        isLoading={isFetching}
+        isLoading={isLoading}
+        isReloading={isFetching}
         rescanInfo={rescanStatus.rescanInfo}
         walletName={walletName}
         totalBalance={walletBalanceSummary.calculatedTotalBalanceInSats}

--- a/src/components/receive/ReceiveForm.tsx
+++ b/src/components/receive/ReceiveForm.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
+import type { TFunction } from 'i18next'
 import { useForm, useWatch, type Resolver, type SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import * as yup from 'yup'
@@ -23,28 +24,33 @@ const FieldPrefixSatSymbol = (
   />
 )
 
-const receiveFormSchema = (jars: Jar[]) => {
+const receiveFormSchema = (jars: Jar[], t: TFunction) => {
+  const invalidSourceJarFeedbackMessage = t('receive.feedback_invalid_source_jar', {
+    /* TODO: i18n: remove defaultValue and add key to language files */
+    defaultValue: 'Please select a source jar.',
+  })
+
   return yup
     .object({
       source: yup
         .object({
           fromJar: yup
             .number()
-            .integer()
-            .test('valid-source-jar-index-test', 'Invalid source jar index.', (value) =>
+            .integer(invalidSourceJarFeedbackMessage)
+            .required(invalidSourceJarFeedbackMessage)
+            .test('valid-source-jar-index-test', invalidSourceJarFeedbackMessage, (value) =>
               jars.some((it) => it.jarIndex === value),
-            )
-            .required(),
+            ),
         })
         .required(),
       amount: yup
         .object({
           amount: yup
             .number()
-            .integer()
-            .min(1)
-            .max(21_000_000 * 100_000_000)
-            .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+            .integer(t('receive.feedback_invalid_amount'))
+            .min(1, t('receive.feedback_invalid_amount'))
+            .max(21_000_000 * 100_000_000, t('receive.feedback_invalid_amount'))
+            .transform((value) => (Number.isNaN(value) ? null : Number(value)))
             .nullable()
             .optional(),
         })
@@ -66,7 +72,7 @@ export const ReceiveForm = ({ className, defaultValues, onSubmit, jars, disabled
   const { t } = useTranslation()
   const { walletBalanceSummary } = useWalletBalanceSummary()
 
-  const schema = useMemo(() => receiveFormSchema(jars), [jars])
+  const schema = useMemo(() => receiveFormSchema(jars, t), [jars, t])
 
   const {
     control,
@@ -107,10 +113,13 @@ export const ReceiveForm = ({ className, defaultValues, onSubmit, jars, disabled
             ))}
           </div>
         </Field>
+        {errors.source?.fromJar?.message && (
+          <div className="text-destructive text-xs">{errors.source.fromJar.message}</div>
+        )}
       </div>
 
       <div className="space-y-2">
-        <Field data-invalid={errors.amount?.amount !== undefined}>
+        <Field data-invalid={errors.amount !== undefined}>
           <FieldLabel htmlFor="receive-amount">{t('receive.label_amount_input')}</FieldLabel>
           <InputGroup>
             <InputGroupInput
@@ -127,8 +136,8 @@ export const ReceiveForm = ({ className, defaultValues, onSubmit, jars, disabled
             <InputGroupAddon align="inline-start">{FieldPrefixSatSymbol}</InputGroupAddon>
           </InputGroup>
         </Field>
-        {errors.amount?.amount && (
-          <div className="text-destructive text-xs">{t('receive.feedback_invalid_amount')}</div>
+        {errors.amount?.amount?.message && (
+          <div className="text-destructive text-xs">{errors.amount.amount.message}</div>
         )}
       </div>
 

--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
-import { getaddressOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
-import { useQuery } from '@tanstack/react-query'
-import { CopyCheckIcon, CopyIcon, RefreshCwIcon, ShareIcon } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { getaddressQueryKey } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import { getaddress, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { useMutation } from '@tanstack/react-query'
+import { CopyCheckIcon, CopyIcon, HatGlassesIcon, RefreshCwIcon, ShareIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useStore } from 'zustand'
@@ -12,10 +13,10 @@ import PageTitle from '@/components/ui/jam/PageTitle'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useJars } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
-import { withQueryDelay } from '@/lib/queryClient'
+import { withMutationDelay } from '@/lib/queryClient'
 import { cn, type WalletFileName } from '@/lib/utils'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
-import type { AmountSats, BitcoinAddress, Milliseconds } from '@/types/global'
+import type { AmountSats, BitcoinAddress } from '@/types/global'
 import { Badge } from '../ui/badge'
 import { buttonVariants } from '../ui/button-variants'
 import { CopyButton } from '../ui/jam/CopyButton'
@@ -23,12 +24,6 @@ import { BitcoinQR } from './BitcoinQR'
 import { ReceiveForm } from './ReceiveForm'
 
 const QRCODE_WIDTH = 320 // "h-[320px] w-[320px]" <- Comment for tailwind importer (ADAPT THE COMMENT IF YOU CHANGE THE VALUE)
-
-// new-address query stale time considerations:
-// - high enough to prevent increasing address gap on accidental page switch
-// - low enough to provide new address on purpose
-// - "too low" is better than "too high"
-const GET_ADDRESS_QUERY_TALE_TIME: Milliseconds = 10_000
 
 interface ReceivePageProps {
   walletFileName: WalletFileName
@@ -38,17 +33,17 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
   const { t } = useTranslation()
   const { jars } = useJars()
 
-  const [sourceJarIndex, setSourceJarIndex] = useState(jars.length > 0 ? jars[0].jarIndex : undefined)
+  const [selectedSourceJarIndex, setSelectedSourceJarIndex] = useState(jars.length > 0 ? jars[0].jarIndex : undefined)
   const [amount, setAmount] = useState<AmountSats>()
 
-  const sourceJar = useMemo(() => {
-    if (sourceJarIndex === undefined) return
-    return jars[sourceJarIndex]
-  }, [jars, sourceJarIndex])
+  const selectedSourceJar = useMemo(() => {
+    if (selectedSourceJarIndex === undefined) return
+    return jars[selectedSourceJarIndex]
+  }, [jars, selectedSourceJarIndex])
 
   const [receiveFormDefaultValues] = useState({
     source: {
-      fromJar: sourceJar?.jarIndex,
+      fromJar: selectedSourceJar?.jarIndex,
     },
     amount: {
       amount: undefined,
@@ -59,33 +54,45 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
 
   const client = useApiClient()
 
-  const getAddressQueryOptions = getaddressOptions({
+  const getAddressOptions = {
     client,
     path: {
       walletname: encodeURIComponent(walletFileName),
-      mixdepth: String(sourceJar?.jarIndex),
+      mixdepth: String(selectedSourceJar?.jarIndex),
+    },
+  }
+
+  // wrap as mutation manually, as `getAddressQuery` is a `GET` request
+  const getAddressMutation = useMutation({
+    mutationKey: ['receive', ...getaddressQueryKey(getAddressOptions)],
+    mutationFn: withMutationDelay(
+      async () => {
+        const { data } = await getaddress({
+          ...getAddressOptions,
+          throwOnError: true,
+        })
+        return {
+          address: data.address,
+          sourceJarIndex: Number.parseInt(getAddressOptions.path.mixdepth, 10),
+        }
+      },
+      {
+        delayAfter: 21,
+      },
+    ),
+    retry: false,
+    gcTime: Number.POSITIVE_INFINITY,
+    onError: (error: ErrorMessage) => {
+      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      // TODO: add reason to i18n
+      toast.error(t('receive.error_loading_address_failed', { reason }))
     },
   })
 
-  const getAddressQuery = useQuery({
-    ...getAddressQueryOptions,
-    queryFn: withQueryDelay(getAddressQueryOptions.queryFn, {
-      delayAfter: 21,
-    }),
-    enabled: walletFileName !== undefined && sourceJarIndex !== undefined,
-    staleTime: GET_ADDRESS_QUERY_TALE_TIME,
-    retry: false,
-    retryOnMount: false,
-    refetchOnMount: true,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
-  })
-
-  useEffect(() => {
-    if (getAddressQuery.error) {
-      toast.error(t('receive.error_loading_address_failed'))
-    }
-  }, [getAddressQuery.error, t])
+  const sourceJar = useMemo(() => {
+    if (getAddressMutation.data?.sourceJarIndex === undefined) return
+    return jars[getAddressMutation.data.sourceJarIndex]
+  }, [jars, getAddressMutation.data])
 
   const shareAddress = async (bitcoinAddress: BitcoinAddress) => {
     if ('share' in navigator) {
@@ -102,9 +109,9 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
     }
   }
 
-  const getNewAddress = useCallback(async () => {
-    await getAddressQuery.refetch()
-  }, [getAddressQuery])
+  const fetchNewAddress = async () => {
+    await getAddressMutation.mutateAsync()
+  }
 
   return (
     <div className="mx-auto max-w-4xl space-y-3 p-4">
@@ -112,19 +119,35 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
 
       <Card>
         <CardContent className="flex w-full flex-col items-center justify-center gap-2">
-          {getAddressQuery.isFetching ? (
+          {getAddressMutation.isPending ? (
             <Skeleton className={`h-[${QRCODE_WIDTH}px] w-[${QRCODE_WIDTH}px]`} />
-          ) : getAddressQuery.data?.address ? (
+          ) : getAddressMutation.data?.address ? (
             <BitcoinQR
               className="animate-in fade-in duration-1000"
-              address={getAddressQuery.data.address}
+              address={getAddressMutation.data.address}
               amount={amount}
               width={QRCODE_WIDTH}
             />
+          ) : getAddressMutation.isIdle ? (
+            <div
+              className={cn('flex items-center justify-center border', `h-[${QRCODE_WIDTH}px] w-[${QRCODE_WIDTH}px]`)}
+            >
+              <Button
+                variant="outline"
+                size="lg"
+                onClick={() => void fetchNewAddress()}
+                disabled={getAddressMutation.isPending}
+              >
+                <HatGlassesIcon />
+                {t('receive.button_reveal_address', {
+                  defaultValue: 'Reveal address',
+                })}
+              </Button>
+            </div>
           ) : (
             <div
               className={cn(
-                'flex animate-pulse items-center justify-center border text-gray-500',
+                'text-destructive flex items-center justify-center border text-sm',
                 `h-[${QRCODE_WIDTH}px] w-[${QRCODE_WIDTH}px]`,
               )}
             >
@@ -132,16 +155,24 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
             </div>
           )}
 
-          {getAddressQuery.isFetching ? (
-            <>
+          {getAddressMutation.isPending ? (
+            <div className="flex flex-col items-center space-y-2">
               <Skeleton className="mt-0.5 h-5 w-[24rem]" />
               <Skeleton className="h-6 w-[84px]" />
-            </>
+            </div>
           ) : (
             <div className="animate-in fade-in space-y-2 text-center duration-1000">
-              <p className="font-mono text-sm break-all select-all">{getAddressQuery.data?.address}</p>
-              <Badge className="text-sm" variant="default">
-                {sourceJar?.name} <span className="text-xs">#{sourceJar?.jarIndex}</span>
+              <div className="min-h-5 font-mono text-sm break-all select-all">{getAddressMutation.data?.address}</div>
+              <Badge className="min-h-6 text-sm" variant={sourceJar ? 'default' : 'secondary'}>
+                {sourceJar ? (
+                  <>
+                    {sourceJar.name} <span className="text-xs">#{sourceJar.jarIndex}</span>
+                  </>
+                ) : (
+                  <>
+                    {selectedSourceJar?.name} <span className="text-xs">#{selectedSourceJar?.jarIndex}</span>
+                  </>
+                )}
               </Badge>
             </div>
           )}
@@ -150,10 +181,10 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => void getNewAddress()}
-              disabled={getAddressQuery.isFetching}
+              onClick={() => void fetchNewAddress()}
+              disabled={getAddressMutation.isPending}
             >
-              {getAddressQuery.isFetching ? (
+              {getAddressMutation.isPending ? (
                 <>
                   <RefreshCwIcon className="animate-spin motion-reduce:hidden" />
                   {t('receive.text_getting_address')}
@@ -171,8 +202,8 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
                 size: 'sm',
                 variant: 'outline',
               })}
-              disabled={getAddressQuery.isFetching || !getAddressQuery.data?.address}
-              value={getAddressQuery.data?.address ?? ''}
+              disabled={getAddressMutation.isPending || !getAddressMutation.data?.address}
+              value={getAddressMutation.data?.address ?? ''}
               text={
                 <>
                   <CopyIcon />
@@ -193,8 +224,8 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => void shareAddress(getAddressQuery.data!.address)}
-                disabled={getAddressQuery.isFetching || !getAddressQuery.data?.address}
+                onClick={() => void shareAddress(getAddressMutation.data!.address)}
+                disabled={getAddressMutation.isPending || !getAddressMutation.data?.address}
               >
                 <ShareIcon />
                 {t('receive.button_share_address')}
@@ -212,10 +243,10 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
               className={'mx-1' /* add x-spacing for input component focus state*/}
               defaultValues={receiveFormDefaultValues}
               jars={jars}
-              disabled={getAddressQuery.isFetching}
+              disabled={getAddressMutation.isPending}
               debug={isDeveloperMode}
               onSubmit={(values) => {
-                setSourceJarIndex(values.source?.fromJar)
+                setSelectedSourceJarIndex(values.source?.fromJar)
                 setAmount(values.amount.amount)
               }}
             />

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -486,7 +486,9 @@ export function SendForm({
                 )}
                 aria-disabled
               >
-                <Balance valueString={String(values.amount?.sweepAmount)} convertToUnit={SATS} showBalance={true} />
+                {values.amount?.sweepAmount !== undefined && (
+                  <Balance valueString={values.amount.sweepAmount.toFixed(0)} convertToUnit={SATS} showBalance={true} />
+                )}
 
                 <Badge className="text-sm" variant="default">
                   {sourceJar?.name} <span className="text-xs">#{sourceJar?.jarIndex}</span>

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -92,7 +92,7 @@ const MAX_NUM_COLLABORATORS = 99
 // TODO: this value should be dynamic via jm backend settings
 const MIN_NUM_COLLABORATORS = isDevMode() ? DEV_INITIAL_NUM_COLLABORATORS_INPUT : JM_MINIMUM_MAKERS_DEFAULT
 
-const FORM_INPUT_DEFAULT_VALUES: SendFormValues = {
+const FORM_INPUT_DEFAULT_VALUES: Partial<SendFormValues> = {
   source: undefined,
   destination: undefined,
   amount: undefined,
@@ -299,7 +299,7 @@ export function SendForm({
         onError={(_ignoredOnPurpose) => {
           // TODO: i18n own key `send.error_loading_address_failed`
           toast.error(t('receive.error_loading_address_failed'))
-          setValue('destination.address', undefined, { shouldValidate: true })
+          setValue('destination.address', '', { shouldValidate: true })
           setValue('destination.fromJar', undefined, { shouldValidate: true })
         }}
         onConfirm={(jarIndex, addressInfo) => {
@@ -331,7 +331,7 @@ export function SendForm({
                       setValue('amount.amount', undefined, { shouldValidate: true })
                     }
                     if (destinationJarIndex === jar.jarIndex) {
-                      setValue('destination.address', undefined, { shouldValidate: true })
+                      setValue('destination.address', '', { shouldValidate: true })
                       setValue('destination.fromJar', undefined, { shouldValidate: true })
                     } else if (destinationAddress !== undefined) {
                       void trigger('destination.address')
@@ -410,7 +410,7 @@ export function SendForm({
                 className="h-auto"
                 disabled={disabled}
                 onClick={() => {
-                  setValue('destination.address', undefined, { shouldValidate: true })
+                  setValue('destination.address', '', { shouldValidate: true })
                   setValue('destination.fromJar', undefined, { shouldValidate: true })
                 }}
               >

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -166,7 +166,7 @@ const sendFormSchema = (
               schema
                 .integer(t('send.feedback_invalid_amount'))
                 .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
-                .nonNullable()
+                .nonNullable(t('send.feedback_invalid_amount'))
                 .min(1, t('send.feedback_invalid_amount'))
                 .max(21_000_000 * 100_000_000, t('send.feedback_invalid_amount'))
                 .required(t('send.feedback_invalid_amount')),

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -3,6 +3,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { getaddress, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { getAddressInfo, validate as isValidBitcoinAddress, Network } from 'bitcoin-address-validation'
 import type { AddressInfo } from 'bitcoin-address-validation'
+import type { TFunction } from 'i18next'
 import { BrushCleaningIcon, MilkIcon, XIcon } from 'lucide-react'
 import { useForm, useWatch } from 'react-hook-form'
 import type { Resolver, SubmitHandler } from 'react-hook-form'
@@ -11,7 +12,7 @@ import { toast } from 'sonner'
 import * as yup from 'yup'
 import { isDevMode } from '@/constants/debugFeatures'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '@/constants/jm'
-import type { Jar } from '@/context/JamWalletInfoContext'
+import type { AddressSummary, Jar } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { cn, delayedPromise, pseudoRandomInteger, SATS, type WalletFileName } from '@/lib/utils'
@@ -99,21 +100,26 @@ const FORM_INPUT_DEFAULT_VALUES: SendFormValues = {
   numCollaborators: undefined,
 }
 
-const sendFormSchema = (jars: Jar[], minNumberOfCollaborators: number) => {
+const sendFormSchema = (
+  jars: Jar[],
+  addressSummary: AddressSummary,
+  minNumberOfCollaborators: number,
+  t: TFunction,
+) => {
   return yup
     .object({
       source: yup
         .object({
           fromJar: yup
             .number()
-            .integer()
+            .integer(t('send.feedback_invalid_source_jar'))
+            .required(t('send.feedback_invalid_source_jar'))
             .test(
               'valid-source-jar-index-test',
-              'Invalid source jar index.',
+              t('send.feedback_invalid_source_jar'),
               (value) =>
                 (jars.find((it) => it.jarIndex === value)?.balanceSummary.calculatedAvailableBalanceInSats || 0) > 0,
-            )
-            .required(),
+            ),
         })
         .required(),
       destination: yup
@@ -121,10 +127,13 @@ const sendFormSchema = (jars: Jar[], minNumberOfCollaborators: number) => {
           fromJar: yup.number().optional(),
           address: yup
             .string()
-            .test('valid-address-test', 'Invalid bitcoin address.', (value) => {
-              return isValidBitcoinAddress(value || '')
+            .required(t('send.feedback_invalid_destination_address'))
+            .test('valid-address-test', t('send.feedback_invalid_destination_address'), (value) => {
+              return isValidBitcoinAddress(value)
             })
-            .required(),
+            .test('reused-address-test', t('send.feedback_reused_address'), (value) => {
+              return addressSummary[value]?.used !== true
+            }),
         })
         .required(),
       amount: yup
@@ -154,10 +163,12 @@ const sendFormSchema = (jars: Jar[], minNumberOfCollaborators: number) => {
                 .optional(),
             otherwise: (schema) =>
               schema
-                .integer()
-                .min(1)
-                .max(21_000_000 * 100_000_000)
-                .required(),
+                .integer(t('send.feedback_invalid_amount'))
+                .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+                .nonNullable()
+                .min(1, t('send.feedback_invalid_amount'))
+                .max(21_000_000 * 100_000_000, t('send.feedback_invalid_amount'))
+                .required(t('send.feedback_invalid_amount')),
           }),
         })
         .required(),
@@ -198,6 +209,7 @@ interface SendFormProps {
   walletFileName: WalletFileName
   jars: Jar[]
   walletBalanceSummary: BalanceSummary
+  addressSummary: AddressSummary
   disabled?: boolean
   debug?: boolean
 }
@@ -210,13 +222,17 @@ export function SendForm({
   minNumberOfCollaborators = MIN_NUM_COLLABORATORS,
   jars,
   walletBalanceSummary,
+  addressSummary,
   debug,
 }: SendFormProps) {
   const { t } = useTranslation()
 
   const [showAddressFromJarSelectorDialog, setShowAddressFromJarSelectorDialog] = useState(false)
 
-  const schema = useMemo(() => sendFormSchema(jars, minNumberOfCollaborators), [jars, minNumberOfCollaborators])
+  const schema = useMemo(
+    () => sendFormSchema(jars, addressSummary, minNumberOfCollaborators, t),
+    [jars, addressSummary, minNumberOfCollaborators, t],
+  )
 
   const {
     control,
@@ -311,8 +327,9 @@ export function SendForm({
               ))}
             </div>
           </Field>
-
-          {errors.source && <div className="text-destructive text-xs">{t('send.feedback_invalid_source_jar')}</div>}
+          {errors.source?.fromJar?.message && (
+            <div className="text-destructive text-xs">{errors.source?.fromJar.message}</div>
+          )}
         </div>
 
         <div className="space-y-2">
@@ -387,12 +404,14 @@ export function SendForm({
             </ButtonGroup>
           </Field>
 
-          {errors.destination && (
+          {errors.destination?.address?.message && (
             <>
-              <div className="text-destructive text-xs">{t('send.feedback_invalid_destination_address')}</div>
+              <div className="text-destructive text-xs">{errors.destination.address.message}</div>
               {/* TODO: feedback_invalid_source_jar */}
-              {/* TODO: feedback_reused_address */}
             </>
+          )}
+          {errors.destination?.fromJar?.message && (
+            <div className="text-destructive text-xs">{errors.destination.fromJar.message}</div>
           )}
         </div>
 
@@ -476,7 +495,15 @@ export function SendForm({
               </Button>
             </ButtonGroup>
           </Field>
-          {errors.amount?.amount && <div className="text-destructive text-xs">{t('send.feedback_invalid_amount')}</div>}
+          {errors.amount?.amount?.message && (
+            <div className="text-destructive text-xs">{errors.amount.amount.message}</div>
+          )}
+          {errors.amount?.sweepAmount?.message && (
+            <div className="text-destructive text-xs">{errors.amount.sweepAmount.message}</div>
+          )}
+          {errors.amount?.isSweep?.message && (
+            <div className="text-destructive text-xs">{errors.amount.isSweep.message}</div>
+          )}
         </div>
 
         <Accordion type="single" collapsible>

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -65,6 +65,7 @@ const AddressFromJarSelectorDialog = ({
         if (result.error) {
           onError(result.error)
         } else if (result.data?.address === undefined) {
+          // TODO: i18n? does this ever happen?
           onError(new Error('Missing bitcoin address.'))
         } else {
           const addressInfo = getAddressInfo(result.data.address)
@@ -190,6 +191,17 @@ const sendFormSchema = (
       }),
     })
     .required()
+    .test('address-not-from-source-jar-test', function (root) {
+      const addressIsFromSourceJar = addressSummary[root.destination.address]?.jarIndex === root.source.fromJar
+      if (!addressIsFromSourceJar) return true
+
+      const errorMessage = t('send.feedback_address_from_source_jar', {
+        /* TODO: i18n: remove defaultValue and add key to language files */
+        defaultValue: 'This address is from the source jar. To preserve your privacy please choose a different one.',
+      })
+
+      return new yup.ValidationError(errorMessage, root.destination.address, 'destination.address', undefined, true)
+    })
 }
 
 const FieldPrefixSatSymbol = (
@@ -240,6 +252,7 @@ export function SendForm({
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
     setValue,
+    trigger,
   } = useForm<SendFormValues, unknown, SendFormValues>({
     mode: 'onSubmit',
     defaultValues: FORM_INPUT_DEFAULT_VALUES,
@@ -320,6 +333,8 @@ export function SendForm({
                     if (destinationJarIndex === jar.jarIndex) {
                       setValue('destination.address', undefined, { shouldValidate: true })
                       setValue('destination.fromJar', undefined, { shouldValidate: true })
+                    } else if (destinationAddress !== undefined) {
+                      void trigger('destination.address')
                     }
                   }}
                   disabled={disabled || jar.balanceSummary.calculatedAvailableBalanceInSats <= 0}

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -15,6 +15,8 @@ import PageTitle from '@/components/ui/jam/PageTitle'
 import { useAddressSummary, useJars, useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import type { UtxoId } from '@/hooks/useQueryUtxos'
+import { useWaitForUtxosToBeSpent } from '@/hooks/useWaitForUtxosToBeSpent'
 import type { WalletFileName } from '@/lib/utils'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
@@ -74,6 +76,30 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     retry: false,
   })
 
+  const [waitForUtxosToBeSpent, setWaitForUtxosToBeSpent] = useState<UtxoId[]>([])
+
+  const waitForUtxosToBeSpentContext = useMemo(
+    () => ({
+      walletFileName,
+      waitForUtxosToBeSpent,
+      setWaitForUtxosToBeSpent,
+      onError: (error: unknown) => {
+        const reason =
+          typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string'
+            ? error.message
+            : undefined
+
+        const message = t('global.errors.error_reloading_wallet_failed', {
+          reason: reason || t('global.errors.reason_unknown'),
+        })
+        toast.error(message)
+      },
+    }),
+    [walletFileName, waitForUtxosToBeSpent, t],
+  )
+
+  useWaitForUtxosToBeSpent(waitForUtxosToBeSpentContext)
+
   const triggerNonCollarborativeTransaction = useMutation<DirectSendResult, ErrorMessage, SendFormValues, unknown>({
     mutationFn: async (data: SendFormValues) => {
       if (data.amount === undefined) {
@@ -122,6 +148,10 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     try {
       const result = await triggerNonCollarborativeTransaction.mutateAsync(data)
       jmTxStore.getState().add(result.response.txinfo as JmTxInfo)
+      const inputUtxoIds = (result.response.txinfo.inputs || []).flatMap((it) =>
+        it?.outpoint !== undefined ? [it.outpoint as UtxoId] : [],
+      )
+      setWaitForUtxosToBeSpent(inputUtxoIds)
     } catch (error: unknown) {
       console.error('Error while sending non-collaborative transaction', error)
     }
@@ -255,7 +285,12 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
               jars={jars}
               addressSummary={addressSummary}
               walletBalanceSummary={walletBalanceSummary}
-              disabled={jmSession?.maker_running || jmSession?.coinjoin_in_process || jmSession?.rescanning}
+              disabled={
+                jmSession?.maker_running ||
+                jmSession?.coinjoin_in_process ||
+                jmSession?.rescanning ||
+                waitForUtxosToBeSpent.length > 0
+              }
               debug={isDeveloperMode}
             />
           </CardContent>

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -27,6 +27,12 @@ import PaymentConfirmDialog from './PaymentConfirmDialog'
 import { SendForm } from './SendForm'
 import type { SendFormValues } from './types'
 
+interface SimpleAlert {
+  variant: React.ComponentProps<typeof Alert>['variant']
+  title: string
+  description: string
+}
+
 type DirectSendResult = {
   request: DirectSendRequest
   response: DirectSendResponse
@@ -44,6 +50,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
   const [showPaymentConfirmDialog, setShowPaymentConfirmDialog] = useState(false)
   const [sendFromValuesAwaitingConfirmation, setSendFromValuesAwaitingConfirmation] = useState<SendFormValues>()
+  const [paymentSuccessfulInfoAlert, setPaymentSuccessfulInfoAlert] = useState<SimpleAlert>()
 
   const { addressSummary } = useAddressSummary()
   const { walletBalanceSummary } = useWalletBalanceSummary()
@@ -146,12 +153,27 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
 
   const onSubmitDirectSend: SubmitHandler<SendFormValues> = async (data) => {
     try {
+      setPaymentSuccessfulInfoAlert(undefined)
       const result = await triggerNonCollarborativeTransaction.mutateAsync(data)
-      jmTxStore.getState().add(result.response.txinfo as JmTxInfo)
+      const tx = result.response.txinfo as Required<JmTxInfo>
+
+      const output = tx.outputs.find((output) => output.address === data.destination.address)
+      setPaymentSuccessfulInfoAlert({
+        variant: 'success',
+        title: /* TODO: i18n */ 'Successfully sent non-collaborative transaction',
+        description: t('send.alert_payment_successful', {
+          amount: output?.value_sats,
+          address: output?.address,
+          txid: tx.txid,
+        }),
+      })
+
       const inputUtxoIds = (result.response.txinfo.inputs || []).flatMap((it) =>
         it?.outpoint !== undefined ? [it.outpoint as UtxoId] : [],
       )
       setWaitForUtxosToBeSpent(inputUtxoIds)
+
+      jmTxStore.getState().add(result.response.txinfo as JmTxInfo)
     } catch (error: unknown) {
       console.error('Error while sending non-collaborative transaction', error)
     }
@@ -257,20 +279,23 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
           </Alert>
         ) : (
           <>
-            {triggerNonCollarborativeTransaction.data && (
-              <Alert variant="success">
-                <AlertTriangleIcon />
-                <AlertTitle>{/* TODO: i18n */}Successfully sent non-collaborative transaction</AlertTitle>
-                <AlertDescription>
-                  <span className="text-wrap slashed-zero">
-                    {t('send.alert_payment_successful', {
-                      amount: triggerNonCollarborativeTransaction.data.request.amount_sats,
-                      address: triggerNonCollarborativeTransaction.data.request.destination,
-                      txid: triggerNonCollarborativeTransaction.data.response.txinfo.txid,
-                    })}
-                  </span>
-                </AlertDescription>
-              </Alert>
+            {paymentSuccessfulInfoAlert && (
+              <>
+                <Alert variant={paymentSuccessfulInfoAlert.variant}>
+                  <AlertTriangleIcon />
+                  <AlertTitle>{paymentSuccessfulInfoAlert.title}</AlertTitle>
+                  <AlertDescription className="ext-wrap slashed-zero">
+                    {paymentSuccessfulInfoAlert.description}
+                  </AlertDescription>
+                </Alert>
+
+                {waitForUtxosToBeSpent.length > 0 && (
+                  <Alert variant="default" className="motion-safe:animate-in blur-in my-2">
+                    <Spinner className="motion-reduce:hidden" />
+                    <AlertTitle>{/* TODO: i18n*/ t('Waiting for utxos to be marked as spent...')}</AlertTitle>
+                  </Alert>
+                )}
+              </>
             )}
           </>
         )}

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -12,7 +12,7 @@ import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
 import PageTitle from '@/components/ui/jam/PageTitle'
-import { useJars, useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
+import { useAddressSummary, useJars, useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import type { WalletFileName } from '@/lib/utils'
@@ -42,6 +42,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   const [showPaymentConfirmDialog, setShowPaymentConfirmDialog] = useState(false)
   const [sendFromValuesAwaitingConfirmation, setSendFromValuesAwaitingConfirmation] = useState<SendFormValues>()
 
+  const { addressSummary } = useAddressSummary()
   const { walletBalanceSummary } = useWalletBalanceSummary()
   const { jars } = useJars()
 
@@ -250,6 +251,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
               walletFileName={walletFileName}
               minNumberOfCollaborators={undefined}
               jars={jars}
+              addressSummary={addressSummary}
               walletBalanceSummary={walletBalanceSummary}
               disabled={jmSession?.maker_running || jmSession?.coinjoin_in_process || jmSession?.rescanning}
               debug={isDeveloperMode}

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -18,6 +18,7 @@ import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import type { WalletFileName } from '@/lib/utils'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
+import { jmTxStore, type JmTxInfo } from '@/store/jmTxStore'
 import { Card, CardContent } from '../ui/card'
 import { Spinner } from '../ui/spinner'
 import PaymentConfirmDialog from './PaymentConfirmDialog'
@@ -119,7 +120,8 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
 
   const onSubmitDirectSend: SubmitHandler<SendFormValues> = async (data) => {
     try {
-      await triggerNonCollarborativeTransaction.mutateAsync(data)
+      const result = await triggerNonCollarborativeTransaction.mutateAsync(data)
+      jmTxStore.getState().add(result.response.txinfo as JmTxInfo)
     } catch (error: unknown) {
       console.error('Error while sending non-collaborative transaction', error)
     }

--- a/src/components/send/types.d.ts
+++ b/src/components/send/types.d.ts
@@ -33,9 +33,9 @@ export type AmountValue =
     }
 
 export interface SendFormValues {
-  source?: SourceValue
-  destination?: DestinationValue
-  amount?: AmountValue
+  source: SourceValue
+  destination: DestinationValue
+  amount: AmountValue
   txFee?: TxFee
   isCoinJoin: boolean
   numCollaborators?: number

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -218,6 +218,7 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
           <Label>{t('settings.fees.label_max_sweep_fee_change')}</Label>
           <p className="text-muted-foreground text-xs">
             {t('settings.fees.description_max_sweep_fee_change', {
+              // TODO: i18n - change variable name.. `defaultValue` is used by the library!
               defaultValue: `${factorToPercentage(JM_MAX_SWEEP_FEE_CHANGE_DEFAULT)}%`,
             })}
           </p>

--- a/src/components/settings/SettingsItem.tsx
+++ b/src/components/settings/SettingsItem.tsx
@@ -32,7 +32,7 @@ export const SettingItem = ({
       <div className="flex items-center gap-2">
         <div className="bg-muted/50 flex h-7 w-7 items-center justify-center rounded-lg border">
           {Icon && <Icon className="text-muted-foreground h-4 w-4" />}
-          {renderIcon && renderIcon({ className: 'text-muted-foreground h-4 w-4' })}
+          {renderIcon?.({ className: 'text-muted-foreground h-4 w-4' })}
         </div>
         <div>
           <p className="text-sm font-medium">{title}</p>
@@ -64,7 +64,7 @@ export const SettingsLink = ({ to, external = false, ...props }: SettingsLinkPro
         }
       }}
     >
-      {external && <ExternalLinkIcon className="text-muted-foreground h-3 w-3" />}
+      {external && <ExternalLinkIcon className="text-muted-foreground size-3.5" />}
     </SettingItem>
   )
 }
@@ -76,7 +76,7 @@ type SettingsSwitchProps = Omit<SettingsItemProps, 'children' | 'action'> & {
 }
 export const SettingSwitch = ({ checked, onCheckedChange, displayToggle = true, ...props }: SettingsSwitchProps) => {
   return (
-    <SettingItem {...props} action={() => onCheckedChange && onCheckedChange(!checked)}>
+    <SettingItem {...props} action={() => onCheckedChange?.(!checked)}>
       {displayToggle && <Switch checked={checked} onCheckedChange={onCheckedChange} disabled={props.disabled} />}
     </SettingItem>
   )

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -8,7 +8,6 @@ import {
   DollarSignIcon,
   FileTextIcon,
   BookIcon,
-  ExternalLinkIcon,
   TerminalIcon,
   KeyRoundIcon,
   PackageSearchIcon,
@@ -29,7 +28,7 @@ import { JAM_SEED_MODAL_TIMEOUT } from '@/constants/jam'
 import { routes } from '@/constants/routes'
 import { useJamDisplayContext } from '@/context/JamDisplayContext'
 import { useFeatures } from '@/hooks/useFeatures'
-import type { WalletFileName } from '@/lib/utils'
+import { cn, type WalletFileName } from '@/lib/utils'
 import { authStore } from '@/store/authStore'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
 import { AccountXpubsDialog } from './AccountXpubsDialog'
@@ -166,39 +165,20 @@ export const SettingsPage = ({ walletFileName, onLockWallet }: SettingPageProps)
           <CardTitle>{t('settings.section_title_community')}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-0">
-          <a
-            href="https://matrix.to/#/%23jam:bitcoin.kyoto"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="hover:bg-muted/50 -mx-2 flex cursor-pointer items-center justify-between rounded-md px-2 py-2 text-inherit no-underline"
-          >
-            <div className="flex items-center gap-2">
-              <div className="flex h-7 w-7 items-center justify-center rounded-lg">
-                <img src="/matrix-logo.png" alt="Matrix" className="light:invert-0 h-4 w-4 invert" />
-              </div>
-              <div>
-                <p className="text-sm font-medium">{t('settings.matrix')}</p>
-              </div>
-            </div>
-            <ExternalLinkIcon className="text-muted-foreground h-3 w-3" />
-          </a>
-          <Separator className="opacity-50" />
-          <a
-            href="https://t.me/JoinMarketWebUI"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="hover:bg-muted/50 -mx-2 flex cursor-pointer items-center justify-between rounded-md px-2 py-2 text-inherit no-underline"
-          >
-            <div className="flex items-center gap-2">
-              <div className="flex h-7 w-7 items-center justify-center rounded-lg">
-                <img src="/telegram-logo.png" alt="Telegram" className="h-4 w-4" />
-              </div>
-              <div>
-                <p className="text-sm font-medium">{t('settings.telegram')}</p>
-              </div>
-            </div>
-            <ExternalLinkIcon className="text-muted-foreground h-3 w-3" />
-          </a>
+          <SettingsLink
+            renderIcon={({ className }) => (
+              <img src="/matrix-logo.png" alt="Matrix" className={cn(className, 'light:invert-0 invert')} />
+            )}
+            title={t('settings.matrix')}
+            to="https://matrix.to/#/%23jam:bitcoin.kyoto"
+            external={true}
+          />
+          <SettingsLink
+            renderIcon={({ className }) => <img src="/telegram-logo.png" alt="Telegram" className={className} />}
+            title={t('settings.telegram')}
+            to="https://t.me/JoinMarketWebUI"
+            external={true}
+          />
         </CardContent>
       </Card>
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -33,6 +33,18 @@ function DialogOverlay({ className, ...props }: React.ComponentProps<typeof Dial
   )
 }
 
+// workaround for "Cannot interact with Sonner toasts with open Dialogs"
+// see https://github.com/shadcn-ui/ui/issues/3461#issuecomment-2053682487 (last checked 2026-02-07)
+const __workaround_preventEventOfOrigin = (selectors: string) => {
+  return (e: CustomEvent<{ originalEvent: PointerEvent | FocusEvent }>) => {
+    if (e.target && document.querySelector(selectors)?.contains(e.target as HTMLElement)) {
+      e.preventDefault()
+    }
+  }
+}
+
+const __workaround_preventEventOfToasterOrigin = __workaround_preventEventOfOrigin('.toaster')
+
 function DialogContent({
   className,
   children,
@@ -42,6 +54,7 @@ function DialogContent({
   showCloseButton?: boolean
 }) {
   const { t } = useTranslation()
+
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -51,6 +64,14 @@ function DialogContent({
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-2xl',
           className,
         )}
+        onPointerDownOutside={(event) => {
+          __workaround_preventEventOfToasterOrigin(event)
+          props.onPointerDownOutside?.(event)
+        }}
+        onInteractOutside={(event) => {
+          __workaround_preventEventOfToasterOrigin(event)
+          props.onInteractOutside?.(event)
+        }}
         {...props}
       >
         {children}

--- a/src/components/ui/jam/CopyButton.tsx
+++ b/src/components/ui/jam/CopyButton.tsx
@@ -110,9 +110,7 @@ export function CopyButton({ text, successText = text, successTextTimeout = 1_50
       {...buttonProps}
       onSuccess={() => {
         setValueCopiedFlag((current) => current + 1)
-        if (buttonProps.onSuccess !== undefined) {
-          buttonProps.onSuccess()
-        }
+        buttonProps.onSuccess?.()
       }}
     >
       {showValueCopiedConfirmation ? successText : text}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,10 +1,25 @@
 import { useTheme } from 'next-themes'
 import { Toaster as Sonner, type ToasterProps } from 'sonner'
+import { cn } from '@/lib/utils'
 
-const Toaster = ({ ...props }: ToasterProps) => {
+const Toaster = ({ theme, className, ...props }: ToasterProps) => {
   const { resolvedTheme = 'dark' } = useTheme()
 
-  return <Sonner theme={resolvedTheme as ToasterProps['theme']} className="toaster group" {...props} />
+  return (
+    <Sonner
+      theme={theme ?? (resolvedTheme as ToasterProps['theme'])}
+      className={cn(
+        'toaster group',
+        {
+          // workaround for sonner interaction in dialogs
+          // see: https://github.com/shadcn-ui/ui/issues/3461 (last checked: 2026-02-07)
+          'pointer-events-auto': true,
+        },
+        className,
+      )}
+      {...props}
+    />
+  )
 }
 
 export { Toaster }

--- a/src/components/wallet/BranchEntryTable.tsx
+++ b/src/components/wallet/BranchEntryTable.tsx
@@ -17,14 +17,18 @@ import {
   type FilterFnOption,
   type Table as TableType,
 } from '@tanstack/react-table'
+import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { TablePagination } from '@/components/ui/jam/TablePagination'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import type { AccountBranch } from '@/context/JamWalletInfoContext'
 import type { UtxoTag } from '@/lib/tags'
 import { cn } from '@/lib/utils'
 import type { AmountSats, BitcoinAddress, HdPath } from '@/types/global'
+import { buttonVariants } from '../ui/button-variants'
 import { Balance } from '../ui/jam/Balance'
+import { CopyButton } from '../ui/jam/CopyButton'
 import { SortIcon } from '../ui/jam/SortIcon'
 import { StatusBadge } from '../ui/jam/StatusBadge'
 
@@ -99,7 +103,7 @@ export const BranchEntryTable = ({
           numeric: true,
         },
       }),
-      columnHelper.accessor('address', {
+      columnHelper.accessor<'address', BranchEntryTableRow['address']>('address', {
         header: () => (
           <div className="flex items-center">
             {t(/* TODO: i18n keys */ 'jar_details.utxo_list.column_title_address')}
@@ -111,7 +115,19 @@ export const BranchEntryTable = ({
           // tie-break using derivationIndex
           return a.original.derivationIndex - b.original.derivationIndex
         },
-        cell: (info) => <span className="font-mono text-sm select-all">{info.getValue()}</span>,
+        cell: (info) => (
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm select-all">{info.getValue()}</span>
+            <CopyButton
+              value={info.getValue()}
+              text={<CopyIcon />}
+              successText={<CheckIcon className="text-green-500" />}
+              className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
+              onSuccess={() => toast.success(t('receive.text_copy_address'))}
+              onError={() => toast.error(t('receive.error_copy_address_failed'))}
+            />
+          </div>
+        ),
         meta: {
           alphabetic: true,
         },

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -290,9 +290,7 @@ export const JarUtxosTable = ({
     onRowPinningChange: setRowPinning,
     onRowSelectionChange: (rowSelection) => {
       setRowSelection(rowSelection)
-      if (onRowSelectionChange !== undefined) {
-        onRowSelectionChange(rowSelection)
-      }
+      onRowSelectionChange?.(rowSelection)
     },
     onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -22,7 +22,7 @@ import {
   type CellContext,
 } from '@tanstack/react-table'
 import type { TFunction } from 'i18next'
-import { SnowflakeIcon } from 'lucide-react'
+import { CheckIcon, CopyIcon, SnowflakeIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { TablePagination } from '@/components/ui/jam/TablePagination'
@@ -30,8 +30,10 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import type { Utxo } from '@/hooks/useQueryUtxos'
 import type { UtxoTag } from '@/lib/tags'
 import { cn } from '@/lib/utils'
+import { buttonVariants } from '../ui/button-variants'
 import { Checkbox } from '../ui/checkbox'
 import { Balance } from '../ui/jam/Balance'
+import { CopyButton } from '../ui/jam/CopyButton'
 import { SortIcon } from '../ui/jam/SortIcon'
 import { StatusBadge } from '../ui/jam/StatusBadge'
 
@@ -178,7 +180,7 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
         numeric: true,
       } as UtxoTableColumnMeta,
     }),
-    columnHelper.accessor('address', {
+    columnHelper.accessor<'address', UtxoTableEntry['address']>('address', {
       header: () => <div className="flex items-center">{t('jar_details.utxo_list.column_title_address')}</div>,
       sortingFn: (a, b) => {
         const val = a.original.address.localeCompare(b.original.address)
@@ -188,7 +190,19 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
         const bid = Number(b.original.confirmations)
         return aid - bid
       },
-      cell: (info) => <span className="font-mono text-sm select-all">{info.getValue()}</span>,
+      cell: (info) => (
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm select-all">{info.getValue()}</span>
+          <CopyButton
+            value={info.getValue()}
+            text={<CopyIcon />}
+            successText={<CheckIcon className="text-green-500" />}
+            className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
+            onSuccess={() => toast.success(t('receive.text_copy_address'))}
+            onError={() => toast.error(t('receive.error_copy_address_failed'))}
+          />
+        </div>
+      ),
       meta: {
         alphabetic: true,
       } as UtxoTableColumnMeta,

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -24,6 +24,7 @@ import {
 import type { TFunction } from 'i18next'
 import { SnowflakeIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { TablePagination } from '@/components/ui/jam/TablePagination'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import type { Utxo } from '@/hooks/useQueryUtxos'
@@ -87,6 +88,8 @@ const UtxoTableRow = ({ row }: { row: Row<UtxoTableEntry> }) => {
   )
 }
 
+const AUTO_CHANGE_SELECTION_TOAST_ID = 'utxo.selection_changed_automatically'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
   return [
@@ -95,15 +98,42 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
       header: ({ table }: HeaderContext<UtxoTableEntry, unknown>) => (
         <Checkbox
           checked={table.getIsAllRowsSelected() ? true : table.getIsSomeRowsSelected() ? 'indeterminate' : false}
-          onCheckedChange={(checked) => table.toggleAllRowsSelected(checked === true)}
+          onCheckedChange={(checked) => {
+            table.toggleAllRowsSelected(checked === true)
+            toast.dismiss(AUTO_CHANGE_SELECTION_TOAST_ID)
+          }}
         />
       ),
-      cell: ({ row }: CellContext<UtxoTableEntry, unknown>) => (
+      cell: ({ row, table }: CellContext<UtxoTableEntry, unknown>) => (
         <Checkbox
           className="light:bg-background/80"
           checked={row.getIsSelected()}
           disabled={!row.getCanSelect()}
-          onCheckedChange={row.getToggleSelectedHandler()}
+          onCheckedChange={(checked) => {
+            const address = row.original.address
+            const eligibleRows = table.getRowModel().rows.filter((it) => it.original.address === address)
+            eligibleRows.forEach((it) => it.getToggleSelectedHandler()(checked))
+
+            if (eligibleRows.length > 1) {
+              if (checked) {
+                /* TODO: i18n */
+                toast.warning(`Security measure: Selection changed`, {
+                  description: `Automatically selected ${eligibleRows.length - 1} more UTXOs with address ${address}!`,
+                  id: AUTO_CHANGE_SELECTION_TOAST_ID,
+                  duration: 10_000,
+                })
+              } else {
+                /* TODO: i18n */
+                toast.warning(`Security measure: Deselection changed`, {
+                  description: `Automatically deselected ${eligibleRows.length - 1} more UTXOs with address ${address}!`,
+                  id: AUTO_CHANGE_SELECTION_TOAST_ID,
+                  duration: 10_000,
+                })
+              }
+            } else {
+              toast.dismiss(AUTO_CHANGE_SELECTION_TOAST_ID)
+            }
+          }}
         />
       ),
     },

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -130,8 +130,18 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
   const operationsEnabled = enabled && !(walletInfo.isFetching || freezeUtxos.isPending || unfreezeUtxos.isPending)
 
   const onFreezeClick = async () => {
+    const selectedAddresses = new Set(selectedUtxos.map((it) => it.address))
+    const eligibleUtxos = jar.utxos.filter((it) => selectedAddresses.has(it.address))
+
+    if (eligibleUtxos.length > selectedUtxos.length) {
+      // TODO: i18n
+      toast.warning('Security measure: Freeze additional UTXOs', {
+        description: `Automatically freezing ${eligibleUtxos.length - selectedUtxos.length} additional UTXOs. They should be spent together.`,
+      })
+    }
+
     try {
-      const result = await freezeUtxos.mutateAsync(selectedUtxos)
+      const result = await freezeUtxos.mutateAsync(eligibleUtxos)
       const fulfilled = result.filter((it) => it.status === 'fulfilled')
       const rejected = result.filter((it) => it.status === 'rejected')
       if (rejected.length === 0) {
@@ -145,8 +155,18 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
   }
 
   const onUnfreezeClick = async () => {
+    const selectedAddresses = new Set(selectedUtxos.map((it) => it.address))
+    const eligibleUtxos = jar.utxos.filter((it) => selectedAddresses.has(it.address))
+
+    if (eligibleUtxos.length > selectedUtxos.length) {
+      // TODO: i18n
+      toast.warning('Security measure: Unfreeze additional UTXOs', {
+        description: `Automatically unfreezing ${eligibleUtxos.length - selectedUtxos.length} additional UTXOs. They should be spent together.`,
+      })
+    }
+
     try {
-      const result = await unfreezeUtxos.mutateAsync(selectedUtxos)
+      const result = await unfreezeUtxos.mutateAsync(eligibleUtxos)
       const fulfilled = result.filter((it) => it.status === 'fulfilled')
       const rejected = result.filter((it) => it.status === 'rejected')
       if (rejected.length === 0) {
@@ -295,7 +315,7 @@ export const WalletJarsDetailsContent = ({
   return (
     <div className={cn('mx-auto space-y-3', className)}>
       <Tabs
-        value={activeJar?.jarIndex.toString()}
+        value={activeJar.jarIndex.toString()}
         onValueChange={(value) => setActiveJarIndex(Number.parseInt(value, 10))}
         className="flex flex-col gap-4"
       >

--- a/src/context/JamWalletInfoContext.ts
+++ b/src/context/JamWalletInfoContext.ts
@@ -41,6 +41,7 @@ export type AddressStatus = AddressStaticStatus | AddressStatusDynamic
 
 export type AddressMeta = {
   address: BitcoinAddress
+  used: boolean
   status: AddressStatus
   info?: Omit<AddressInfo, 'address'>
   __raw: NonNullable<

--- a/src/context/JamWalletInfoContext.ts
+++ b/src/context/JamWalletInfoContext.ts
@@ -40,6 +40,7 @@ type AddressStatusDynamic = string
 export type AddressStatus = AddressStaticStatus | AddressStatusDynamic
 
 export type AddressMeta = {
+  jarIndex: JarIndex
   address: BitcoinAddress
   used: boolean
   status: AddressStatus

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -45,26 +45,33 @@ const toAccountSummary = (walletInfo: WalletInfoApiObject): AccountSummary => {
 
 const toAddressSummary = (accountSummary: AccountSummary): AddressSummary => {
   return Object.values(accountSummary)
-    .flatMap((it) => it.__raw)
-    .flatMap((it) => it.branches || [])
-    .flatMap((it) => it.entries || [])
-    .reduce((acc, __raw) => {
-      if (!__raw.address || !__raw.status) {
+    .flatMap(
+      (it) =>
+        it.__raw.branches
+          ?.flatMap((branch) => branch.entries || [])
+          .flatMap((entry) => ({
+            account: it,
+            entry,
+          })) || [],
+    )
+    .reduce((acc, { account, entry }) => {
+      if (!entry.address || !entry.status) {
         return acc
       }
 
-      const info = getAddressInfo(__raw.address)
+      const info = getAddressInfo(entry.address)
 
       const meta: AddressMeta = {
-        address: __raw.address,
-        used: __raw.status !== 'new',
-        status: __raw.status,
+        jarIndex: account.jarIndex,
+        address: entry.address,
+        used: entry.status !== 'new',
+        status: entry.status,
         info: {
           bech32: info.bech32,
           network: info.network,
           type: info.type,
         },
-        __raw,
+        __raw: entry,
       }
       acc[meta.address] = meta
       return acc

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -57,6 +57,7 @@ const toAddressSummary = (accountSummary: AccountSummary): AddressSummary => {
 
       const meta: AddressMeta = {
         address: __raw.address,
+        used: __raw.status !== 'new',
         status: __raw.status,
         info: {
           bech32: info.bech32,

--- a/src/hooks/useJmWebsocket.ts
+++ b/src/hooks/useJmWebsocket.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import useWebSocket, { ReadyState } from 'react-use-websocket'
-import type { WebSocketHook } from 'react-use-websocket/dist/lib/types'
+import type { Options, WebSocketHook } from 'react-use-websocket/dist/lib/types'
 import { useStore } from 'zustand'
 import {
   JAM_JM_WEBSOCKET_CONNECTION_AUTHENTICATED_DURATION,
@@ -32,7 +32,12 @@ export type JmWebsocket = Omit<WebSocketHook, 'sendMessage' | 'sendJsonMessage'>
   isAuthenticated: boolean
 }
 
-export const useJmWebsocket = (): JmWebsocket => {
+interface UseJmWebsocketProps {
+  options?: Pick<Options, 'onOpen' | 'onClose' | 'onMessage' | 'onError' | 'onReconnectStop'>
+  enableHeartbeat: boolean
+}
+
+export const useJmWebsocket = ({ enableHeartbeat, options }: UseJmWebsocketProps): JmWebsocket => {
   const authToken = useStore(authStore, (state) => state.state?.auth?.token)
 
   const [socketUrl] = useState(url)
@@ -59,13 +64,21 @@ export const useJmWebsocket = (): JmWebsocket => {
       console.debug(`Websocket reconnect attempt #${attemptNumber} in ${value}ms`)
       return value
     },
-    onClose: () => {
+    onOpen: (event) => {
+      console.debug('Websocket opened.')
+      options?.onOpen?.(event)
+    },
+    onClose: (event) => {
       console.debug('Websocket closed.')
       setAuthenticated(false)
+      options?.onClose?.(event)
     },
-    onOpen: () => {
-      console.debug('Websocket opened.')
+    onError: (event) => {
+      console.debug('Websocket error.')
+      options?.onError?.(event)
     },
+    onMessage: options?.onMessage,
+    onReconnectStop: options?.onReconnectStop,
   })
 
   const isOpen = useMemo(() => websocket.readyState === ReadyState.OPEN, [websocket.readyState])
@@ -103,7 +116,7 @@ export const useJmWebsocket = (): JmWebsocket => {
 
   useEffect(
     function setupHeartbeat() {
-      if (!isOpen || !authenticated || authToken === undefined) {
+      if (!enableHeartbeat || !isOpen || !authenticated || authToken === undefined) {
         return
       }
 
@@ -130,7 +143,7 @@ export const useJmWebsocket = (): JmWebsocket => {
         clearTimeout(timerId)
       }
     },
-    [sendMessage, isOpen, authenticated, authToken],
+    [enableHeartbeat, sendMessage, isOpen, authenticated, authToken],
   )
 
   return {

--- a/src/hooks/useRefreshSession.ts
+++ b/src/hooks/useRefreshSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { sessionOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { SessionResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useQuery } from '@tanstack/react-query'
@@ -28,13 +28,9 @@ export function useRefreshSession({
 }: UseRefreshSessionProps): UseRefreshSessionResult {
   const client = useApiClient()
   const authState = useStore(authStore, (state) => state.state)
-  const sessionOptionsQueryOptions = useMemo(
-    () =>
-      sessionOptions({
-        client,
-      }),
-    [client],
-  )
+  const sessionOptionsQueryOptions = sessionOptions({
+    client,
+  })
 
   const { data: sessionData, refetch: refetchSessionData } = useQuery({
     ...sessionOptionsQueryOptions,

--- a/src/hooks/useWaitForUtxosToBeSpent.ts
+++ b/src/hooks/useWaitForUtxosToBeSpent.ts
@@ -1,0 +1,68 @@
+import { useEffect } from 'react'
+import type { WalletFileName } from '@/lib/utils'
+import type { Milliseconds } from '@/types/global'
+import { useQueryUtxos, type UtxoId } from './useQueryUtxos'
+
+// Delaying the poll requests gives the wallet some time to synchronize
+// the utxo set and reduces amount of http requests
+const DEFAUL_DELAY: Milliseconds = 1_000
+
+interface WaitForUtxosToBeSpentArguments {
+  walletFileName: WalletFileName
+  waitForUtxosToBeSpent: UtxoId[]
+  setWaitForUtxosToBeSpent: (utxos: UtxoId[]) => void
+  onError: (error: unknown) => void
+  delay?: Milliseconds
+  resetOnErrors?: boolean
+}
+
+// This callback is responsible for updating the utxo array when a
+// payment is made. The wallet needs some time after a tx is sent
+// to reflect the changes internally. All outputs given in
+// `waitForUtxosToBeSpent` must have been removed from the wallet
+// for a payment to be considered done.
+export const useWaitForUtxosToBeSpent = ({
+  walletFileName,
+  waitForUtxosToBeSpent,
+  setWaitForUtxosToBeSpent,
+  onError,
+  delay = DEFAUL_DELAY,
+  resetOnErrors = true,
+}: WaitForUtxosToBeSpentArguments): void => {
+  const {
+    queryResult: { refetch },
+  } = useQueryUtxos({ walletFileName })
+  return useEffect(() => {
+    if (waitForUtxosToBeSpent.length === 0) return
+
+    const abortCtrl = new AbortController()
+
+    const updateUtxos = async (signal: AbortSignal) => {
+      if (signal.aborted) return
+      try {
+        const result = await refetch({ throwOnError: true })
+        if (signal.aborted) return
+        const outputs = result?.data?.utxos?.map((it) => it.utxo)
+        const utxosStillPresent = waitForUtxosToBeSpent.filter((it) => outputs?.includes(it))
+        // updating the utxos array will trigger a recursive call
+        setWaitForUtxosToBeSpent([...utxosStillPresent])
+      } catch (error: unknown) {
+        if (signal.aborted) return
+        if (resetOnErrors) {
+          // Stop waiting for wallet synchronization on errors
+          setWaitForUtxosToBeSpent([])
+        }
+        onError(error)
+      }
+    }
+
+    const timer = setTimeout(() => {
+      void updateUtxos(abortCtrl.signal)
+    }, delay)
+
+    return () => {
+      abortCtrl.abort()
+      clearTimeout(timer)
+    }
+  }, [waitForUtxosToBeSpent, setWaitForUtxosToBeSpent, resetOnErrors, onError, delay, refetch])
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -432,7 +432,7 @@
   "receive": {
     "title": "Receive",
     "subtitle": "Send sats to the address below to fund your wallet.",
-    "text_copy_address": "Address copied",
+    "text_copy_address": "Address copied.",
     "error_loading_address_failed": "Unable to get new address.",
     "error_copy_address_failed": "Could not copy address.",
     "error_share_address_failed": "Could not share address",

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from '@tanstack/react-query'
-import type { QueryFunction, QueryKey } from '@tanstack/react-query'
+import type { MutationFunction, QueryFunction, QueryKey } from '@tanstack/react-query'
 import { delayedPromise } from './utils'
 
 export const queryClient = new QueryClient({
@@ -35,4 +35,21 @@ export function withQueryDelay<TQueryFnData, TQueryKey extends QueryKey>(
     }
     return result
   }) as QueryFunction<TQueryFnData, TQueryKey>
+}
+
+export function withMutationDelay<TMutateFnData, TVariables = void>(
+  queryFn: MutationFunction<TMutateFnData, TVariables> | undefined,
+  { delayBefore, delayAfter }: WithQueryDelayOptions,
+): MutationFunction<TMutateFnData, TVariables> | undefined {
+  if (!queryFn) return undefined
+  return (async (variables, options) => {
+    if (delayBefore !== undefined && delayBefore > 0) {
+      await delayedPromise(delayBefore)
+    }
+    const result = queryFn(variables, options)
+    if (delayAfter !== undefined && delayAfter > 0) {
+      await delayedPromise(delayAfter)
+    }
+    return result
+  }) as MutationFunction<TMutateFnData, TVariables>
 }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -26,7 +26,7 @@ export const authStore = createStore<AuthStoreState>()(
       clear: () => set({ state: undefined }),
     }),
     {
-      name: 'jam-auth',
+      name: 'jam-auth-store',
       storage: createJSONStorage(() => sessionStorage),
     },
   ),

--- a/src/store/jamSettingsStore.ts
+++ b/src/store/jamSettingsStore.ts
@@ -31,7 +31,7 @@ export const jamSettingsStore = createStore<JamSettingsStoreState>()(
       clear: () => set({ state: initial }),
     }),
     {
-      name: 'jam-settings',
+      name: 'jam-settings-store',
       storage: createJSONStorage(() => localStorage),
     },
   ),

--- a/src/store/jmConfigStore.ts
+++ b/src/store/jmConfigStore.ts
@@ -9,7 +9,6 @@ export type JmConfigs = {
 interface JmConfigStoreState {
   state: JmConfigs
   get: (val: ConfigKey) => ConfigValue | null
-  getAll: () => ConfigValue[]
   set: (val: ConfigValue) => void
   clear: () => void
 }
@@ -21,39 +20,20 @@ export const jmConfigStore = createStore<JmConfigStoreState>()(
     (set, get) => ({
       state: initial,
       get: (key) => {
-        const fields = get().state[key.section]
-        if (fields === undefined) return null
-
-        const value = fields[key.field]
-        if (value === undefined) return null
-
-        return {
-          key,
-          value: value || null,
-        }
-      },
-      getAll: () => {
-        return Object.entries(get().state).flatMap(([section, entries]) => {
-          return Object.entries(entries).map(([field, value]) => ({
-            key: {
-              section,
-              field,
-            },
-            value,
-          }))
-        })
+        const value = get().state[key.section]?.[key.field]
+        return value !== undefined ? { key, value } : null
       },
       set: (val) =>
         set((state) => {
-          const copy = { state: { ...state.state } }
-          copy.state[val.key.section] = copy.state[val.key.section] || {}
-          copy.state[val.key.section][val.key.field] = val.value
-          return copy
+          const copy = { ...state.state }
+          copy[val.key.section] = copy[val.key.section] || {}
+          copy[val.key.section][val.key.field] = val.value
+          return { state: copy }
         }),
       clear: () => set({ state: initial }),
     }),
     {
-      name: 'jm-config',
+      name: 'jm-config-store',
       storage: createJSONStorage(() => sessionStorage),
     },
   ),

--- a/src/store/jmSessionStore.ts
+++ b/src/store/jmSessionStore.ts
@@ -8,5 +8,5 @@ interface JmSessionStoreState {
 
 export const jmSessionStore = createStore<JmSessionStoreState>()((set) => ({
   state: undefined,
-  update: (val) => set((state) => ({ state: { ...state.state, ...val } })),
+  update: (val) => set(() => ({ state: val })),
 }))

--- a/src/store/jmTxStore.ts
+++ b/src/store/jmTxStore.ts
@@ -1,0 +1,37 @@
+import type { DirectSendResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { createStore } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+export type TxId = NonNullable<DirectSendResponse['txinfo']['txid']>
+export type JmTxInfo = Omit<DirectSendResponse['txinfo'], 'txid'> & {
+  txid: TxId
+}
+
+type JmTxInfoMap = Map<TxId, JmTxInfo>
+
+interface JmTxStoreState {
+  state: JmTxInfoMap
+  get: (txid: TxId) => JmTxInfo | undefined
+  getAll: () => JmTxInfoMap
+  add: (val: JmTxInfo) => void
+  clear: () => void
+}
+
+export const jmTxStore = createStore<JmTxStoreState>()(
+  persist(
+    (set, get) => ({
+      state: new Map([] as [TxId, JmTxInfo][]),
+      get: (txid) => get().state.get(txid),
+      getAll: () => get().state,
+      add: (val) =>
+        set((state) => ({
+          state: new Map(state.state).set(val.txid, val),
+        })),
+      clear: () => set({ state: new Map() }),
+    }),
+    {
+      name: 'jm-tx-store',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+)

--- a/src/store/jmTxStore.ts
+++ b/src/store/jmTxStore.ts
@@ -7,12 +7,18 @@ export type JmTxInfo = Omit<DirectSendResponse['txinfo'], 'txid'> & {
   txid: TxId
 }
 
-type JmTxInfoMap = Map<TxId, JmTxInfo>
+export type JmTxInfos = {
+  [key: TxId]: {
+    data: JmTxInfo
+    insertedAt: number
+    updatedAt: number
+  }
+}
 
 interface JmTxStoreState {
-  state: JmTxInfoMap
+  state: JmTxInfos
   get: (txid: TxId) => JmTxInfo | undefined
-  getAll: () => JmTxInfoMap
+  getAll: () => JmTxInfos
   add: (val: JmTxInfo) => void
   clear: () => void
 }
@@ -20,14 +26,21 @@ interface JmTxStoreState {
 export const jmTxStore = createStore<JmTxStoreState>()(
   persist(
     (set, get) => ({
-      state: new Map([] as [TxId, JmTxInfo][]),
-      get: (txid) => get().state.get(txid),
+      state: {} as JmTxInfos,
+      get: (txid) => get().state[txid]?.data,
       getAll: () => get().state,
-      add: (val) =>
-        set((state) => ({
-          state: new Map(state.state).set(val.txid, val),
-        })),
-      clear: () => set({ state: new Map() }),
+      add: (data) =>
+        set((state) => {
+          const now = Date.now()
+          const copy = { ...state.state }
+          copy[data.txid] = {
+            data,
+            insertedAt: copy[data.txid]?.insertedAt || now,
+            updatedAt: now,
+          }
+          return { state: copy }
+        }),
+      clear: () => set({ state: {} as JmTxInfos }),
     }),
     {
       name: 'jm-tx-store',

--- a/src/stories/jam/AppNavbar.stories.tsx
+++ b/src/stories/jam/AppNavbar.stories.tsx
@@ -42,6 +42,14 @@ export const Loading: Story = {
   },
 }
 
+export const Reloading: Story = {
+  args: {
+    ...defaults,
+    isLoading: false,
+    isReloading: true,
+  },
+}
+
 export const RescanInProgress: Story = {
   args: {
     ...defaults,


### PR DESCRIPTION
A couple of improvements:
- manually reveal address on receive page (should prevent large gap limits)
- validate destination addresses (make sure it is not reused or from the same jar - if possible)
- freeze/unfreeze coins of reused addresses together
- copy addresses in jar details overlay
- wait for utxos to be spent on send page (still needs work to be resused by other components)
- store tx in session storage (can be used later to show a history during session)