### PR TITLE
fix(v2): unify backend error reason extraction across earn/receive flows

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -12,6 +12,7 @@ import { useStore } from 'zustand'
 import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { Utxo } from '@/hooks/useQueryUtxos'
+import { getErrorReason } from '@/lib/errorReason'
 import * as fb from '@/lib/fidelityBondUtils'
 import type { WalletFileName } from '@/lib/utils'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
@@ -119,7 +120,7 @@ export function useCreateFidelityBondWizard(
   const freezeUtxo = useMutation({
     ...freezeMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.error_freezing_utxos')} ${reason}`)
     },
   })
@@ -127,7 +128,7 @@ export function useCreateFidelityBondWizard(
   const unfreezeUtxo = useMutation({
     ...freezeMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.error_unfreezing_utxos')} ${reason}`)
     },
   })
@@ -135,7 +136,7 @@ export function useCreateFidelityBondWizard(
   const directSend = useMutation({
     ...directsendMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.error_creating_fidelity_bond')} ${reason}`)
     },
   })

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -20,6 +20,7 @@ import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import type { FidelityBondUtxo } from '@/hooks/useQueryUtxos'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
+import { getErrorReason } from '@/lib/errorReason'
 import * as fb from '@/lib/fidelityBondUtils'
 import { withQueryDelay } from '@/lib/queryClient'
 import { cn, isAbsoluteOffer, isRelativeOffer, percentageToFactor, scrollToTop } from '@/lib/utils'
@@ -104,7 +105,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
       toast.info(t('earn.alert_stopping'), { id: 'earn.alert_stopping' })
     },
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       // TODO: i18n
       toast.error(`Error while stopping the earn process. Reason: ${reason}`)
     },
@@ -118,7 +119,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     },
     onError: (error: ErrorMessage) => {
       console.error('StartMaker error:', error)
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       toast.error(t('earn.alert_start_failed', { reason }))
     },
   })

--- a/src/components/earn/MoveToJarDialog.tsx
+++ b/src/components/earn/MoveToJarDialog.tsx
@@ -36,6 +36,7 @@ import { Switch } from '@/components/ui/switch'
 import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { FidelityBondUtxo, Utxo } from '@/hooks/useQueryUtxos'
+import { getErrorReason } from '@/lib/errorReason'
 import { cn, formatSats, type WalletFileName } from '@/lib/utils'
 import type { JarIndex } from '@/types/global'
 
@@ -96,7 +97,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
   const freezeUtxo = useMutation({
     ...freezeMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.move.error_freezing_utxos')} ${reason}`)
     },
   })
@@ -104,7 +105,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
   const unfreezeUtxo = useMutation({
     ...freezeMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.move.error_unfreezing_fidelity_bond')} ${reason}`)
     },
   })
@@ -112,7 +113,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
   const directSend = useMutation({
     ...directsendMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.move.error_spending_fidelity_bond')} ${reason}`)
     },
   })

--- a/src/components/earn/RenewBondDialog.tsx
+++ b/src/components/earn/RenewBondDialog.tsx
@@ -38,6 +38,7 @@ import { Switch } from '@/components/ui/switch'
 import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { FidelityBondUtxo, Utxo } from '@/hooks/useQueryUtxos'
+import { getErrorReason } from '@/lib/errorReason'
 import * as fb from '@/lib/fidelityBondUtils'
 import { cn, formatSats, type WalletFileName } from '@/lib/utils'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
@@ -118,7 +119,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
   const freezeUtxo = useMutation({
     ...freezeMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.error_freezing_utxos')} ${reason}`)
     },
   })
@@ -126,7 +127,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
   const unfreezeUtxo = useMutation({
     ...freezeMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.error_unfreezing_utxos')} ${reason}`)
     },
   })
@@ -134,7 +135,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
   const directSend = useMutation({
     ...directsendMutation({ client }),
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       setError(`${t('earn.fidelity_bond.renew.error_renewing_fidelity_bond')} ${reason}`)
     },
   })

--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -13,6 +13,7 @@ import PageTitle from '@/components/ui/jam/PageTitle'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useJars } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
+import { getErrorReason } from '@/lib/errorReason'
 import { withMutationDelay } from '@/lib/queryClient'
 import { cn, type WalletFileName } from '@/lib/utils'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
@@ -83,7 +84,7 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
     retry: false,
     gcTime: Number.POSITIVE_INFINITY,
     onError: (error: ErrorMessage) => {
-      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       // TODO: add reason to i18n
       toast.error(t('receive.error_loading_address_failed', { reason }))
     },

