### PR TITLE
refactor(earn): move maker transition side-effects to effects

### DIFF
--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -66,11 +66,9 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   const client = useApiClient()
   const jmSession = useStore(jmSessionStore, (state) => state.state)
   const isDeveloperMode = useStore(jamSettingsStore, (state) => state.state.developerMode)
+  const makerRunning = jmSession?.maker_running === true
 
   const walletInfo = useJamWalletInfoContext()
-
-  const [isWaitingMakerStart, setIsWaitingMakerStart] = useState(false)
-  const [isWaitingMakerStop, setIsWaitingMakerStop] = useState(false)
 
   const [moveToJarUtxo, setMoveToJarUtxo] = useState<FidelityBondUtxo | undefined>()
   const [renewBondUtxo, setRenewBondUtxo] = useState<FidelityBondUtxo | undefined>()
@@ -80,13 +78,6 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   const { maxFeesConfigMissing } = useFeeConfigValidation({ walletFileName })
 
   const isCurrentOfferAvailable = jmSession?.offer_list && jmSession.offer_list.length > 0
-  const waitingForMakerUpdate = isWaitingMakerStart || isWaitingMakerStop
-  const waitingForOfferUpdate = jmSession?.maker_running === true && !isCurrentOfferAvailable
-  useRefreshSession({
-    enabled: waitingForMakerUpdate || waitingForOfferUpdate,
-    refetchInterval: WAIT_FOR_UPDATE_SESSION_POLLING_INTERVAL,
-    refetchDelay: WAIT_FOR_UPDATE_SESSION_POLLING_DELAY,
-  })
 
   const stopMakerQueryOptions = stopmakerOptions({
     client,
@@ -109,11 +100,9 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     },
     retry: false,
     onMutate: () => {
-      setIsWaitingMakerStop(true)
       toast.info(t('earn.alert_stopping'), { id: 'earn.alert_stopping' })
     },
     onError: (error: ErrorMessage) => {
-      setIsWaitingMakerStop(false)
       const reason = error.message || error.error_description || t('global.errors.reason_unknown')
       // TODO: i18n
       toast.error(`Error while stopping the earn process. Reason: ${reason}`)
@@ -124,15 +113,24 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     ...startmakerMutation({ client }),
     retry: false,
     onMutate: () => {
-      setIsWaitingMakerStart(true)
       toast.info(t('earn.alert_starting'), { id: 'earn.alert_starting' })
     },
     onError: (error: ErrorMessage) => {
-      setIsWaitingMakerStart(false)
       console.error('StartMaker error:', error)
       const reason = error.message || error.error_description || t('global.errors.reason_unknown')
       toast.error(t('earn.alert_start_failed', { reason }))
     },
+  })
+
+  const isWaitingMakerStart = startMaker.isPending || (startMaker.isSuccess && !makerRunning)
+  const isWaitingMakerStop = stopMaker.isPending || (stopMaker.isSuccess && makerRunning)
+
+  const waitingForMakerUpdate = isWaitingMakerStart || isWaitingMakerStop
+  const waitingForOfferUpdate = makerRunning && !isCurrentOfferAvailable
+  useRefreshSession({
+    enabled: waitingForMakerUpdate || waitingForOfferUpdate,
+    refetchInterval: WAIT_FOR_UPDATE_SESSION_POLLING_INTERVAL,
+    refetchDelay: WAIT_FOR_UPDATE_SESSION_POLLING_DELAY,
   })
 
   const onStop = async () => {
@@ -148,27 +146,24 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     })
   }
 
