### PR TITLE
extract fee validation and add coverage

### DIFF
--- a/src/hooks/useFeeConfigValidation.ts
+++ b/src/hooks/useFeeConfigValidation.ts
@@ -1,17 +1,11 @@
 import { useCallback, useMemo, useState } from 'react'
 import { FEE_CONFIG_KEYS } from '@/constants/jm'
+import { isMaxFeesConfigMissing, type FeeConfigValues } from '@/lib/feeConfig'
 import type { WalletFileName } from '@/lib/utils'
 import { useJmConfig } from './useJmConfig'
 
-//TODO: needs testing!
-
-export interface FeeConfigValues {
-  max_cj_fee_abs?: string
-  max_cj_fee_rel?: string
-  tx_fees?: string
-  tx_fees_factor?: string
-  max_sweep_fee_change?: string
-}
+export type { FeeConfigValues } from '@/lib/feeConfig'
+export { isMaxFeesConfigMissing } from '@/lib/feeConfig'
 
 interface UseFeeConfigValidationProps {
   walletFileName: WalletFileName
@@ -62,9 +56,7 @@ export const useFeeConfigValidation = ({ walletFileName }: UseFeeConfigValidatio
       return true
     }
 
-    return (
-      feeConfigValues && (feeConfigValues.max_cj_fee_abs === undefined || feeConfigValues.max_cj_fee_rel === undefined)
-    )
+    return isMaxFeesConfigMissing(feeConfigValues)
   }, [feeConfigValues, forceFeeConfigMissing])
 
   return {

--- a/src/lib/feeConfig.test.ts
+++ b/src/lib/feeConfig.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { isMaxFeesConfigMissing, type FeeConfigValues } from './feeConfig'
+
+describe('isMaxFeesConfigMissing', () => {
+  it('should return false when both max fee values are present', () => {
+    const values: FeeConfigValues = {
+      max_cj_fee_abs: '1500',
+      max_cj_fee_rel: '0.00025',
+      tx_fees: '3',
+      tx_fees_factor: '0.2',
+      max_sweep_fee_change: '0.8',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(false)
+  })
+
+  it('should return true when max_cj_fee_abs is missing', () => {
+    const values: FeeConfigValues = {
+      max_cj_fee_rel: '0.00025',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(true)
+  })
+
+  it('should return true when max_cj_fee_rel is missing', () => {
+    const values: FeeConfigValues = {
+      max_cj_fee_abs: '1500',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(true)
+  })
+
+  it('should return true when both max fee values are missing', () => {
+    const values: FeeConfigValues = {
+      tx_fees: '3',
+      tx_fees_factor: '0.2',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(true)
+  })
+
+  it('should return false when values is undefined', () => {
+    expect(isMaxFeesConfigMissing(undefined)).toBe(false)
+  })
+
+  it('should return false with zero-value strings', () => {
+    const values: FeeConfigValues = {
+      max_cj_fee_abs: '0',
+      max_cj_fee_rel: '0',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(false)
+  })
+
+  it('should treat empty string as present', () => {
+    const values: FeeConfigValues = {
+      max_cj_fee_abs: '',
+      max_cj_fee_rel: '',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(false)
+  })
+
+  it('should not be affected by other fee fields', () => {
+    const values: FeeConfigValues = {
+      max_cj_fee_abs: '1500',
+      max_cj_fee_rel: '0.00025',
+    }
+    expect(isMaxFeesConfigMissing(values)).toBe(false)
+  })
+})

--- a/src/lib/feeConfig.ts
+++ b/src/lib/feeConfig.ts
@@ -1,0 +1,11 @@
+export interface FeeConfigValues {
+  max_cj_fee_abs?: string
+  max_cj_fee_rel?: string
+  tx_fees?: string
+  tx_fees_factor?: string
+  max_sweep_fee_change?: string
+}
+
+export const isMaxFeesConfigMissing = (values: FeeConfigValues | undefined): boolean => {
+  return !!values && (values.max_cj_fee_abs === undefined || values.max_cj_fee_rel === undefined)
+}


### PR DESCRIPTION
Extracts isMaxFeesConfigMissing from useFeeConfigValidation into feeConfig.ts to enable isolated unit testing, adds branch coverage for fee validation logic. Removes stale testing TODO.