### PR TITLE
unfreeze UTXOs on partial failure in fidelity bond and move to jar flows

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -223,17 +223,29 @@ export function useCreateFidelityBondWizard(
   }
 
   const handleFreezeUtxos = async () => {
+    const frozen: Utxo[] = []
     try {
       for (const utxo of utxosToFreeze) {
         await freezeUtxo.mutateAsync({
           path: { walletname: encodeURIComponent(walletFileName) },
           body: { 'utxo-string': utxo.utxo, freeze: true },
         })
+        frozen.push(utxo)
       }
-      setFrozenUtxos([...utxosToFreeze])
+      setFrozenUtxos(frozen)
       setStep('review')
     } catch {
-      // Error handled in onError
+      // Best-effort rollback — unfreeze UTXOs that were frozen before the error
+      for (const utxo of frozen) {
+        try {
+          await unfreezeUtxo.mutateAsync({
+            path: { walletname: encodeURIComponent(walletFileName) },
+            body: { 'utxo-string': utxo.utxo, freeze: false },
+          })
+        } catch {
+          // logged via onError
+        }
+      }
     }
   }
 
@@ -254,9 +266,34 @@ export function useCreateFidelityBondWizard(
       setTxResult(result)
       setStep('success')
       toast.success(t('earn.fidelity_bond.create_fidelity_bond.success_text'))
+
+      // Best-effort cleanup — tx already broadcast, don't throw on unfreeze failure
+      for (const utxo of frozenUtxos) {
+        try {
+          await unfreezeUtxo.mutateAsync({
+            path: { walletname: encodeURIComponent(walletFileName) },
+            body: { 'utxo-string': utxo.utxo, freeze: false },
+          })
+        } catch {
+          // logged via onError
+        }
+      }
+
       await walletInfo.refetch()
     } catch {
-      setStep('review')
+      // Best-effort rollback — unfreeze UTXOs that were frozen for this operation
+      for (const utxo of frozenUtxos) {
+        try {
+          await unfreezeUtxo.mutateAsync({
+            path: { walletname: encodeURIComponent(walletFileName) },
+            body: { 'utxo-string': utxo.utxo, freeze: false },
+          })
+        } catch {
+          // logged via onError
+        }
+      }
+      setFrozenUtxos([])
+      setStep('freeze_utxos')
     }
   }
 

--- a/src/components/earn/MoveToJarDialog.tsx
+++ b/src/components/earn/MoveToJarDialog.tsx
@@ -138,9 +138,9 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
     setStep('sending')
     setError(undefined)
 
+    const frozen: Utxo[] = []
     try {
       // Freeze other UTXOs in the source jar so only the FB gets swept
-      const frozen: Utxo[] = []
       for (const u of utxosToFreeze) {
         await freezeUtxo.mutateAsync({
           path: { walletname: encodeURIComponent(walletFileName) },
@@ -183,6 +183,17 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
 
       await walletInfo.refetch()
     } catch {
+      // Best-effort rollback — unfreeze UTXOs that were frozen before the error
+      for (const u of frozen) {
+        try {
+          await unfreezeUtxo.mutateAsync({
+            path: { walletname: encodeURIComponent(walletFileName) },
+            body: { 'utxo-string': u.utxo, freeze: false },
+          })
+        } catch {
+          // logged via onError
+        }
+      }
       setStep('confirm')
     }
   }

--- a/src/components/earn/RenewBondDialog.tsx
+++ b/src/components/earn/RenewBondDialog.tsx
@@ -160,9 +160,9 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
     setStep('sending')
     setError(undefined)
 
+    const frozen: Utxo[] = []
     try {
       // Freeze other UTXOs in the source jar so only the FB gets swept
-      const frozen: Utxo[] = []
       for (const u of utxosToFreeze) {
         await freezeUtxo.mutateAsync({
           path: { walletname: encodeURIComponent(walletFileName) },
@@ -205,6 +205,17 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
 
       await walletInfo.refetch()
     } catch {
+      // Best-effort rollback — unfreeze UTXOs that were frozen before the error
+      for (const u of frozen) {
+        try {
+          await unfreezeUtxo.mutateAsync({
+            path: { walletname: encodeURIComponent(walletFileName) },
+            body: { 'utxo-string': u.utxo, freeze: false },
+          })
+        } catch {
+          // logged via onError
+        }
+      }
       setStep('confirm')
     }
   }


### PR DESCRIPTION
fixes #1048
Ensure UTXOs frozen during fidelity bond creation or move to jar operations are unfrozen if the freeze step or sweep transction fails, track frozen UTXOs incrementally in handleFreezeUtxos so partial failures can be cleaned up correctly.