### PR TITLE
fix(auth): throw on lock/stop refetch errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,7 @@ function App() {
   const doOnLockWalletConfirm = async (navigate: NavigateFunction, t: TFunction<'translation', undefined>) => {
     if (!walletFileName) return
     try {
-      await lockWalletQuery.refetch()
+      await lockWalletQuery.refetch({ throwOnError: true })
       toast.success(
         t('wallets.wallet_preview.alert_wallet_locked_successfully', { walletName: walletDisplayName(walletFileName) }),
       )

--- a/src/components/SwitchWalletPage.tsx
+++ b/src/components/SwitchWalletPage.tsx
@@ -84,7 +84,7 @@ const SwitchWalletPage = ({ walletFileName }: SwitchWalletPageProps) => {
 
   const handleLockCurrentWallet = async () => {
     try {
-      await lockCurrentWallet.refetch()
+      await lockCurrentWallet.refetch({ throwOnError: true })
       authStore.getState().clear()
       setCurrentWalletLocked(true)
       toast.success(


### PR DESCRIPTION
closes #1049 
lock/stop flows now call refetch({ throwOnError: true }) so API failures are handled by existing catch blocks instead of continuing success flow.

@theborakompanioni @saurabhraghuvanshii 