### PR TITLE
fix(login): restore active wallet blinking status indicator

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -118,11 +118,17 @@ export const LoginFormComponent = ({
                   {shortenStringMiddle(walletDisplayName(wallet), 32)}
                   {activeWallet === wallet ? (
                     <span
-                      className={cn('py-1 text-xs', {
+                      className={cn('inline-flex items-center gap-1.5 py-1 text-xs', {
                         'text-muted-foreground/50': !(makerRunning || coinjoinInProgress),
                         'light:text-green-600 animate-pulse text-green-300/90': makerRunning || coinjoinInProgress,
                       })}
                     >
+                      <span
+                        className={cn('h-2 w-2 rounded-full motion-safe:animate-pulse', {
+                          'bg-green-500/70': !(makerRunning || coinjoinInProgress),
+                          'light:bg-green-600 bg-green-300/90': makerRunning || coinjoinInProgress,
+                        })}
+                      />
                       {t('wallets.wallet_preview.wallet_active')}
                     </span>
                   ) : undefined}


### PR DESCRIPTION
summary : -
adds the green blinking indicator next to the `Active` wallet label in the login wallet selector.

reviewer feedback on #1081 mentioned the missing green blinking indicator near `Active`. this PR restores that UX cue.

closes #1086 
