### PR TITLE
refactor(logs): reuse LogsContent in LogsPage

### DIFF
--- a/src/components/LogsPage.tsx
+++ b/src/components/LogsPage.tsx
@@ -1,38 +1,14 @@
-import { AlertTriangleIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { LogViewer } from '@/components/logging/LogViewer'
-import { useJmwalletdStdoutLog } from '@/components/logging/useJmwalletdStdoutLog'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { LogsContent } from '@/components/LogsContent'
 import PageTitle from './ui/jam/PageTitle'
-import { Spinner } from './ui/spinner'
 
 export const LogsPage = () => {
   const { t } = useTranslation()
-  const { alert, isInitialized, logFileContent, refresh, fileName } = useJmwalletdStdoutLog()
-
-  if (!isInitialized) {
-    return (
-      <div className="mx-auto max-w-4xl space-y-3 p-4">
-        <div className="m-2 flex items-center justify-center gap-2">
-          <Spinner className="motion-reduce:hidden" />
-          {t('global.loading')}
-        </div>
-      </div>
-    )
-  }
 
   return (
     <div className="mx-auto space-y-3 p-4">
       <PageTitle title={t('logs.title')} />
-
-      {alert && (
-        <Alert variant={alert.variant}>
-          <AlertTriangleIcon />
-          <AlertDescription>{alert.message}</AlertDescription>
-        </Alert>
-      )}
-
-      {logFileContent && <LogViewer fileName={fileName} value={logFileContent} refresh={refresh} />}
+      <LogsContent enabled={true} />
     </div>
   )
 }


### PR DESCRIPTION
so i refactored `LogsPage` to consume the shared `LogsContent` component instead of maintaining a separate inline implementation.

this removes duplicate code and keeps logs behavior centralized in one reusable flow (`LogsContent` + logging hook/viewer), making future maintenance and UI cleanup easier.

ping @theborakompanioni @saurabhraghuvanshii 
