### PR TITLE
chore(lint): ignore build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+build
 *.local
 
 # Environment variables

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+# TODO(v2-cleanup): remove after v2 branch is merged; legacy `devel` (CRA) outputs `build/`
 build
 *.local
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Dist folder
 dist/
+build/
 
 # Other common ignores
 node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Dist folder
 dist/
+# TODO(v2-cleanup): remove after v2 branch is merged; legacy `devel` (CRA) outputs `build/`
 build/
 
 # Other common ignores

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default defineConfig(
+  // TODO(v2-cleanup): remove `build` ignore after v2 branch is merged; legacy `devel` (CRA) outputs `build/`
   { ignores: ['dist', 'build', './.storybook/**', './storybook-static/**'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default defineConfig(
-  { ignores: ['dist', './.storybook/**', './storybook-static/**'] },
+  { ignores: ['dist', 'build', './.storybook/**', './storybook-static/**'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],


### PR DESCRIPTION
Closes: #1044 

Ignore build/ in git, eslint, and prettier.

I have thought doing this because it : - while working on v2 locally I noticed `build/` output (generated by frontend builds) was easy to accidentally stage/commit, and it also caused tooling to spend time linting/formatting generated files.

@theborakompanioni @saurabhraghuvanshii 
