### PR TITLE
fix broken i18n keys in EarnPage and OfferCard

### DIFF
--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -119,8 +119,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
       setIsWaitingMakerStart(false)
       console.error('StartMaker error:', error)
       const reason = error.message ?? error.error_description ?? t('global.errors.reason_unknown')
-      // TODO: i18n
-      toast.error(`Error while starting the earn process. Reason: ${reason}`)
+      toast.error(t('earn.alert_start_failed', { reason }))
     },
   })
 
@@ -180,8 +179,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
       toast.dismiss('earn.alert_stopping')
       toast.dismiss('earn.alert_starting')
       toast.dismiss('earn.alert_running')
-      // TODO: i18n!
-      toast.success('Service successfully stopped.', { id: 'earn.alert_stopped' })
+      toast.success(t('earn.alert_stopped'), { id: 'earn.alert_stopped' })
     }
   }
 
@@ -203,7 +201,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
       {waitingForOfferUpdate && (
         <Alert variant="default" className="motion-safe:animate-in blur-in my-2">
           <Spinner className="motion-reduce:hidden" />
-          <AlertTitle>{/* TODO: i18n*/ t('Loading offer...')}</AlertTitle>
+          <AlertTitle>{t('earn.alert_loading_offer')}</AlertTitle>
         </Alert>
       )}
 

--- a/src/components/earn/OfferCard.tsx
+++ b/src/components/earn/OfferCard.tsx
@@ -56,12 +56,7 @@ export function OfferCard({ className, value, nickname, children }: PropsWithChi
         <div className="flex items-center gap-4">
           <FingerprintIcon />
           <div className="flex flex-col">
-            <Label className="font-semibold">
-              {
-                /*TODO: i18n*/
-                t('Offer Id')
-              }
-            </Label>
+            <Label className="font-semibold">{t('earn.current.text_offer_id')}</Label>
             <span className="text-md font-mono select-all">
               {nickname}:{value?.oid}
             </span>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -455,6 +455,9 @@
     "error_loading_report_failed": "Failed to load earnings report.",
     "alert_starting": "Service is starting.",
     "alert_stopping": "Service is stopping.",
+    "alert_stopped": "Service successfully stopped.",
+    "alert_start_failed": "Error while starting the earn process. Reason: {{ reason }}",
+    "alert_loading_offer": "Loading offer...",
     "alert_running": "Offering sats to earn more sats...",
     "alert_coinjoin_in_progress": "A collaborative transaction is currently in progress.",
     "button_settings": "Offer options",
@@ -483,6 +486,7 @@
       "text_minsize": "Minimum Size",
       "text_maxsize": "Maximum Size",
       "text_txfee": "Transaction Fee",
+      "text_offer_id": "Offer Id",
       "text_offer_type_absolute": "absolute",
       "text_offer_type_relative": "relative"
     },


### PR DESCRIPTION
#1023
fixes broken i18n keys in EarnPage and OfferCard by replacing hardcoded strings with proper translations