### PR TITLE
fix(utils): truncate btcToSats beyond 8 decimals

### DIFF
--- a/src/components/ui/jam/Balance.tsx
+++ b/src/components/ui/jam/Balance.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { CurrencySymbol } from '@/components/ui/jam/CurrencySymbol'
 import { useJamDisplayContext } from '@/context/JamDisplayContext'
-import { cn, satsToBtc, btcToSats, isValidNumber, formatBtc, formatSats, SATS, BTC, type Unit } from '@/lib/utils'
+import { cn, satsToBtc, tryBtcToSat, isValidNumber, formatBtc, formatSats, SATS, BTC, type Unit } from '@/lib/utils'
 import type { Currency } from '@/types/global'
 
 const DISPLAY_MODE_BTC: Currency = 'btc'
@@ -178,7 +178,12 @@ export const Balance = ({ valueString, convertToUnit, showBalance = true, ...pro
       if (valueIsSats) {
         return <SatsBalance value={valueNumber} {...props} />
       } else {
-        return <SatsBalance value={btcToSats(valueString)} {...props} />
+        const valueInSats = tryBtcToSat(valueString)
+        if (!isValidNumber(valueInSats)) {
+          console.warn('<Balance /> component expects decimal BTC input in plain notation')
+          return <BalanceComponent {...props}>{valueString}</BalanceComponent>
+        }
+        return <SatsBalance value={valueInSats} {...props} />
       }
     }
 

--- a/src/components/wallet/AccountDetailsTabContent.tsx
+++ b/src/components/wallet/AccountDetailsTabContent.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import type { AccountBranch, AccountMeta } from '@/context/JamWalletInfoContext'
 import { statusTags } from '@/lib/tags'
-import { btcToSats, isValidNumber } from '@/lib/utils'
+import { tryBtcToSat, isValidNumber } from '@/lib/utils'
 import type { HdPath } from '@/types/global'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion'
 import { BranchEntryTable, type BranchEntryApiObject, type BranchEntryTableRow } from './BranchEntryTable'
@@ -40,7 +40,7 @@ const branchToTableEntry = (value: BranchEntryApiObject): BranchEntryTableRow =>
     derivationIndex: toLastHdPathIndex(value.hd_path as HdPath) ?? -1,
     derivationPath: (value.hd_path !== undefined ? value.hd_path : 'm/-1') as HdPath,
     address: value.address || '',
-    balance: btcToSats(value.amount || '0'),
+    balance: tryBtcToSat(value.amount || '0') ?? 0,
     tags: statusTags(value.status || ''),
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -158,6 +158,30 @@ describe('btcToSats', () => {
     expect(btcToSats('0.000000005')).toBe(0) // 0.5 sats truncates down to 0
     expect(btcToSats('0.00000003')).toBe(3) // Avoids floating point errors for exact-sat values
   })
+
+  it('should handle signs and whitespace', () => {
+    expect(btcToSats('+1')).toBe(100000000)
+    expect(btcToSats(' -1 ')).toBe(-100000000)
+    expect(btcToSats('-0.00000001')).toBe(-1)
+    expect(btcToSats('-0.000000005')).toBe(0) // Truncates towards 0 (no -0)
+  })
+
+  it('should handle exponent notation', () => {
+    expect(btcToSats('3e-8')).toBe(3)
+    expect(btcToSats('3E-8')).toBe(3)
+    expect(btcToSats('1e-8')).toBe(1)
+    expect(btcToSats('-3e-8')).toBe(-3)
+    expect(btcToSats('1e2')).toBe(10000000000) // 100 BTC
+  })
+
+  it('should return NaN for invalid values', () => {
+    expect(btcToSats('')).toBeNaN()
+    expect(btcToSats('   ')).toBeNaN()
+    expect(btcToSats('.')).toBeNaN()
+    expect(btcToSats('+')).toBeNaN()
+    expect(btcToSats('-')).toBeNaN()
+    expect(btcToSats('abc')).toBeNaN()
+  })
 })
 
 describe('parseSemanticVersion', () => {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -152,10 +152,11 @@ describe('btcToSats', () => {
     expect(btcToSats('0')).toBe(0)
   })
 
-  it('should handle rounding', () => {
+  it('should truncate beyond 8 decimals', () => {
     expect(btcToSats('0.123456789')).toBe(12345678) // Truncates beyond 8 decimals
     expect(btcToSats('0.000000004')).toBe(0) // Less than 0.5 sats truncates down
     expect(btcToSats('0.000000005')).toBe(0) // 0.5 sats truncates down to 0
+    expect(btcToSats('0.00000003')).toBe(3) // Avoids floating point errors for exact-sat values
   })
 })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -153,9 +153,9 @@ describe('btcToSats', () => {
   })
 
   it('should handle rounding', () => {
-    expect(btcToSats('0.123456789')).toBe(12345679) // Rounds to nearest integer
-    expect(btcToSats('0.000000004')).toBe(0) // Less than 0.5 sats rounds down
-    expect(btcToSats('0.000000005')).toBe(1) // TODO fix this 0.5 sats should rounds down to 0
+    expect(btcToSats('0.123456789')).toBe(12345678) // Truncates beyond 8 decimals
+    expect(btcToSats('0.000000004')).toBe(0) // Less than 0.5 sats truncates down
+    expect(btcToSats('0.000000005')).toBe(0) // 0.5 sats truncates down to 0
   })
 })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,7 +5,7 @@ import {
   walletDisplayName,
   setIntervalDebounced,
   satsToBtc,
-  btcToSats,
+  tryBtcToSat,
   percentageToFactor,
   isValidNumber,
   factorToPercentage,
@@ -144,43 +144,43 @@ describe('satsToBtc', () => {
   })
 })
 
