### PR TITLE
fix(settings): i18n and normalize rescan-chain error reasons

### DIFF
--- a/src/components/create/CreateWalletPage.tsx
+++ b/src/components/create/CreateWalletPage.tsx
@@ -10,6 +10,7 @@ import { useStore } from 'zustand'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { routes } from '@/constants/routes'
 import { useApiClient } from '@/hooks/useApiClient'
+import { getErrorReason } from '@/lib/errorReason'
 import { hashPassword } from '@/lib/hash'
 import { walletDisplayName, walletDisplayNameToFileName } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
@@ -105,8 +106,9 @@ const CreateWalletPage = () => {
       })
       setStep('seed')
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to create wallet' // TODO: i18n
-      toast.error(errorMessage)
+      /* TODO: i18n */
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+      toast.error(`Failed to create wallet: ${reason}`)
     } finally {
       toast.dismiss(durationHintToastId)
     }

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import { useStore } from 'zustand'
 import { routes } from '@/constants/routes'
 import { useApiClient } from '@/hooks/useApiClient'
+import { getErrorReason } from '@/lib/errorReason'
 import { hashPassword } from '@/lib/hash'
 import { withQueryDelay } from '@/lib/queryClient'
 import { sortWallets } from '@/lib/utils'
@@ -84,7 +85,8 @@ const LoginPage = () => {
     },
     onError: (error) => {
       /* TODO: i18n */
-      toast.error(`Failed to unlock wallet: ${error.message || t('global.errors.reason_unknown')}`)
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+      toast.error(`Failed to unlock wallet: ${reason}`)
     },
   })
 

--- a/src/components/settings/RescanChainPage.tsx
+++ b/src/components/settings/RescanChainPage.tsx
@@ -16,6 +16,7 @@ import { Label } from '@/components/ui/label'
 import { routes } from '@/constants/routes'
 import { useRescanStatus, type RescanInfo } from '@/context/JamSessionInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
+import { getErrorReason } from '@/lib/errorReason'
 import { SEGWIT_ACTIVATION_BLOCK } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 
@@ -73,8 +74,7 @@ function RescanChainForm({ rescanInfo, onSubmit, disabled }: RescanChainFormProp
             type="number"
             step={1}
             className="bg-background pl-10"
-            /* TODO: i18n */
-            placeholder="Enter block height"
+            placeholder={t('rescan_chain.placeholder_blockheight')}
           />
         </div>
         {errors.blockHeight && (
@@ -120,8 +120,7 @@ export const RescanChainPage = ({ walletFileName }: RescanChainProps) => {
       return data
     },
     onSuccess: () => {
-      // TODO: i18n
-      toast.success('Rescan started successfully')
+      toast.success(t('rescan_chain.success_rescan_started'))
       setRescanInfo({
         updatedAt: Date.now(),
         rescanning: true,
@@ -137,7 +136,7 @@ export const RescanChainPage = ({ walletFileName }: RescanChainProps) => {
         progress: undefined,
       })
 
-      const reason = error instanceof Error ? error.message : String(error)
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       toast.error(t('rescan_chain.error_rescanning_failed', { reason }))
     },
   })

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -329,7 +329,9 @@
     "subtitle": "Rescan the local timechain for wallet related transactions.",
     "label_blockheight": "Rescan height",
     "description_blockheight": "The height of the chain at which the rescan process is started.",
+    "placeholder_blockheight": "Enter block height",
     "error_rescanning_failed": "Error while starting the rescan process. Reason: {{ reason }}",
+    "success_rescan_started": "Rescan started successfully.",
     "feedback_invalid_blockheight": "Please provide a valid value between {{ min }} and the current blockheight.",
     "text_button_submit": "Rescan timechain",
     "text_button_submitting": "Rescanning timechain..."

--- a/src/lib/errorReason.ts
+++ b/src/lib/errorReason.ts
@@ -1,0 +1,23 @@
+export const getErrorReason = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+
+  if (error && typeof error === 'object') {
+    const maybeError = error as {
+      message?: unknown
+      error_description?: unknown
+      detail?: unknown
+    }
+    if (typeof maybeError.error_description === 'string' && maybeError.error_description.trim()) {
+      return maybeError.error_description
+    }
+    if (typeof maybeError.message === 'string' && maybeError.message.trim()) {
+      return maybeError.message
+    }
+    if (typeof maybeError.detail === 'string' && maybeError.detail.trim()) {
+      return maybeError.detail
+    }
+  }
+
+  return fallback
+}


### PR DESCRIPTION
fixes #1074 
rescan chain page still had hardcoded UI strings and inconsistent error reason parsing, which could produce poor error messages.

changes
reused shared `getErrorReason` in `RescanChainPage` error handling.
replaced hardcoded block-height placeholder with i18n key.
replaced hardcoded success toast with i18n key.
added missing translation keys:
 - `rescan_chain.placeholder_blockheight`
 - `rescan_chain.success_rescan_started`


ping @theborakompanioni @saurabhraghuvanshii 
Depends on #1071 