### PR TITLE
Use wallet balance for offer min size validation

### DIFF
--- a/src/components/earn/EarnForm.tsx
+++ b/src/components/earn/EarnForm.tsx
@@ -111,15 +111,11 @@ const OfferTypeInput = (props: React.ComponentProps<typeof RadioGroup>) => {
   )
 }
 
-/* TODO: make offerMinsizeMax mandatory and remove this placehodler */
-const OFFER_MINSIZE_MAX_PLACEHODLER = JAM.OFFER_MINSIZE_MIN * 1_000
-
 interface EarnFormProps {
   className?: string
   isWaitingMakerStart: boolean
   onSubmit: SubmitHandler<EarnFormValues>
-  /* TODO: make offerMinsizeMax mandatory */
-  offerMinsizeMax?: AmountSats
+  offerMinsizeMax: AmountSats
   disabled?: boolean
   debug?: boolean
 }
@@ -129,7 +125,7 @@ export function EarnForm({
   isWaitingMakerStart,
   onSubmit,
   disabled,
-  offerMinsizeMax = OFFER_MINSIZE_MAX_PLACEHODLER,
+  offerMinsizeMax,
   debug = false,
 }: EarnFormProps) {
   const { t } = useTranslation()
@@ -254,7 +250,9 @@ export function EarnForm({
 
         {errors.offerMinAmount && (
           <div className="text-destructive text-xs">
-            {errors.offerMinAmount.type === 'min' || errors.offerMinAmount.type === 'max' ? (
+            {offerMinsizeMax < JAM.OFFER_MINSIZE_MIN ? (
+              <>{t('earn.feedback_invalid_min_amount_insufficient_funds')}</>
+            ) : errors.offerMinAmount.type === 'min' || errors.offerMinAmount.type === 'max' ? (
               <>
                 {t('earn.feedback_invalid_min_amount_range', {
                   minAmountMin: JAM.OFFER_MINSIZE_MIN.toLocaleString(),

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -224,7 +224,9 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
           <EarnForm
             onSubmit={onSubmit}
             isWaitingMakerStart={isWaitingMakerStart}
+            offerMinsizeMax={walletInfo.maxJarAvailableBalance}
             disabled={
+              walletInfo.isFetching ||
               isWaitingMakerStart ||
               isWaitingMakerStop ||
               jmSession.maker_running ||

--- a/src/context/JamWalletInfoContext.ts
+++ b/src/context/JamWalletInfoContext.ts
@@ -4,7 +4,7 @@ import { Network, type AddressInfo } from 'bitcoin-address-validation'
 import type { UseQueryDisplayWalletResult } from '@/hooks/useQueryDisplayWallet'
 import type { FidelityBondUtxo, UseQueryUtxosResult, Utxo } from '@/hooks/useQueryUtxos'
 import type { BalanceSummary } from '@/lib/balanceSummary'
-import type { BitcoinAddress, HdPath, JarIndex } from '@/types/global'
+import type { AmountSats, BitcoinAddress, HdPath, JarIndex } from '@/types/global'
 
 // Comments for tailwind importer (ADAPT THE COMMENT IF YOU CHANGE THE VALUE)
 // "text-[#e2b86a]", "group-hover/jar:text-[#e2b86a]"
@@ -80,6 +80,7 @@ export type AccountSummary = {
 interface JamWalletInfoContextType {
   walletName: string | null
   walletBalanceSummary: WalletBalanceSummary
+  maxJarAvailableBalance: AmountSats
   fidelityBondSummary: FidelityBondSummary
   addressSummary: AddressSummary
   accountSummary: AccountSummary

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -206,9 +206,12 @@ export const JamWalletInfoContextProvider = ({
     return null
   }, [utxos, addressSummary])
 
+  const maxJarAvailableBalance = Math.max(0, ...jars.map((jar) => jar.balanceSummary.calculatedAvailableBalanceInSats))
+
   const value = {
     walletName: walletFileName ? walletDisplayName(walletFileName) : null,
     walletBalanceSummary: walletBalanceSummary,
+    maxJarAvailableBalance,
     fidelityBondSummary,
     addressSummary,
     accountSummary,


### PR DESCRIPTION
Replace hardcoded OFFER_MINSIZE_MAX_PLACEHODLER with the wallet's actual available balance, prevents users from setting a minimum offer size they can not back.

https://github.com/user-attachments/assets/2f1c69b3-7c0e-4b83-bf8f-b1bd94695c86

