### PR TITLE
Fix stale fee config warning reactivity

### DIFF
--- a/src/hooks/useFeeConfigValidation.ts
+++ b/src/hooks/useFeeConfigValidation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { FEE_CONFIG_KEYS } from '@/constants/jm'
-import type { FeeConfigValues } from '@/lib/feeConfig'
+import { isMaxFeesConfigMissing, type FeeConfigValues } from '@/lib/feeConfig'
 import type { WalletFileName } from '@/lib/utils'
 import { useJmConfig } from './useJmConfig'
 
@@ -61,7 +61,7 @@ export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidatio
       return true
     }
 
-    return feeConfigValues.max_cj_fee_abs === undefined || feeConfigValues.max_cj_fee_rel === undefined
+    return isMaxFeesConfigMissing(feeConfigValues)
   }, [feeConfigValues, forceFeeConfigMissing])
 
   return {

--- a/src/hooks/useFeeConfigValidation.ts
+++ b/src/hooks/useFeeConfigValidation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { FEE_CONFIG_KEYS } from '@/constants/jm'
-import { isMaxFeesConfigMissing, type FeeConfigValues } from '@/lib/feeConfig'
+import type { FeeConfigValues } from '@/lib/feeConfig'
 import type { WalletFileName } from '@/lib/utils'
 import { useJmConfig } from './useJmConfig'
 
@@ -14,7 +14,6 @@ interface UseFeeConfigValidationProps {
 export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidationProps) => {
   const {
     state: configState,
-    get: getConfig,
     refetch: refetchConfig,
     fetchIfMissing: fetchConfigIfMissing,
   } = useJmConfig({ walletFileName })
@@ -24,14 +23,19 @@ export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidatio
   const forceFeeConfigMissing = import.meta.env.DEV && import.meta.env.VITE_FORCE_FEE_CONFIG_MISSING === 'true'
 
   const feeConfigValues = useMemo<FeeConfigValues>(() => {
-    return {
-      max_cj_fee_abs: getConfig(FEE_CONFIG_KEYS['max_cj_fee_abs'])?.value ?? undefined,
-      max_cj_fee_rel: getConfig(FEE_CONFIG_KEYS['max_cj_fee_rel'])?.value ?? undefined,
-      tx_fees: getConfig(FEE_CONFIG_KEYS['tx_fees'])?.value ?? undefined,
-      tx_fees_factor: getConfig(FEE_CONFIG_KEYS['tx_fees_factor'])?.value ?? undefined,
-      max_sweep_fee_change: getConfig(FEE_CONFIG_KEYS['max_sweep_fee_change'])?.value ?? undefined,
+    const getConfigValue = (key: keyof typeof FEE_CONFIG_KEYS) => {
+      const configKey = FEE_CONFIG_KEYS[key]
+      return configState[configKey.section]?.[configKey.field] ?? undefined
     }
-  }, [configState, getConfig])
+
+    return {
+      max_cj_fee_abs: getConfigValue('max_cj_fee_abs'),
+      max_cj_fee_rel: getConfigValue('max_cj_fee_rel'),
+      tx_fees: getConfigValue('tx_fees'),
+      tx_fees_factor: getConfigValue('tx_fees_factor'),
+      max_sweep_fee_change: getConfigValue('max_sweep_fee_change'),
+    }
+  }, [configState])
 
   const refetchAll = useCallback(async () => {
     setIsLoading(true)

--- a/src/hooks/useFeeConfigValidation.ts
+++ b/src/hooks/useFeeConfigValidation.ts
@@ -19,6 +19,7 @@ interface UseFeeConfigValidationProps {
 
 export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidationProps) => {
   const {
+    state: configState,
     get: getConfig,
     refetch: refetchConfig,
     fetchIfMissing: fetchConfigIfMissing,
@@ -28,7 +29,7 @@ export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidatio
   // Debug flag to force fee config missing error for testing
   const forceFeeConfigMissing = import.meta.env.DEV && import.meta.env.VITE_FORCE_FEE_CONFIG_MISSING === 'true'
 
-  const feeConfigValues = useMemo<FeeConfigValues | undefined>(() => {
+  const feeConfigValues = useMemo<FeeConfigValues>(() => {
     return {
       max_cj_fee_abs: getConfig(FEE_CONFIG_KEYS['max_cj_fee_abs'])?.value ?? undefined,
       max_cj_fee_rel: getConfig(FEE_CONFIG_KEYS['max_cj_fee_rel'])?.value ?? undefined,
@@ -36,7 +37,7 @@ export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidatio
       tx_fees_factor: getConfig(FEE_CONFIG_KEYS['tx_fees_factor'])?.value ?? undefined,
       max_sweep_fee_change: getConfig(FEE_CONFIG_KEYS['max_sweep_fee_change'])?.value ?? undefined,
     }
-  }, [getConfig])
+  }, [configState, getConfig])
 
   const refetchAll = useCallback(async () => {
     setIsLoading(true)
@@ -62,9 +63,7 @@ export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidatio
       return true
     }
 
-    return (
-      feeConfigValues && (feeConfigValues.max_cj_fee_abs === undefined || feeConfigValues.max_cj_fee_rel === undefined)
-    )
+    return feeConfigValues.max_cj_fee_abs === undefined || feeConfigValues.max_cj_fee_rel === undefined
   }, [feeConfigValues, forceFeeConfigMissing])
 
   return {

--- a/src/store/jmConfigStore.ts
+++ b/src/store/jmConfigStore.ts
@@ -45,10 +45,16 @@ export const jmConfigStore = createStore<JmConfigStoreState>()(
       },
       set: (val) =>
         set((state) => {
-          const copy = { state: { ...state.state } }
-          copy.state[val.key.section] = copy.state[val.key.section] || {}
-          copy.state[val.key.section][val.key.field] = val.value
-          return copy
+          const currentSection = state.state[val.key.section] || {}
+          return {
+            state: {
+              ...state.state,
+              [val.key.section]: {
+                ...currentSection,
+                [val.key.field]: val.value,
+              },
+            },
+          }
         }),
       clear: () => set({ state: initial }),
     }),


### PR DESCRIPTION
problem : 
fee-config UI state could become stale after loading/saving config values, which kept showing false “fee configuration missing” warnings.
root cause : 
`useFeeConfigValidation` memoized `feeConfigValues` without depending on config state changes.
`jmConfigStore.set` used nested mutation patterns that could miss reactivity updates.

fix
updated `/src/hooks/useFeeConfigValidation.ts` to recompute fee config values when store state changes.
updated `/src/store/jmConfigStore.ts` to perform fully immutable nested updates.

impact on user 
this keeps fee warnings in `Send`, `Earn`, and `Sweep` accurate after config fetch/save and prevents stale values in fee settings UI.

fixes #1054 
@theborakompanioni @saurabhraghuvanshii 