-describe('btcToSats', () => {
+describe('tryBtcToSat', () => {
   it('should correctly convert BTC to satoshis', () => {
-    expect(btcToSats('1')).toBe(100000000)
-    expect(btcToSats('0.5')).toBe(50000000)
-    expect(btcToSats('0.00001')).toBe(1000)
-    expect(btcToSats('0')).toBe(0)
+    expect(tryBtcToSat('1')).toBe(100000000)
+    expect(tryBtcToSat('0.5')).toBe(50000000)
+    expect(tryBtcToSat('0.00001')).toBe(1000)
+    expect(tryBtcToSat('0')).toBe(0)
   })
 
   it('should truncate beyond 8 decimals', () => {
-    expect(btcToSats('0.123456789')).toBe(12345678) // Truncates beyond 8 decimals
-    expect(btcToSats('0.000000004')).toBe(0) // Less than 0.5 sats truncates down
-    expect(btcToSats('0.000000005')).toBe(0) // 0.5 sats truncates down to 0
-    expect(btcToSats('0.00000003')).toBe(3) // Avoids floating point errors for exact-sat values
+    expect(tryBtcToSat('0.123456789')).toBe(12345678) // Truncates beyond 8 decimals
+    expect(tryBtcToSat('0.000000004')).toBe(0) // Less than 0.5 sats truncates down
+    expect(tryBtcToSat('0.000000005')).toBe(0) // 0.5 sats truncates down to 0
+    expect(tryBtcToSat('0.00000003')).toBe(3) // Avoids floating point errors for exact-sat values
   })
 
   it('should handle signs and whitespace', () => {
-    expect(btcToSats('+1')).toBe(100000000)
-    expect(btcToSats(' -1 ')).toBe(-100000000)
-    expect(btcToSats('-0.00000001')).toBe(-1)
-    expect(btcToSats('-0.000000005')).toBe(0) // Truncates towards 0 (no -0)
+    expect(tryBtcToSat('+1')).toBe(100000000)
+    expect(tryBtcToSat(' -1 ')).toBe(-100000000)
+    expect(tryBtcToSat('-0.00000001')).toBe(-1)
+    expect(tryBtcToSat('-0.000000005')).toBe(0) // Truncates towards 0 (no -0)
   })
 
-  it('should handle exponent notation', () => {
-    expect(btcToSats('3e-8')).toBe(3)
-    expect(btcToSats('3E-8')).toBe(3)
-    expect(btcToSats('1e-8')).toBe(1)
-    expect(btcToSats('-3e-8')).toBe(-3)
-    expect(btcToSats('1e2')).toBe(10000000000) // 100 BTC
+  it('should return undefined for exponent notation', () => {
+    expect(tryBtcToSat('3e-8')).toBeUndefined()
+    expect(tryBtcToSat('3E-8')).toBeUndefined()
+    expect(tryBtcToSat('1e2')).toBeUndefined()
   })
 
-  it('should return NaN for invalid values', () => {
-    expect(btcToSats('')).toBeNaN()
-    expect(btcToSats('   ')).toBeNaN()
-    expect(btcToSats('.')).toBeNaN()
-    expect(btcToSats('+')).toBeNaN()
-    expect(btcToSats('-')).toBeNaN()
-    expect(btcToSats('abc')).toBeNaN()
+  it('should return undefined for invalid values', () => {
+    expect(tryBtcToSat('')).toBeUndefined()
+    expect(tryBtcToSat('   ')).toBeUndefined()
+    expect(tryBtcToSat('.')).toBeUndefined()
+    expect(tryBtcToSat('+')).toBeUndefined()
+    expect(tryBtcToSat('-')).toBeUndefined()
+    expect(tryBtcToSat('abc')).toBeUndefined()
+    expect(tryBtcToSat('1.2.3')).toBeUndefined()
+    expect(tryBtcToSat('+.1')).toBeUndefined()
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -91,6 +91,7 @@ export function setIntervalDebounced(
 export const satsToBtc = (value: string) => Number.parseInt(value, 10) / 100_000_000
 
 const isAsciiDigits = (value: string) => {
+  if (value.length === 0) return false
   for (const char of value) {
     const codePoint = char.codePointAt(0)
     if (codePoint === undefined || codePoint < 48 || codePoint > 57) return false
@@ -98,8 +99,25 @@ const isAsciiDigits = (value: string) => {
   return true
 }
 
+const parseIntStrict = (value: string) => {
+  if (value.length === 0) return undefined
+
+  let sign = 1
+  let digits = value
+  if (digits.startsWith('-')) {
+    sign = -1
+    digits = digits.slice(1)
+  } else if (digits.startsWith('+')) {
+    digits = digits.slice(1)
+  }
+
+  if (!isAsciiDigits(digits)) return undefined
+  return sign * Number.parseInt(digits, 10)
+}
+
 export const btcToSats = (value: string) => {
   const trimmed = value.trim()
+  if (trimmed === '') return Number.NaN
 
   let sign = 1
   let numericPart = trimmed
@@ -110,21 +128,42 @@ export const btcToSats = (value: string) => {
     numericPart = numericPart.slice(1)
   }
 
-  // Fast path for plain decimal notation: do a string-based conversion to avoid floating point issues.
-  if (!numericPart.includes('e') && !numericPart.includes('E')) {
-    const dotIndex = numericPart.indexOf('.')
-    const hasOnlyOneDot = dotIndex === -1 || !numericPart.includes('.', dotIndex + 1)
-    if (hasOnlyOneDot) {
-      const wholePartRaw = dotIndex === -1 ? numericPart : numericPart.slice(0, dotIndex)
-      const fractionalPartRaw = dotIndex === -1 ? '' : numericPart.slice(dotIndex + 1)
-      const wholePartDigits = wholePartRaw === '' ? '0' : wholePartRaw
+  // String parsing (supports decimals and `e` notation) to avoid floating point precision issues.
+  const exponentMarkerIndexLower = numericPart.indexOf('e')
+  const exponentMarkerIndexUpper = numericPart.indexOf('E')
+  const exponentMarkerIndex =
+    exponentMarkerIndexLower === -1
+      ? exponentMarkerIndexUpper
+      : exponentMarkerIndexUpper === -1
+        ? exponentMarkerIndexLower
+        : Math.min(exponentMarkerIndexLower, exponentMarkerIndexUpper)
+  const mantissaPart = exponentMarkerIndex === -1 ? numericPart : numericPart.slice(0, exponentMarkerIndex)
+  const exponentPart = exponentMarkerIndex === -1 ? undefined : numericPart.slice(exponentMarkerIndex + 1)
 
-      if (isAsciiDigits(wholePartDigits) && isAsciiDigits(fractionalPartRaw)) {
-        // Truncate beyond 8 decimals (no rounding up of fractional sats).
-        const fractionalPartPadded = (fractionalPartRaw + '00000000').slice(0, 8)
-        const sats = BigInt(wholePartDigits) * 100000000n + BigInt(fractionalPartPadded || '0')
-        const result = sign * Number(sats)
-        return result === 0 ? 0 : result
+  const dotIndex = mantissaPart.indexOf('.')
+  const hasAtMostOneDot = dotIndex === -1 || !mantissaPart.includes('.', dotIndex + 1)
+  if (hasAtMostOneDot) {
+    const wholePartRaw = dotIndex === -1 ? mantissaPart : mantissaPart.slice(0, dotIndex)
+    const fractionalPartRaw = dotIndex === -1 ? '' : mantissaPart.slice(dotIndex + 1)
+
+    // Must contain at least one digit somewhere.
+    if (wholePartRaw !== '' || fractionalPartRaw !== '') {
+      const wholePartDigits = wholePartRaw === '' ? '0' : wholePartRaw
+      const fractionalIsValid = fractionalPartRaw === '' || isAsciiDigits(fractionalPartRaw)
+
+      if (isAsciiDigits(wholePartDigits) && fractionalIsValid) {
+        const parsedExponent = exponentPart ? parseIntStrict(exponentPart) : 0
+        if (parsedExponent !== undefined) {
+          const digits = wholePartDigits + fractionalPartRaw
+          const scale = fractionalPartRaw.length
+          const satExponent = parsedExponent + 8 - scale
+
+          const mantissa = BigInt(digits)
+          const sats =
+            satExponent >= 0 ? mantissa * 10n ** BigInt(satExponent) : mantissa / 10n ** BigInt(Math.abs(satExponent))
+
+          return sats === 0n ? 0 : sign * Number(sats)
+        }
       }
     }
   }
@@ -132,7 +171,7 @@ export const btcToSats = (value: string) => {
   const parsed = Number.parseFloat(trimmed)
   if (!Number.isFinite(parsed)) return Number.NaN
 
-  // Fallback for non-decimal inputs (e.g. scientific notation). Truncate towards 0.
+  // Fallback for unrecognized inputs. Truncate towards 0.
   return Math.trunc(parsed * 100_000_000)
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,7 +90,27 @@ export function setIntervalDebounced(
 
 export const satsToBtc = (value: string) => Number.parseInt(value, 10) / 100_000_000
 
-export const btcToSats = (value: string) => Math.round(Number.parseFloat(value) * 100_000_000)
+export const btcToSats = (value: string) => {
+  const trimmed = value.trim()
+
+  const decimalMatch = /^([+-]?)(\d+)(?:\.(\d+))?$/.exec(trimmed)
+  if (decimalMatch) {
+    const sign = decimalMatch[1] === '-' ? -1 : 1
+    const wholePart = BigInt(decimalMatch[2])
+    const fractionalPartRaw = decimalMatch[3] ?? ''
+    // Truncate beyond 8 decimals (no rounding up of fractional sats).
+    const fractionalPartPadded = (fractionalPartRaw + '00000000').slice(0, 8)
+
+    const sats = wholePart * 100000000n + BigInt(fractionalPartPadded)
+    return sign * Number(sats)
+  }
+
+  const parsed = Number.parseFloat(trimmed)
+  if (!Number.isFinite(parsed)) return Number.NaN
+
+  // Fallback for non-decimal inputs (e.g. scientific notation). Truncate towards 0.
+  return Math.trunc(parsed * 100_000_000)
+}
 
 export const SEGWIT_ACTIVATION_BLOCK = 481_824 // https://github.com/bitcoin/bitcoin/blob/v25.0/src/kernel/chainparams.cpp#L86
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -99,25 +99,9 @@ const isAsciiDigits = (value: string) => {
   return true
 }
 
-const parseIntStrict = (value: string) => {
-  if (value.length === 0) return undefined
-
-  let sign = 1
-  let digits = value
-  if (digits.startsWith('-')) {
-    sign = -1
-    digits = digits.slice(1)
-  } else if (digits.startsWith('+')) {
-    digits = digits.slice(1)
-  }
-
-  if (!isAsciiDigits(digits)) return undefined
-  return sign * Number.parseInt(digits, 10)
-}
-
-export const btcToSats = (value: string) => {
+export const tryBtcToSat = (value: string): number | undefined => {
   const trimmed = value.trim()
-  if (trimmed === '') return Number.NaN
+  if (trimmed === '') return undefined
 
   let sign = 1
   let numericPart = trimmed
@@ -128,51 +112,25 @@ export const btcToSats = (value: string) => {
     numericPart = numericPart.slice(1)
   }
 
-  // String parsing (supports decimals and `e` notation) to avoid floating point precision issues.
-  const exponentMarkerIndexLower = numericPart.indexOf('e')
-  const exponentMarkerIndexUpper = numericPart.indexOf('E')
-  const exponentMarkerIndex =
-    exponentMarkerIndexLower === -1
-      ? exponentMarkerIndexUpper
-      : exponentMarkerIndexUpper === -1
-        ? exponentMarkerIndexLower
-        : Math.min(exponentMarkerIndexLower, exponentMarkerIndexUpper)
-  const mantissaPart = exponentMarkerIndex === -1 ? numericPart : numericPart.slice(0, exponentMarkerIndex)
-  const exponentPart = exponentMarkerIndex === -1 ? undefined : numericPart.slice(exponentMarkerIndex + 1)
+  // Keep this strict and simple: only plain decimal strings (no scientific notation).
+  if (numericPart.includes('e') || numericPart.includes('E')) return undefined
 
-  const dotIndex = mantissaPart.indexOf('.')
-  const hasAtMostOneDot = dotIndex === -1 || !mantissaPart.includes('.', dotIndex + 1)
-  if (hasAtMostOneDot) {
-    const wholePartRaw = dotIndex === -1 ? mantissaPart : mantissaPart.slice(0, dotIndex)
-    const fractionalPartRaw = dotIndex === -1 ? '' : mantissaPart.slice(dotIndex + 1)
+  const dotIndex = numericPart.indexOf('.')
+  const hasAtMostOneDot = dotIndex === -1 || !numericPart.includes('.', dotIndex + 1)
+  if (!hasAtMostOneDot) return undefined
 
-    // Must contain at least one digit somewhere.
-    if (wholePartRaw !== '' || fractionalPartRaw !== '') {
-      const wholePartDigits = wholePartRaw === '' ? '0' : wholePartRaw
-      const fractionalIsValid = fractionalPartRaw === '' || isAsciiDigits(fractionalPartRaw)
+  const wholePartRaw = dotIndex === -1 ? numericPart : numericPart.slice(0, dotIndex)
+  const fractionalPartRaw = dotIndex === -1 ? '' : numericPart.slice(dotIndex + 1)
 
-      if (isAsciiDigits(wholePartDigits) && fractionalIsValid) {
-        const parsedExponent = exponentPart ? parseIntStrict(exponentPart) : 0
-        if (parsedExponent !== undefined) {
-          const digits = wholePartDigits + fractionalPartRaw
-          const scale = fractionalPartRaw.length
-          const satExponent = parsedExponent + 8 - scale
+  // Expect: [+-]?\\d+\\.?\\d*
+  if (!isAsciiDigits(wholePartRaw)) return undefined
+  if (fractionalPartRaw !== '' && !isAsciiDigits(fractionalPartRaw)) return undefined
 
-          const mantissa = BigInt(digits)
-          const sats =
-            satExponent >= 0 ? mantissa * 10n ** BigInt(satExponent) : mantissa / 10n ** BigInt(Math.abs(satExponent))
-
-          return sats === 0n ? 0 : sign * Number(sats)
-        }
-      }
-    }
-  }
-
-  const parsed = Number.parseFloat(trimmed)
-  if (!Number.isFinite(parsed)) return Number.NaN
-
-  // Fallback for unrecognized inputs. Truncate towards 0.
-  return Math.trunc(parsed * 100_000_000)
+  const wholePart = Number.parseInt(wholePartRaw, 10)
+  const fractionalPart =
+    fractionalPartRaw === '' ? 0 : Number.parseInt((fractionalPartRaw + '00000000').slice(0, 8), 10)
+  const sats = wholePart * 100_000_000 + fractionalPart
+  return sats === 0 ? 0 : sign * sats
 }
 
 export const SEGWIT_ACTIVATION_BLOCK = 481_824 // https://github.com/bitcoin/bitcoin/blob/v25.0/src/kernel/chainparams.cpp#L86

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,19 +90,43 @@ export function setIntervalDebounced(
 
 export const satsToBtc = (value: string) => Number.parseInt(value, 10) / 100_000_000
 
+const isAsciiDigits = (value: string) => {
+  for (const char of value) {
+    const codePoint = char.codePointAt(0)
+    if (codePoint === undefined || codePoint < 48 || codePoint > 57) return false
+  }
+  return true
+}
+
 export const btcToSats = (value: string) => {
   const trimmed = value.trim()
 
-  const decimalMatch = /^([+-]?)(\d+)(?:\.(\d+))?$/.exec(trimmed)
-  if (decimalMatch) {
-    const sign = decimalMatch[1] === '-' ? -1 : 1
-    const wholePart = BigInt(decimalMatch[2])
-    const fractionalPartRaw = decimalMatch[3] ?? ''
-    // Truncate beyond 8 decimals (no rounding up of fractional sats).
-    const fractionalPartPadded = (fractionalPartRaw + '00000000').slice(0, 8)
+  let sign = 1
+  let numericPart = trimmed
+  if (numericPart.startsWith('-')) {
+    sign = -1
+    numericPart = numericPart.slice(1)
+  } else if (numericPart.startsWith('+')) {
+    numericPart = numericPart.slice(1)
+  }
 
-    const sats = wholePart * 100000000n + BigInt(fractionalPartPadded)
-    return sign * Number(sats)
+  // Fast path for plain decimal notation: do a string-based conversion to avoid floating point issues.
+  if (!numericPart.includes('e') && !numericPart.includes('E')) {
+    const dotIndex = numericPart.indexOf('.')
+    const hasOnlyOneDot = dotIndex === -1 || !numericPart.includes('.', dotIndex + 1)
+    if (hasOnlyOneDot) {
+      const wholePartRaw = dotIndex === -1 ? numericPart : numericPart.slice(0, dotIndex)
+      const fractionalPartRaw = dotIndex === -1 ? '' : numericPart.slice(dotIndex + 1)
+      const wholePartDigits = wholePartRaw === '' ? '0' : wholePartRaw
+
+      if (isAsciiDigits(wholePartDigits) && isAsciiDigits(fractionalPartRaw)) {
+        // Truncate beyond 8 decimals (no rounding up of fractional sats).
+        const fractionalPartPadded = (fractionalPartRaw + '00000000').slice(0, 8)
+        const sats = BigInt(wholePartDigits) * 100000000n + BigInt(fractionalPartPadded || '0')
+        const result = sign * Number(sats)
+        return result === 0 ? 0 : result
+      }
+    }
   }
 
   const parsed = Number.parseFloat(trimmed)


### PR DESCRIPTION
### what this PR does : - 
- `btcToSats` now truncates beyond 8 decimals (no rounding up fractional sats).
- Updates unit tests (e.g. `0.000000005 BTC -> 0 sats`).


@theborakompanioni  @saurabhraghuvanshii 