### PR TITLE
fix(auth): stop refresh loop when logged out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,9 +250,11 @@ const Loading = () => {
 
 function RefreshApiToken() {
   const client = useApiClient()
+  const hasRefreshToken = useStore(authStore, (state) => state.state?.auth?.refresh_token !== undefined)
 
-  // TODO: stop this interval if no wallet is active
   useEffect(() => {
+    if (!hasRefreshToken) return
+
     const isDevMode = jamSettingsStore.getState().state.developerMode
     if (isDevMode) {
       toast.info(`[DEV] setup refresh interval`)
@@ -302,7 +304,7 @@ function RefreshApiToken() {
     return () => {
       clearInterval(intervalId)
     }
-  }, [client])
+  }, [client, hasRefreshToken])
 
   return <></>
 }


### PR DESCRIPTION
Fixes #1034 

Login → token refresh works
Logout → refresh loop stops (no background renew requests)

@kunal-595 @theborakompanioni @saurabhraghuvanshii 