--- a/src/lib/errorReason.test.ts
+++ b/src/lib/errorReason.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { getErrorReason } from './errorReason'
+
+describe('getErrorReason', () => {
+  it('returns fallback when nothing usable is present', () => {
+    expect(getErrorReason(undefined, 'fallback')).toBe('fallback')
+    expect(getErrorReason({}, 'fallback')).toBe('fallback')
+    expect(getErrorReason('   ', 'fallback')).toBe('fallback')
+  })
+
+  it('returns direct string errors', () => {
+    expect(getErrorReason('backend exploded', 'fallback')).toBe('backend exploded')
+  })
+
+  it('prefers backend error_description over message', () => {
+    const error = {
+      message: 'Request failed with status 400',
+      error_description: 'Wallet is already unlocked',
+    }
+    expect(getErrorReason(error, 'fallback')).toBe('Wallet is already unlocked')
+  })
+
+  it('prefers detail over message when error_description is missing', () => {
+    const error = {
+      message: 'Request failed with status 422',
+      detail: 'Seed phrase checksum failed',
+    }
+    expect(getErrorReason(error, 'fallback')).toBe('Seed phrase checksum failed')
+  })
+
+  it('extracts nested backend reason from response.data', () => {
+    const error = {
+      response: {
+        data: {
+          error_description: 'Invalid wallet password',
+        },
+      },
+    }
+    expect(getErrorReason(error, 'fallback')).toBe('Invalid wallet password')
+  })
+
+  it('extracts nested backend reason from error payload', () => {
+    const error = {
+      error: {
+        detail: 'Coinjoin is currently in progress',
+      },
+    }
+    expect(getErrorReason(error, 'fallback')).toBe('Coinjoin is currently in progress')
+  })
+})

--- a/src/lib/errorReason.ts
+++ b/src/lib/errorReason.ts
@@ -1,23 +1,64 @@
-export const getErrorReason = (error: unknown, fallback: string): string => {
-  if (error instanceof Error && error.message) return error.message
-  if (typeof error === 'string' && error.trim()) return error
+const toNonEmptyString = (value: unknown): string | undefined => {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
 
-  if (error && typeof error === 'object') {
-    const maybeError = error as {
-      message?: unknown
-      error_description?: unknown
-      detail?: unknown
-    }
-    if (typeof maybeError.error_description === 'string' && maybeError.error_description.trim()) {
-      return maybeError.error_description
-    }
-    if (typeof maybeError.message === 'string' && maybeError.message.trim()) {
-      return maybeError.message
-    }
-    if (typeof maybeError.detail === 'string' && maybeError.detail.trim()) {
-      return maybeError.detail
+const extractReason = (error: unknown, depth = 0): string | undefined => {
+  if (depth > 4 || error === null || error === undefined) {
+    return undefined
+  }
+
+  const directString = toNonEmptyString(error)
+  if (directString) {
+    return directString
+  }
+
+  if (typeof error !== 'object') {
+    return undefined
+  }
+
+  const maybeError = error as {
+    message?: unknown
+    error_description?: unknown
+    detail?: unknown
+    error?: unknown
+    response?: { data?: unknown } | unknown
+    data?: unknown
+    body?: unknown
+    cause?: unknown
+  }
+
+  const prioritizedReason = [maybeError.error_description, maybeError.detail, maybeError.message]
+    .map((value) => toNonEmptyString(value))
+    .find(Boolean)
+
+  if (prioritizedReason) {
+    return prioritizedReason
+  }
+
+  const responseData =
+    maybeError.response && typeof maybeError.response === 'object'
+      ? (maybeError.response as { data?: unknown }).data
+      : undefined
+
+  const nestedCandidates = [
+    maybeError.error,
+    maybeError.response,
+    responseData,
+    maybeError.data,
+    maybeError.body,
+    maybeError.cause,
+  ]
+
+  for (const candidate of nestedCandidates) {
+    const nestedReason = extractReason(candidate, depth + 1)
+    if (nestedReason) {
+      return nestedReason
     }
   }
 
-  return fallback
+  return undefined
+}
+
+export const getErrorReason = (error: unknown, fallback: string): string => {
+  return extractReason(error) ?? fallback
 }


### PR DESCRIPTION
summary
this PR standardizes backend error-reason extraction in v2 so user-facing errors are consistent and accurate across Earn/Receive-related flows.

what changed
Updated shared parser in `src/lib/errorReason.ts`
   prioritizes: `error_description` -> `detail` -> `message`
      Supports nested payload extraction from:
    `error`
    `response.data`
    `data`
    `body`
    `cause`
  Trims string values and guards recursion depth

added tests in `/Users/parthbandwal/Desktop/JamSoB/jam/src/lib/errorReason.test.ts`
  fallback behavior
  direct string errors
  priority ordering
  nested payload extraction

replaced ad-hoc parsing with shared helper in:
  `/src/components/receive/ReceivePage.tsx`
  `/src/components/earn/EarnPage.tsx`
  `/src/components/earn/MoveToJarDialog.tsx`
  `/src/components/earn/RenewBondDialog.tsx`
 `/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts`
why i changed this 
some v2 flows still showed generic error text even when backend returned better reasons. This aligns behavior with shared parsing and improves UX consistency.

closes #1088 

ping @theborakompanioni @saurabhraghuvanshii 

