### PR TITLE
refactor(logs): dedupe log viewer

### DIFF
--- a/src/components/LogsContent.tsx
+++ b/src/components/LogsContent.tsx
@@ -1,136 +1,9 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
-import { AlertTriangleIcon, Loader2Icon, RefreshCwIcon, DownloadIcon, ArrowDownIcon } from 'lucide-react'
+import { AlertTriangleIcon, Loader2Icon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useStore } from 'zustand'
+import { LogViewer } from '@/components/logging/LogViewer'
+import { useJmwalletdStdoutLog } from '@/components/logging/useJmwalletdStdoutLog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { isDevMode } from '@/constants/debugFeatures'
-import { fetchLog } from '@/lib/api/logs'
-import { cn, delayedPromise } from '@/lib/utils'
-import { authStore } from '@/store/authStore'
-
-const JMWALLETD_LOG_FILE_NAME = 'jmwalletd_stdout.log'
-
-interface SimpleAlert {
-  variant: React.ComponentProps<typeof Alert>['variant']
-  message: string
-}
-
-interface LogViewerProps {
-  value: string
-  refresh: (signal: AbortSignal) => Promise<void>
-}
-
-function LogViewer({ value, refresh }: LogViewerProps) {
-  const { t } = useTranslation()
-  const logContentRef = useRef<HTMLPreElement>(null)
-  const [isLoadingRefresh, setIsLoadingRefresh] = useState(false)
-  const [logScrollProgress, setLogScrollProgress] = useState(0)
-  const isScrolledToLogBottom = useMemo(() => logScrollProgress >= 0.995, [logScrollProgress])
-
-  const scrollToLogBottom = () => {
-    logContentRef.current?.scrollTo({
-      top: logContentRef.current.scrollHeight,
-      behavior: 'smooth',
-    })
-  }
-
-  const logScrollHandler = (event: React.UIEvent<HTMLPreElement>) => {
-    const containerHeight = event.currentTarget.clientHeight
-    const scrollHeight = event.currentTarget.scrollHeight
-
-    const scrollTop = event.currentTarget.scrollTop
-    setLogScrollProgress((scrollTop + containerHeight) / scrollHeight)
-  }
-
-  useEffect(() => {
-    if (!value) return
-    scrollToLogBottom()
-  }, [value])
-
-  const handleRefresh = useCallback(async () => {
-    if (isLoadingRefresh) return
-
-    setIsLoadingRefresh(true)
-    const abortCtrl = new AbortController()
-
-    try {
-      await refresh(abortCtrl.signal).then(() => delayedPromise(210))
-    } finally {
-      setIsLoadingRefresh(false)
-    }
-  }, [isLoadingRefresh, refresh])
-
-  const handleDownload = useCallback(() => {
-    const blob = new Blob([value], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = JMWALLETD_LOG_FILE_NAME
-    document.body.append(a)
-    a.click()
-    a.remove()
-    setTimeout(() => {
-      URL.revokeObjectURL(url)
-    }, 4)
-  }, [value])
-
-  return (
-    <Card className="flex flex-1 flex-col overflow-hidden pb-0">
-      <CardHeader className="flex flex-col justify-center gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <CardTitle className="font-mono break-all select-all">{JMWALLETD_LOG_FILE_NAME}</CardTitle>
-        <div className="flex items-center justify-end gap-2">
-          <Button
-            className="hover:[&>svg]:motion-safe:animate-bounce"
-            variant="outline"
-            onClick={handleDownload}
-            disabled={!value || isLoadingRefresh}
-            title={t('global.download')}
-          >
-            <DownloadIcon className="group/download" />
-            {t('global.download')}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => void handleRefresh()}
-            disabled={isLoadingRefresh}
-            title={t('global.refresh')}
-          >
-            <RefreshCwIcon
-              className={cn({
-                'animate-spin': isLoadingRefresh,
-              })}
-            />
-            {t('global.refresh')}
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="relative flex-1 overflow-hidden rounded-b-xl p-0">
-        <pre
-          onScrollEnd={logScrollHandler}
-          ref={logContentRef}
-          className="bg-muted/90 absolute inset-0 overflow-auto rounded-b-xl px-2 py-2 font-mono text-sm break-words whitespace-pre-wrap"
-        >
-          {value}
-        </pre>
-        <Button
-          className={cn('absolute top-2 right-2 size-12', {
-            'opacity-25 hover:opacity-50': !isScrolledToLogBottom,
-            hidden: isScrolledToLogBottom,
-          })}
-          variant={isScrolledToLogBottom ? 'ghost' : 'default'}
-          disabled={isScrolledToLogBottom}
-          size="icon"
-          onClick={scrollToLogBottom}
-          title={/* TODO: i18n */ 'Scroll to bottom'}
-        >
-          <ArrowDownIcon />
-        </Button>
-      </CardContent>
-    </Card>
-  )
-}
+import { cn } from '@/lib/utils'
 
 interface LogsContentProps {
   className?: string
@@ -138,63 +11,8 @@ interface LogsContentProps {
 }
 
 export const LogsContent = ({ enabled, className }: LogsContentProps) => {
-  const authState = useStore(authStore, (state) => state.state)
   const { t } = useTranslation()
-  const [alert, setAlert] = useState<SimpleAlert>()
-  const [isInitialized, setIsInitialized] = useState(false)
-  const [logFileContent, setLogFileContent] = useState<string>()
-
-  const refresh = useCallback(
-    async (signal: AbortSignal) => {
-      if (!authState?.auth?.token) {
-        setAlert({
-          variant: 'destructive',
-          // TODO: i18n
-          message: 'No authentication token available. Please login again.',
-        })
-        throw new Error('No authentication token')
-      }
-
-      return fetchLog({
-        token: authState.auth.token,
-        fileName: JMWALLETD_LOG_FILE_NAME,
-        signal,
-      })
-        .then((response) => (response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`))))
-        .then((data) => {
-          if (signal.aborted) return
-          setAlert(undefined)
-          setLogFileContent(data)
-        })
-        .catch((error: unknown) => {
-          if (signal.aborted) return
-
-          const reason = (error instanceof Error ? error.message : undefined) || t('global.errors.reason_unknown')
-          const errorMessage = t('logs.error_loading_logs_failed', {
-            /* TODO: add reason to i18n string */
-            reason,
-          })
-
-          if (isDevMode()) {
-            setLogFileContent(`${errorMessage}\n`.repeat(1_000))
-          }
-
-          setAlert({
-            variant: 'warning',
-            message: errorMessage,
-          })
-        })
-    },
-    [t, authState],
-  )
-
-  if (enabled && !isInitialized) {
-    const abortCtrl = new AbortController()
-    void refresh(abortCtrl.signal).finally(() => {
-      if (abortCtrl.signal.aborted) return
-      setIsInitialized(true)
-    })
-  }
+  const { alert, isInitialized, logFileContent, refresh, fileName } = useJmwalletdStdoutLog({ enabled })
 
   if (!isInitialized) {
     return (
@@ -214,7 +32,7 @@ export const LogsContent = ({ enabled, className }: LogsContentProps) => {
         </Alert>
       )}
 
-      {logFileContent && <LogViewer value={logFileContent} refresh={refresh} />}
+      {logFileContent && <LogViewer variant="fill" fileName={fileName} value={logFileContent} refresh={refresh} />}
     </div>
   )
 }

--- a/src/components/LogsPage.tsx
+++ b/src/components/LogsPage.tsx
@@ -1,197 +1,14 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
-import { AlertTriangleIcon, RefreshCwIcon, DownloadIcon, ArrowDownIcon } from 'lucide-react'
+import { AlertTriangleIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useStore } from 'zustand'
+import { LogViewer } from '@/components/logging/LogViewer'
+import { useJmwalletdStdoutLog } from '@/components/logging/useJmwalletdStdoutLog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { isDevMode } from '@/constants/debugFeatures'
-import { fetchLog } from '@/lib/api/logs'
-import { cn, delayedPromise } from '@/lib/utils'
-import { authStore } from '@/store/authStore'
 import PageTitle from './ui/jam/PageTitle'
 import { Spinner } from './ui/spinner'
 
-const JMWALLETD_LOG_FILE_NAME = 'jmwalletd_stdout.log'
-
-interface SimpleAlert {
-  variant: React.ComponentProps<typeof Alert>['variant']
-  message: string
-}
-
-interface LogContentProps {
-  value: string
-  refresh: (signal: AbortSignal) => Promise<void>
-}
-
-function LogContent({ value, refresh }: LogContentProps) {
-  const { t } = useTranslation()
-  const logContentRef = useRef<HTMLPreElement>(null)
-  const [isLoadingRefresh, setIsLoadingRefresh] = useState(false)
-  const [logScrollProgress, setLogScrollProgress] = useState(0)
-  const isScrolledToLogBottom = useMemo(() => logScrollProgress >= 0.995, [logScrollProgress])
-
-  const scrollToLogBottom = () => {
-    logContentRef.current?.scrollTo({
-      top: logContentRef.current.scrollHeight,
-      behavior: 'smooth',
-    })
-  }
-
-  const logScrollHandler = (event: React.UIEvent<HTMLPreElement>) => {
-    const containerHeight = event.currentTarget.clientHeight
-    const scrollHeight = event.currentTarget.scrollHeight
-
-    const scrollTop = event.currentTarget.scrollTop
-    setLogScrollProgress((scrollTop + containerHeight) / scrollHeight)
-  }
-
-  useEffect(() => {
-    if (!value) return
-    scrollToLogBottom()
-  }, [value])
-
-  const handleRefresh = useCallback(async () => {
-    if (isLoadingRefresh) return
-
-    setIsLoadingRefresh(true)
-    const abortCtrl = new AbortController()
-
-    try {
-      await refresh(abortCtrl.signal)
-        // Add a short delay to avoid flickering
-        .then(() => delayedPromise(210))
-    } finally {
-      setIsLoadingRefresh(false)
-    }
-  }, [isLoadingRefresh, refresh])
-
-  const handleDownload = useCallback(() => {
-    const blob = new Blob([value], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = JMWALLETD_LOG_FILE_NAME
-    document.body.append(a)
-    a.click()
-    a.remove()
-    setTimeout(() => {
-      URL.revokeObjectURL(url)
-    }, 0)
-  }, [value])
-
-  return (
-    <Card className="pb-0">
-      <CardHeader className="flex flex-col justify-center gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <CardTitle className="font-mono break-all">{JMWALLETD_LOG_FILE_NAME}</CardTitle>
-        <div className="flex items-center justify-end gap-2">
-          <Button
-            className="hover:[&>svg]:motion-safe:animate-bounce"
-            variant="outline"
-            onClick={handleDownload}
-            disabled={!value || isLoadingRefresh}
-            title={t('global.download')}
-          >
-            <DownloadIcon className="group/download" />
-            {t('global.download')}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => void handleRefresh()}
-            disabled={isLoadingRefresh}
-            title={t('global.refresh')}
-          >
-            <RefreshCwIcon className={cn({ 'animate-spin': isLoadingRefresh })} />
-            {t('global.refresh')}
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="relative rounded-b-xl p-0">
-        <pre
-          onScrollEnd={logScrollHandler}
-          ref={logContentRef}
-          className="bg-muted/90 max-h-[600px] min-h-[300px] overflow-auto rounded-b-xl px-2 py-2 font-mono text-sm break-words whitespace-pre-wrap"
-        >
-          {value}
-        </pre>
-        <Button
-          className={cn('absolute top-2 right-2 size-12', {
-            'opacity-25 hover:opacity-50': !isScrolledToLogBottom,
-            hidden: isScrolledToLogBottom,
-          })}
-          variant={isScrolledToLogBottom ? 'ghost' : 'default'}
-          disabled={isScrolledToLogBottom}
-          size="icon"
-          onClick={scrollToLogBottom}
-          title={/* TODO: i18n */ 'Scroll to bottom'}
-        >
-          <ArrowDownIcon />
-        </Button>
-      </CardContent>
-    </Card>
-  )
-}
-
 export const LogsPage = () => {
-  const authState = useStore(authStore, (state) => state.state)
   const { t } = useTranslation()
-  const [alert, setAlert] = useState<SimpleAlert>()
-  const [isInitialized, setIsInitialized] = useState(false)
-  const [logFileContent, setLogFileContent] = useState<string>()
-
-  const refresh = useCallback(
-    async (signal: AbortSignal) => {
-      if (!authState?.auth?.token) {
-        setAlert({
-          variant: 'destructive',
-          // TODO: i18n
-          message: 'No authentication token available. Please login again.',
-        })
-        throw new Error('No authentication token')
-      }
-
-      return fetchLog({
-        token: authState.auth.token,
-        fileName: JMWALLETD_LOG_FILE_NAME,
-        signal,
-      })
-        .then((response) => (response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`))))
-        .then((data) => {
-          if (signal.aborted) return
-          setAlert(undefined)
-          setLogFileContent(data)
-        })
-        .catch((error) => {
-          if (signal.aborted) return
-
-          const reason = (error instanceof Error ? error.message : undefined) || t('global.errors.reason_unknown')
-          const errorMessage = t('logs.error_loading_logs_failed', {
-            /* TODO: add reason to i18n string */
-            reason,
-          })
-
-          if (isDevMode()) {
-            // adding content enables manual testing of other component
-            // and functionality (e.g. downloading, refreshing, etc.)
-            setLogFileContent(`${errorMessage}\n`.repeat(1_000))
-          }
-
-          setAlert({
-            variant: 'warning',
-            message: errorMessage,
-          })
-        })
-    },
-    [t, authState],
-  )
-
-  if (!isInitialized) {
-    const abortCtrl = new AbortController()
-    void refresh(abortCtrl.signal).finally(() => {
-      if (abortCtrl.signal.aborted) return
-      setIsInitialized(true)
-    })
-  }
+  const { alert, isInitialized, logFileContent, refresh, fileName } = useJmwalletdStdoutLog()
 
   if (!isInitialized) {
     return (
@@ -215,7 +32,7 @@ export const LogsPage = () => {
         </Alert>
       )}
 
-      {logFileContent && <LogContent value={logFileContent} refresh={refresh} />}
+      {logFileContent && <LogViewer fileName={fileName} value={logFileContent} refresh={refresh} />}
     </div>
   )
 }

