### PR TITLE
Fix freeze/unfreeze toast messages

### DIFF
--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -132,50 +132,30 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
   const onFreezeClick = async () => {
     try {
       const result = await freezeUtxos.mutateAsync(selectedUtxos)
-      const allFulfilled = result.filter((it) => it.status === 'fulfilled')
-      if (allFulfilled) {
-        // TODO: i18n
-        if (result.length === 1) {
-          toast.success('Selected UTXO has been frozen')
-        } else {
-          toast.success('Selected UTXOs have been frozed.')
-        }
+      const fulfilled = result.filter((it) => it.status === 'fulfilled')
+      const rejected = result.filter((it) => it.status === 'rejected')
+      if (rejected.length === 0) {
+        toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: fulfilled.length }))
       } else {
-        // TODO: i18n
-        if (result.length === 1) {
-          toast.warning('Selected UTXO could not been frozen. Please try again.')
-        } else {
-          toast.warning('Some selected UTXO could not been frozen. Please try again.')
-        }
+        toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length }))
       }
     } catch (_ignoredOnPurpose) {
-      // TODO: i18n
-      toast.warning('Some selected UTXO could not been frozen. Please try again.')
+      toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: selectedUtxos.length }))
     }
   }
 
   const onUnfreezeClick = async () => {
     try {
       const result = await unfreezeUtxos.mutateAsync(selectedUtxos)
-      const allFulfilled = result.filter((it) => it.status === 'fulfilled')
-      if (allFulfilled) {
-        // TODO: i18n
-        if (result.length === 1) {
-          toast.success('Selected UTXO has been unfrozen')
-        } else {
-          toast.success('Selected UTXOs have been unfrozed.')
-        }
+      const fulfilled = result.filter((it) => it.status === 'fulfilled')
+      const rejected = result.filter((it) => it.status === 'rejected')
+      if (rejected.length === 0) {
+        toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: fulfilled.length }))
       } else {
-        // TODO: i18n
-        if (result.length === 1) {
-          toast.warning('Selected UTXO could not been unfrozen. Please try again.')
-        } else {
-          toast.warning('Some selected UTXO could not been unfrozen. Please try again.')
-        }
+        toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length }))
       }
     } catch (_ignoredOnPurpose) {
-      // TODO: i18n
-      toast.warning('Some selected UTXO could not been unfrozen. Please try again.')
+      toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: selectedUtxos.length }))
     }
   }
 
@@ -332,8 +312,8 @@ export const WalletJarsDetailsContent = ({
 
       <Alert variant="warning">
         <AlertTriangleIcon />
-        <AlertTitle>Under construction</AlertTitle>
-        <AlertDescription>Not yet implemented.</AlertDescription>
+        <AlertTitle>{t('jar_details.utxo_list.alert_under_construction_title')}</AlertTitle>
+        <AlertDescription>{t('jar_details.utxo_list.alert_under_construction_description')}</AlertDescription>
       </Alert>
       <Tabs defaultValue="utxos" className="flex flex-col gap-4">
         <TabsList className="mx-auto flex items-center gap-2">
@@ -365,8 +345,8 @@ export const WalletJarsDetailsContent = ({
           ) : (
             <Alert variant="warning">
               <AlertTriangleIcon />
-              <AlertTitle>{/* TODO: i18n */}No account information present</AlertTitle>
-              <AlertDescription>Account information is not yet loaded or not present.</AlertDescription>
+              <AlertTitle>{t('jar_details.utxo_list.alert_no_account_info_title')}</AlertTitle>
+              <AlertDescription>{t('jar_details.utxo_list.alert_no_account_info_description')}</AlertDescription>
             </Alert>
           )}
         </TabsContent>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -788,7 +788,19 @@
       "utxo_detail_label_status": "Address status",
       "text_actions_disabled": "Some operations are disabled.",
       "text_actions_disabled_maker_running": "Earn is active. Some operations are disabled.",
-      "text_actions_disabled_taker_running": "A collaborative transaction is currently in progress. Some operations are disabled."
+      "text_actions_disabled_taker_running": "A collaborative transaction is currently in progress. Some operations are disabled.",
+      "toast_freeze_success_one": "Selected UTXO has been frozen.",
+      "toast_freeze_success_other": "Selected UTXOs have been frozen.",
+      "toast_freeze_error_one": "Selected UTXO could not be frozen. Please try again.",
+      "toast_freeze_error_other": "Some selected UTXOs could not be frozen. Please try again.",
+      "toast_unfreeze_success_one": "Selected UTXO has been unfrozen.",
+      "toast_unfreeze_success_other": "Selected UTXOs have been unfrozen.",
+      "toast_unfreeze_error_one": "Selected UTXO could not be unfrozen. Please try again.",
+      "toast_unfreeze_error_other": "Some selected UTXOs could not be unfrozen. Please try again.",
+      "alert_under_construction_title": "Under construction",
+      "alert_under_construction_description": "Not yet implemented.",
+      "alert_no_account_info_title": "No account information present",
+      "alert_no_account_info_description": "Account information is not yet loaded or not present."
     }
   },
   "show_utxos": {


### PR DESCRIPTION
#1023 
fixes typos in freeze/unfreeze toast messages by moving them to i18n with proper pluralization, and corrects a dead error branch caused by using filter() instead of every().