### PR TITLE
fix(auth): sync session auth across browser tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import type { PropsWithChildren } from 'react'
 import { lockwalletOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { token } from '@joinmarket-webui/joinmarket-api-ts/jm'
@@ -38,6 +38,7 @@ import { routes } from '@/constants/routes'
 import { JamDisplayContextProvider } from '@/context/JamDisplayContextProvider'
 import { JamWalletInfoContextProvider } from '@/context/JamWalletInfoContextProvider'
 import { useApiClient } from '@/hooks/useApiClient'
+import { broadcastAuthCleared, useAuthCrossTabSync } from '@/hooks/useAuthCrossTabSync'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
 import { queryClient } from '@/lib/queryClient'
@@ -56,9 +57,13 @@ const DevSetupPage = lazy(() => import('@/components/dev/DevSetupPage'))
 const DevPage = lazy(() => import('@/components/dev/DevPage'))
 const DevErrorThrowingComponent = lazy(() => import('@/components/dev/DevErrorThrowingComponent'))
 
-const clearAuthAndQueryCache = () => {
+const clearAuthAndQueryCache = ({ broadcast }: { broadcast: boolean }) => {
   authStore.getState().clear()
   queryClient.clear()
+
+  if (broadcast) {
+    broadcastAuthCleared()
+  }
 }
 
 const ProtectedRoute = ({ authenticated, children }: PropsWithChildren<{ authenticated: boolean }>) => {
@@ -76,6 +81,7 @@ function App() {
   const hasAuthToken = useStore(authStore, (state) => state.state?.auth?.token !== undefined)
   const isDeveloperMode = useStore(jamSettingsStore, (state) => state.state.developerMode)
   const authenticated = useMemo(() => walletFileName !== undefined && hasAuthToken, [walletFileName, hasAuthToken])
+  const clearAuthStateFromRemoteTab = useCallback(() => clearAuthAndQueryCache({ broadcast: false }), [])
 
   const jmSession = useStore(jmSessionStore, (state) => state.state)
 
@@ -98,8 +104,10 @@ function App() {
   )
   const [lockWalletDialogContext, setLockWalletDialogContext] = useState<LockWalletDialogContext>()
 
+  useAuthCrossTabSync({ onRemoteAuthCleared: clearAuthStateFromRemoteTab })
+
   const doOnLogout = async (navigate: NavigateFunction) => {
-    clearAuthAndQueryCache()
+    clearAuthAndQueryCache({ broadcast: true })
     await navigate(routes.login)
   }
 
@@ -283,7 +291,7 @@ function RefreshApiToken() {
         })
 
         if (!response.data) {
-          clearAuthAndQueryCache()
+          clearAuthAndQueryCache({ broadcast: false })
 
           if (isDevMode) {
             const message = response.error?.message || response.error?.error_description || 'Unknown error.'

--- a/src/hooks/useAuthCrossTabSync.ts
+++ b/src/hooks/useAuthCrossTabSync.ts
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from 'react'
+import { useStore } from 'zustand'
+import { authStore, type AuthState } from '@/store/authStore'
+
+const AUTH_SYNC_CHANNEL_NAME = 'jam:auth:sync'
+
+type AuthStateRequestMessage = {
+  type: 'auth_state_request'
+  requestId: string
+}
+
+type AuthStateResponseMessage = {
+  type: 'auth_state_response'
+  requestId: string
+  state: AuthState
+}
+
+type AuthClearedMessage = {
+  type: 'auth_cleared'
+}
+
+type AuthSyncMessage = AuthStateRequestMessage | AuthStateResponseMessage | AuthClearedMessage
+
+interface UseAuthCrossTabSyncProps {
+  onRemoteAuthCleared: () => void
+}
+
+const createRequestId = () =>
+  globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+const hasValidAuthState = (state?: AuthState): state is AuthState =>
+  state?.walletFileName !== undefined && state?.auth?.token !== undefined && state?.auth?.refresh_token !== undefined
+
+const isAuthStateRequestMessage = (message: unknown): message is AuthStateRequestMessage =>
+  !!message &&
+  typeof message === 'object' &&
+  'type' in message &&
+  message.type === 'auth_state_request' &&
+  'requestId' in message &&
+  typeof message.requestId === 'string'
+
+const isAuthStateResponseMessage = (message: unknown): message is AuthStateResponseMessage =>
+  !!message &&
+  typeof message === 'object' &&
+  'type' in message &&
+  message.type === 'auth_state_response' &&
+  'requestId' in message &&
+  typeof message.requestId === 'string' &&
+  'state' in message
+
+const isAuthClearedMessage = (message: unknown): message is AuthClearedMessage =>
+  !!message && typeof message === 'object' && 'type' in message && message.type === 'auth_cleared'
+
+const isAuthSyncMessage = (message: unknown): message is AuthSyncMessage =>
+  isAuthStateRequestMessage(message) || isAuthStateResponseMessage(message) || isAuthClearedMessage(message)
+
+export const broadcastAuthCleared = () => {
+  if (typeof BroadcastChannel === 'undefined') {
+    return
+  }
+
+  const authSyncChannel = new BroadcastChannel(AUTH_SYNC_CHANNEL_NAME)
+  authSyncChannel.postMessage({ type: 'auth_cleared' } satisfies AuthClearedMessage)
+  authSyncChannel.close()
+}
+
+export const useAuthCrossTabSync = ({ onRemoteAuthCleared }: UseAuthCrossTabSyncProps) => {
+  const hasAuthInCurrentTab = useStore(authStore, (state) => hasValidAuthState(state.state))
+  const pendingRequestIdReference = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') {
+      return
+    }
+
+    const authSyncChannel = new BroadcastChannel(AUTH_SYNC_CHANNEL_NAME)
+
+    const onMessage = (event: MessageEvent<unknown>) => {
+      const { data: message } = event
+      if (!isAuthSyncMessage(message)) {
+        return
+      }
+
+      if (isAuthStateRequestMessage(message)) {
+        const currentAuthState = authStore.getState().state
+        if (!hasValidAuthState(currentAuthState)) {
+          return
+        }
+
+        authSyncChannel.postMessage({
+          type: 'auth_state_response',
+          requestId: message.requestId,
+          state: currentAuthState,
+        } satisfies AuthStateResponseMessage)
+        return
+      }
+
+      if (isAuthStateResponseMessage(message)) {
+        if (pendingRequestIdReference.current === undefined) {
+          return
+        }
+
+        if (message.requestId !== pendingRequestIdReference.current) {
+          return
+        }
+
+        if (!hasValidAuthState(message.state)) {
+          return
+        }
+
+        if (!hasValidAuthState(authStore.getState().state)) {
+          authStore.getState().update(message.state)
+        }
+
+        pendingRequestIdReference.current = undefined
+        return
+      }
+
+      onRemoteAuthCleared()
+    }
+
+    authSyncChannel.addEventListener('message', onMessage)
+
+    if (!hasAuthInCurrentTab) {
+      const requestId = createRequestId()
+      pendingRequestIdReference.current = requestId
+      authSyncChannel.postMessage({
+        type: 'auth_state_request',
+        requestId,
+      } satisfies AuthStateRequestMessage)
+    } else {
+      pendingRequestIdReference.current = undefined
+    }
+
+    return () => {
+      authSyncChannel.removeEventListener('message', onMessage)
+      authSyncChannel.close()
+    }
+  }, [hasAuthInCurrentTab, onRemoteAuthCleared])
+}


### PR DESCRIPTION
summary
this follow-up PR fixes cross-tab login UX while keeping `sessionStorage` as the auth storage model.

context
raised during review discussion of #1069: opening JAM in a new tab could show login even when another tab was already authenticated.

what changed
added `useAuthCrossTabSync` hook:
     new tab requests auth state from existing authenticated tab via `BroadcastChannel`.
     existing authenticated tab responds with current auth state.
     logout/lock broadcasts an auth-cleared event to all tabs.
wired hook into app root and updated auth-clear flow to broadcast only on local logout/lock.


why this approach
preserves current `sessionStorage` security/persistence decision.
solves new-tab UX without broad auth architecture changes.
keeps fix focused and low-risk.

closes #1083 
ping @theborakompanioni @saurabhraghuvanshii 