--- a/src/components/logging/LogViewer.tsx
+++ b/src/components/logging/LogViewer.tsx
@@ -1,0 +1,137 @@
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
+import { RefreshCwIcon, DownloadIcon, ArrowDownIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn, delayedPromise } from '@/lib/utils'
+
+type LogViewerVariant = 'page' | 'fill'
+
+interface LogViewerProps {
+  fileName: string
+  value: string
+  refresh: () => Promise<void>
+  variant?: LogViewerVariant
+}
+
+export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogViewerProps) {
+  const { t } = useTranslation()
+  const logContentRef = useRef<HTMLPreElement>(null)
+  const [isLoadingRefresh, setIsLoadingRefresh] = useState(false)
+  const [logScrollProgress, setLogScrollProgress] = useState(0)
+  const isScrolledToLogBottom = useMemo(() => logScrollProgress >= 0.995, [logScrollProgress])
+
+  const isFill = variant === 'fill'
+
+  const scrollToLogBottom = () => {
+    logContentRef.current?.scrollTo({
+      top: logContentRef.current.scrollHeight,
+      behavior: 'smooth',
+    })
+    setLogScrollProgress(1)
+  }
+
+  const logScrollHandler = (event: React.UIEvent<HTMLPreElement>) => {
+    const containerHeight = event.currentTarget.clientHeight
+    const scrollHeight = event.currentTarget.scrollHeight
+
+    const scrollTop = event.currentTarget.scrollTop
+    setLogScrollProgress((scrollTop + containerHeight) / scrollHeight)
+  }
+
+  useEffect(() => {
+    if (!value) return
+    scrollToLogBottom()
+  }, [value])
+
+  const handleRefresh = useCallback(async () => {
+    if (isLoadingRefresh) return
+
+    setIsLoadingRefresh(true)
+
+    try {
+      await refresh().then(() => delayedPromise(210))
+    } finally {
+      setIsLoadingRefresh(false)
+    }
+  }, [isLoadingRefresh, refresh])
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([value], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = fileName
+    document.body.append(a)
+    a.click()
+    a.remove()
+    setTimeout(() => {
+      URL.revokeObjectURL(url)
+    }, 0)
+  }, [fileName, value])
+
+  return (
+    <Card
+      className={cn('pb-0', {
+        'flex flex-1 flex-col overflow-hidden': isFill,
+      })}
+    >
+      <CardHeader className="flex flex-col justify-center gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <CardTitle className="font-mono break-all select-all">{fileName}</CardTitle>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            className="hover:[&>svg]:motion-safe:animate-bounce"
+            variant="outline"
+            onClick={handleDownload}
+            disabled={!value || isLoadingRefresh}
+            title={t('global.download')}
+          >
+            <DownloadIcon className="group/download" />
+            {t('global.download')}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => void handleRefresh()}
+            disabled={isLoadingRefresh}
+            title={t('global.refresh')}
+          >
+            <RefreshCwIcon className={cn({ 'animate-spin': isLoadingRefresh })} />
+            {t('global.refresh')}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent
+        className={cn('relative rounded-b-xl p-0', {
+          'flex-1 overflow-hidden': isFill,
+        })}
+      >
+        <pre
+          onScroll={logScrollHandler}
+          ref={logContentRef}
+          className={cn(
+            'bg-muted/90 overflow-auto rounded-b-xl px-2 py-2 font-mono text-sm break-words whitespace-pre-wrap',
+            {
+              'max-h-[600px] min-h-[300px]': !isFill,
+              'absolute inset-0': isFill,
+            },
+          )}
+        >
+          {value}
+        </pre>
+        <Button
+          className={cn('absolute top-2 right-2 size-12', {
+            'opacity-25 hover:opacity-50': !isScrolledToLogBottom,
+            hidden: isScrolledToLogBottom,
+          })}
+          variant={isScrolledToLogBottom ? 'ghost' : 'default'}
+          disabled={isScrolledToLogBottom}
+          size="icon"
+          onClick={scrollToLogBottom}
+          title={/* TODO: i18n */ 'Scroll to bottom'}
+        >
+          <ArrowDownIcon />
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/logging/useJmwalletdStdoutLog.ts
+++ b/src/components/logging/useJmwalletdStdoutLog.ts
@@ -1,0 +1,85 @@
+import type { ComponentProps } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { useStore } from 'zustand'
+import { Alert } from '@/components/ui/alert'
+import { isDevMode } from '@/constants/debugFeatures'
+import { fetchLog } from '@/lib/api/logs'
+import { authStore } from '@/store/authStore'
+
+const JMWALLETD_LOG_FILE_NAME = 'jmwalletd_stdout.log'
+
+interface SimpleAlert {
+  variant: ComponentProps<typeof Alert>['variant']
+  message: string
+}
+
+interface UseJmwalletdStdoutLogParameters {
+  enabled?: boolean
+}
+
+export function useJmwalletdStdoutLog({ enabled = true }: UseJmwalletdStdoutLogParameters = {}) {
+  const authState = useStore(authStore, (state) => state.state)
+  const { t } = useTranslation()
+  const token = authState?.auth?.token
+
+  const logQuery = useQuery({
+    queryKey: ['logs', JMWALLETD_LOG_FILE_NAME, token],
+    enabled: enabled && token !== undefined,
+    retry: false,
+    queryFn: ({ signal }) => {
+      if (token === undefined) return Promise.resolve('')
+      return fetchLog({
+        token,
+        fileName: JMWALLETD_LOG_FILE_NAME,
+        signal,
+      }).then((response) => (response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`))))
+    },
+  })
+
+  const alert = useMemo<SimpleAlert | undefined>(() => {
+    if (!enabled) return undefined
+
+    if (token === undefined) {
+      return {
+        variant: 'destructive',
+        // TODO: i18n
+        message: 'No authentication token available. Please login again.',
+      }
+    }
+
+    if (!logQuery.error) return undefined
+
+    const reason =
+      (logQuery.error instanceof Error ? logQuery.error.message : undefined) || t('global.errors.reason_unknown')
+    const errorMessage = t('logs.error_loading_logs_failed', {
+      /* TODO: add reason to i18n string */
+      reason,
+    })
+
+    return {
+      variant: 'warning',
+      message: errorMessage,
+    }
+  }, [enabled, logQuery.error, t, token])
+
+  const isInitialized = useMemo(() => {
+    if (!enabled) return false
+    if (token === undefined) return true
+    return logQuery.isFetched
+  }, [enabled, logQuery.isFetched, token])
+
+  const logFileContent = useMemo(() => {
+    if (logQuery.data) return logQuery.data
+    if (!isDevMode() || alert?.variant !== 'warning') return undefined
+    return `${alert.message}\n`.repeat(1_000)
+  }, [alert, logQuery.data])
+
+  const refresh = useCallback(async () => {
+    if (token === undefined) return
+    await logQuery.refetch()
+  }, [logQuery, token])
+
+  return { alert, isInitialized, logFileContent, refresh, fileName: JMWALLETD_LOG_FILE_NAME }
+}


### PR DESCRIPTION
Closes: #1042 

what this PR contains : - 
deduplicates the jmwalletd log viewer implementation between the logs page and logs overlay.
introduces reusable `LogViewer` + a shared hook to fetch/refresh `jmwalletd_stdout.log`.


why it should be done : - 
reduces duplicate code and keeps logs UX consistent in v2.
centralises refresh/error handling to avoid drift.

it is tested locally everything looks good 
@theborakompanioni @saurabhraghuvanshii @kunal-595 
