### PR TITLE
fix(dev): gate dev routes and menu by developer mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ type LockWalletDialogContext = {
 function App() {
   const walletFileName = useStore(authStore, (state) => state.state?.walletFileName)
   const hasAuthToken = useStore(authStore, (state) => state.state?.auth?.token !== undefined)
+  const isDeveloperMode = useStore(jamSettingsStore, (state) => state.state.developerMode)
   const authenticated = useMemo(() => walletFileName !== undefined && hasAuthToken, [walletFileName, hasAuthToken])
   const { clear: clearAuth } = useStore(authStore, (state) => state)
 
@@ -137,7 +138,7 @@ function App() {
           path={routes.createWallet}
           element={authenticated ? <Navigate to={routes.home} replace /> : <CreateWalletPage />}
         />
-        {isDebugFeatureEnabled('devSetupPage') && (
+        {isDeveloperMode && isDebugFeatureEnabled('devSetupPage') && (
           <Route
             id="dev-setup"
             path={routes.__devSetup}
@@ -148,7 +149,7 @@ function App() {
             }
           />
         )}
-        {isDebugFeatureEnabled('devErrorExamplePage') && (
+        {isDeveloperMode && isDebugFeatureEnabled('devErrorExamplePage') && (
           <Route
             id="error-example"
             path={routes.__devErrorExample}
@@ -198,7 +199,7 @@ function App() {
               path={routes.walletJarsDetails}
               element={<WalletJarsDetailsPage walletFileName={walletFileName!} />}
             />
-            {isDebugFeatureEnabled('devPage') && (
+            {isDeveloperMode && isDebugFeatureEnabled('devPage') && (
               <Route
                 id="dev-page"
                 path={routes.__dev}

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -111,10 +111,10 @@ export function AppSidebar({ side }: Pick<React.ComponentProps<typeof Sidebar>, 
 
   const devItems = useMemo(
     () =>
-      !isDevMode
+      !isDevMode() || !isDeveloperMode
         ? []
         : [
-            ...(!(isDeveloperMode && isDebugFeatureEnabled('devPage'))
+            ...(!isDebugFeatureEnabled('devPage')
               ? []
               : [
                   {


### PR DESCRIPTION
Summary :- 
1 gate all dev sidebar entries behind runtime `developerMode`
2 fix `isDevMode` invocation bug in sidebar (call function)
3 gate `__dev`, `__devSetup`, and `__devErrorExample` routes by runtime `developerMode` in addition to debug feature flags

why this is done 
turning off "Enable developer mode" in Settings should hide/disable all dev-only navigation and routes.  
Before this change, some dev entries/routes could remain accessible in dev builds.

closes #1052 
@theborakompanioni @saurabhraghuvanshii 