### PR TITLE
fix(auth): clear query cache on auth reset paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,11 @@ const DevSetupPage = lazy(() => import('@/components/dev/DevSetupPage'))
 const DevPage = lazy(() => import('@/components/dev/DevPage'))
 const DevErrorThrowingComponent = lazy(() => import('@/components/dev/DevErrorThrowingComponent'))
 
+const clearAuthAndQueryCache = () => {
+  authStore.getState().clear()
+  queryClient.clear()
+}
+
 const ProtectedRoute = ({ authenticated, children }: PropsWithChildren<{ authenticated: boolean }>) => {
   return authenticated ? <>{children}</> : <Navigate to={routes.login} replace />
 }
@@ -71,7 +76,6 @@ function App() {
   const hasAuthToken = useStore(authStore, (state) => state.state?.auth?.token !== undefined)
   const isDeveloperMode = useStore(jamSettingsStore, (state) => state.state.developerMode)
   const authenticated = useMemo(() => walletFileName !== undefined && hasAuthToken, [walletFileName, hasAuthToken])
-  const { clear: clearAuth } = useStore(authStore, (state) => state)
 
   const jmSession = useStore(jmSessionStore, (state) => state.state)
 
@@ -95,8 +99,7 @@ function App() {
   const [lockWalletDialogContext, setLockWalletDialogContext] = useState<LockWalletDialogContext>()
 
   const doOnLogout = async (navigate: NavigateFunction) => {
-    clearAuth()
-    queryClient.clear()
+    clearAuthAndQueryCache()
     await navigate(routes.login)
   }
 
@@ -280,7 +283,7 @@ function RefreshApiToken() {
         })
 
         if (!response.data) {
-          authStore.getState().clear()
+          clearAuthAndQueryCache()
 
           if (isDevMode) {
             const message = response.error?.message || response.error?.error_description || 'Unknown error.'

--- a/src/components/SwitchWalletPage.tsx
+++ b/src/components/SwitchWalletPage.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton'
 import { routes } from '@/constants/routes'
 import { useApiClient } from '@/hooks/useApiClient'
+import { queryClient } from '@/lib/queryClient'
 import { shortenStringMiddle, sortWallets, walletDisplayName } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { authStore } from '@/store/authStore'
@@ -86,6 +87,7 @@ const SwitchWalletPage = ({ walletFileName }: SwitchWalletPageProps) => {
     try {
       await lockCurrentWallet.refetch({ throwOnError: true })
       authStore.getState().clear()
+      queryClient.clear()
       setCurrentWalletLocked(true)
       toast.success(
         t('wallets.wallet_preview.alert_wallet_locked_successfully', { walletName: walletDisplayName(walletFileName) }),


### PR DESCRIPTION
fixes #1063 
this PR makes auth-reset behavior consistent by clearing both auth state and React Query cache in all relevant paths.
Changes
1.Added a shared `clearAuthAndQueryCache()` helper in `App.tsx`.
2.Reused it in normal logout flow.
3.Reused it when refresh-token renewal fails.
4.Cleared `queryClient` in Switch Wallet lock flow after auth clear.

why i did this because : -
previously, some auth-reset paths cleared auth only, which could leave stale query cache from the old wallet/session visible until refetch.

ping @theborakompanioni @saurabhraghuvanshii 

