### PR TITLE
refactor(ui): reuse shared page loading state

### DIFF
--- a/src/components/LogsPage.tsx
+++ b/src/components/LogsPage.tsx
@@ -3,22 +3,15 @@ import { useTranslation } from 'react-i18next'
 import { LogViewer } from '@/components/logging/LogViewer'
 import { useJmwalletdStdoutLog } from '@/components/logging/useJmwalletdStdoutLog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from './ui/jam/PageTitle'
-import { Spinner } from './ui/spinner'
 
 export const LogsPage = () => {
   const { t } = useTranslation()
   const { alert, isInitialized, logFileContent, refresh, fileName } = useJmwalletdStdoutLog()
 
   if (!isInitialized) {
-    return (
-      <div className="mx-auto max-w-4xl space-y-3 p-4">
-        <div className="m-2 flex items-center justify-center gap-2">
-          <Spinner className="motion-reduce:hidden" />
-          {t('global.loading')}
-        </div>
-      </div>
-    )
+    return <PageLoading />
   }
 
   return (

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -13,6 +13,7 @@ import { Alert, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
+import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from '@/components/ui/jam/PageTitle'
 import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
@@ -149,14 +150,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   }
 
   if (!jmSession) {
-    return (
-      <div className="mx-auto max-w-4xl space-y-3 p-4">
-        <div className="m-2 flex items-center justify-center gap-2">
-          <Spinner className="motion-reduce:hidden" />
-          {t('global.loading')}
-        </div>
-      </div>
-    )
+    return <PageLoading />
   }
 
   const makerRunning = jmSession.maker_running === true

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -11,6 +11,7 @@ import { useStore } from 'zustand'
 import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
+import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from '@/components/ui/jam/PageTitle'
 import { useAddressSummary, useJars, useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
@@ -195,14 +196,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   }
 
   if (isLoadingFeeConfig) {
-    return (
-      <div className="mx-auto max-w-4xl space-y-3 p-4">
-        <div className="m-2 flex items-center justify-center gap-2">
-          <Spinner className="motion-reduce:hidden" />
-          {t('global.loading')}
-        </div>
-      </div>
-    )
+    return <PageLoading />
   }
 
   return (

--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
+import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from '@/components/ui/jam/PageTitle'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import type { WalletFileName } from '@/lib/utils'
-import { Spinner } from '../ui/spinner'
 
 interface SweepPageProps {
   walletFileName: WalletFileName
@@ -20,14 +20,7 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
   const { maxFeesConfigMissing, isLoading } = useFeeConfigValidation({ walletFileName })
 
   if (isLoading) {
-    return (
-      <div className="mx-auto max-w-4xl space-y-3 p-4">
-        <div className="m-2 flex items-center justify-center gap-2">
-          <Spinner className="motion-reduce:hidden" />
-          {t('global.loading')}
-        </div>
-      </div>
-    )
+    return <PageLoading />
   }
 
   return (

--- a/src/components/ui/jam/PageLoading.tsx
+++ b/src/components/ui/jam/PageLoading.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next'
+import { Spinner } from '@/components/ui/spinner'
+
+export const PageLoading = () => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-3 p-4">
+      <div className="m-2 flex items-center justify-center gap-2">
+        <Spinner className="motion-reduce:hidden" />
+        {t('global.loading')}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
this PR removes duplicated page-loading UI by extracting a shared `PageLoading` component and reusing it across multiple pages.

Changes
1.Added `/src/components/ui/jam/PageLoading.tsx`.
2.Replaced duplicated loading markup in:
  LogsPage
  EarnPage
  SendPage
  SweepPage

the same loading layout/spinner/text block was repeated in multiple files. Centralizing it reduces redundancy and keeps loading-state UI consistent.

ping @theborakompanioni @saurabhraghuvanshii 
