### PR TITLE
remove console logging of payment data in SendPage

### DIFF
--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -125,7 +125,6 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   }
 
   const onPaymentConfirmed: SubmitHandler<SendFormValues> = async (data) => {
-    console.table(data)
     if (data.isCoinJoin !== true) {
       await onSubmitDirectSend(data)
     } else {


### PR DESCRIPTION
SendPage.tsx unconditionally logs payment data including destination address, amount, and jar index in all environments.
This removes the console logging from the send flow.