-  const makerRunning = jmSession?.maker_running === true
   useEffect(() => {
-    if (!jmSession || !makerRunning || !isWaitingMakerStart || startMaker.isPending) return
-
-    setIsWaitingMakerStart(false)
+    if (!jmSession || !startMaker.isSuccess || !makerRunning) return
     toast.dismiss('earn.alert_starting')
     toast.dismiss('earn.alert_stopping')
     toast.dismiss('earn.alert_stopped')
     toast.success(t('earn.alert_running'), { id: 'earn.alert_running' })
     scrollToTop()
-  }, [jmSession, makerRunning, isWaitingMakerStart, startMaker.isPending, t])
+    startMaker.reset()
+  }, [jmSession, makerRunning, startMaker.isSuccess, startMaker, t])
 
   useEffect(() => {
-    if (!jmSession || makerRunning || !isWaitingMakerStop || stopMaker.isPending) return
-
-    setIsWaitingMakerStop(false)
+    if (!jmSession || !stopMaker.isSuccess || makerRunning) return
     toast.dismiss('earn.alert_stopping')
     toast.dismiss('earn.alert_starting')
     toast.dismiss('earn.alert_running')
     toast.success(t('earn.alert_stopped'), { id: 'earn.alert_stopped' })
-  }, [jmSession, makerRunning, isWaitingMakerStop, stopMaker.isPending, t])
+    stopMaker.reset()
+  }, [jmSession, makerRunning, stopMaker.isSuccess, stopMaker, t])
 
   if (!jmSession) {
     return (

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { startmakerMutation, stopmakerOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { ErrorMessage, StartMakerRequest } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -148,6 +148,28 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     })
   }
 
+  const makerRunning = jmSession?.maker_running === true
+  useEffect(() => {
+    if (!jmSession || !makerRunning || !isWaitingMakerStart || startMaker.isPending) return
+
+    setIsWaitingMakerStart(false)
+    toast.dismiss('earn.alert_starting')
+    toast.dismiss('earn.alert_stopping')
+    toast.dismiss('earn.alert_stopped')
+    toast.success(t('earn.alert_running'), { id: 'earn.alert_running' })
+    scrollToTop()
+  }, [jmSession, makerRunning, isWaitingMakerStart, startMaker.isPending, t])
+
+  useEffect(() => {
+    if (!jmSession || makerRunning || !isWaitingMakerStop || stopMaker.isPending) return
+
+    setIsWaitingMakerStop(false)
+    toast.dismiss('earn.alert_stopping')
+    toast.dismiss('earn.alert_starting')
+    toast.dismiss('earn.alert_running')
+    toast.success(t('earn.alert_stopped'), { id: 'earn.alert_stopped' })
+  }, [jmSession, makerRunning, isWaitingMakerStop, stopMaker.isPending, t])
+
   if (!jmSession) {
     return (
       <div className="mx-auto max-w-4xl space-y-3 p-4">
@@ -157,26 +179,6 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
         </div>
       </div>
     )
-  }
-
-  const makerRunning = jmSession.maker_running === true
-  if (makerRunning) {
-    if (isWaitingMakerStart && !startMaker.isPending) {
-      setIsWaitingMakerStart(false)
-      toast.dismiss('earn.alert_starting')
-      toast.dismiss('earn.alert_stopping')
-      toast.dismiss('earn.alert_stopped')
-      toast.success(t('earn.alert_running'), { id: 'earn.alert_running' })
-      scrollToTop()
-    }
-  } else {
-    if (isWaitingMakerStop && !stopMaker.isPending) {
-      setIsWaitingMakerStop(false)
-      toast.dismiss('earn.alert_stopping')
-      toast.dismiss('earn.alert_starting')
-      toast.dismiss('earn.alert_running')
-      toast.success(t('earn.alert_stopped'), { id: 'earn.alert_stopped' })
-    }
   }
 
   return (


### PR DESCRIPTION
Moves maker start/stop completion side effects out of render and into `useEffect` hooks.
Changes

Added two guarded `useEffect` hooks in `src/components/earn/EarnPage.tsx`:
1.Start completion flow (`isWaitingMakerStart` -> running)
2.Stop completion flow (`isWaitingMakerStop` -> stopped)

Removed render-time side-effect block that called:
1.`setIsWaitingMakerStart/Stop`
2.`toast.dismiss(...)`
3.`toast.success(...)`
4.`scrollToTop()`

No behavior change intended, same transition/toast flow, but now executed in effects (React-safe pattern).
It's generally a good practice to follow this fixes #1061 
ping @theborakompanioni @saurabhraghuvanshii 

