### PR TITLE
show correct toast when copying transaction ID in fidelity bond dialogs

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondDialogSteps.tsx
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondDialogSteps.tsx
@@ -545,7 +545,9 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                     text={<CopyIcon className="h-4 w-4" />}
                     successText={<CheckIcon className="h-4 w-4 text-green-500" />}
                     className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
-                    onSuccess={() => toast.success(t('receive.text_copy_address'))}
+                    onSuccess={() =>
+                      toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))
+                    }
                     onError={() => toast.error(t('global.errors.reason_unknown'))}
                   />
                 </div>

--- a/src/components/earn/MoveToJarDialog.tsx
+++ b/src/components/earn/MoveToJarDialog.tsx
@@ -357,7 +357,9 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
                       text={<CopyIcon className="h-4 w-4" />}
                       successText={<CheckIcon className="h-4 w-4 text-green-500" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
-                      onSuccess={() => toast.success(t('receive.text_copy_address'))}
+                      onSuccess={() =>
+                        toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))
+                      }
                       onError={() => toast.error(t('global.errors.reason_unknown'))}
                     />
                   </div>

--- a/src/components/earn/RenewBondDialog.tsx
+++ b/src/components/earn/RenewBondDialog.tsx
@@ -437,7 +437,9 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
                       text={<CopyIcon className="h-4 w-4" />}
                       successText={<CheckIcon className="h-4 w-4 text-green-500" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
-                      onSuccess={() => toast.success(t('receive.text_copy_address'))}
+                      onSuccess={() =>
+                        toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))
+                      }
                       onError={() => toast.error(t('global.errors.reason_unknown'))}
                     />
                   </div>

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -473,6 +473,7 @@
         "text_secondary_button": "Erledigt",
         "label_lock_date": "Gesperrt bis",
         "label_address": "Zeitlich gesperrte Adresse",
+        "text_copy_transaction_id": "Transaktions-ID kopiert",
         "label_utxos_to_unfreeze": "Willst du die vorher eingefrorenen UTXOs wieder auftauen? "
       },
       "unfreeze_utxos": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -582,6 +582,7 @@
         "label_lock_date": "Locked until",
         "label_address": "Time-locked address",
         "label_transaction_id": "Transaction ID",
+        "text_copy_transaction_id": "Transaction ID copied",
         "label_utxos_to_unfreeze": "Do you want to unfreeze the UTXOs that were frozen earlier?"
       },
       "unfreeze_utxos": {

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -424,6 +424,7 @@
         "text_secondary_button": "Fatto",
         "label_lock_date": "Bloccato fino al",
         "label_address": "Indirizzo bloccato temporalmente",
+        "text_copy_transaction_id": "ID transazione copiato",
         "label_utxos_to_unfreeze": "Vuoi scongelare gli UTXO che erano stati congelati precedentemente?"
       },
       "unfreeze_utxos": {

--- a/src/i18n/locales/pt_BR/translation.json
+++ b/src/i18n/locales/pt_BR/translation.json
@@ -424,6 +424,7 @@
         "text_secondary_button": "Pronto",
         "label_lock_date": "Trancado até",
         "label_address": "Endereços trancados no tempo",
+        "text_copy_transaction_id": "ID da transação copiado",
         "label_utxos_to_unfreeze": "Deseja descongelar os UTXOs que foram congelados anteriormente?"
       },
       "unfreeze_utxos": {

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -522,6 +522,7 @@
         "text_secondary_button": "Завершить",
         "label_lock_date": "Заблокировано до",
         "label_address": "Адрес с ограничением по времени",
+        "text_copy_transaction_id": "ID транзакции скопирован",
         "label_utxos_to_unfreeze": "Хотите ли вы разморозить UTXO, которые были заморожены ранее?"
       },
       "unfreeze_utxos": {

--- a/src/i18n/locales/zh_Hans/translation.json
+++ b/src/i18n/locales/zh_Hans/translation.json
@@ -473,6 +473,7 @@
         "text_secondary_button": "完成",
         "label_lock_date": "锁定至",
         "label_address": "时间锁地址",
+        "text_copy_transaction_id": "交易 ID 已复制",
         "label_utxos_to_unfreeze": "你是否想要解冻之前冻结的 UTXOs？"
       },
       "unfreeze_utxos": {

--- a/src/i18n/locales/zh_Hant/translation.json
+++ b/src/i18n/locales/zh_Hant/translation.json
@@ -473,6 +473,7 @@
         "text_secondary_button": "完成",
         "label_lock_date": "鎖定至",
         "label_address": "時間鎖地址",
+        "text_copy_transaction_id": "交易 ID 已複製",
         "label_utxos_to_unfreeze": "你是否想要解凍之前凍結的 UTXOs？"
       },
       "unfreeze_utxos": {


### PR DESCRIPTION
#1023 
replaces the incorrect receive.text_copy_address key used by txid copybutton in the create, renew, and spend dialogs
adds a dedicated text_copy_transaction_id i18n key and wires it to the three txid copy handlers.