### PR TITLE
fix clearTimeout on setInterval timer in websocket heartbeat

### DIFF
--- a/src/hooks/useJmWebsocket.ts
+++ b/src/hooks/useJmWebsocket.ts
@@ -140,7 +140,7 @@ export const useJmWebsocket = ({ enableHeartbeat, options }: UseJmWebsocketProps
       return () => {
         console.debug(`Cancelling scheduled heartbeat messages.`)
         abortCtrl.abort()
-        clearTimeout(timerId)
+        clearInterval(timerId)
       }
     },
     [enableHeartbeat, sendMessage, isOpen, authenticated, authToken],


### PR DESCRIPTION
The heartbeat cleanup was using clearTimeout for a setInterval, so the interval was not being cleared on unmount, switched to clearInterval to ensure the heartbeat stops correctly