### PR TITLE
Fix useEffect deps causing toast spam on EarnPage

### DIFF
--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -155,7 +155,8 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     toast.success(t('earn.alert_running'), { id: 'earn.alert_running' })
     scrollToTop()
     startMaker.reset()
-  }, [jmSession, makerRunning, startMaker.isSuccess, startMaker, t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jmSession, makerRunning, startMaker.isSuccess, startMaker.reset, t])
 
   useEffect(() => {
     if (!jmSession || !stopMaker.isSuccess || makerRunning) return
@@ -164,7 +165,8 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     toast.dismiss('earn.alert_running')
     toast.success(t('earn.alert_stopped'), { id: 'earn.alert_stopped' })
     stopMaker.reset()
-  }, [jmSession, makerRunning, stopMaker.isSuccess, stopMaker, t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jmSession, makerRunning, stopMaker.isSuccess, stopMaker.reset, t])
 
   if (!jmSession) {
     return <PageLoading />


### PR DESCRIPTION
The start/stop mutation objects are new refrences on each render, causing both effects to run repetedly, narrowed dependencies to isSuccess and reset, which are the only values used, to prevent repeated toasts and resets