### PR TITLE
feat(sweep): make v2 Sweep fully functional with modular UX + validations

### DIFF
--- a/src/components/sweep/SweepDestinationInputs.tsx
+++ b/src/components/sweep/SweepDestinationInputs.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'react-i18next'
+import { Field, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+
+interface SweepDestinationInputsProps {
+  addresses: string[]
+  errors: Array<string | undefined>
+  touched: boolean[]
+  disabled: boolean
+  onChange: (index: number, value: string) => void
+  onBlur: (index: number) => void
+}
+
+export const SweepDestinationInputs = ({
+  addresses,
+  errors,
+  touched,
+  disabled,
+  onChange,
+  onBlur,
+}: SweepDestinationInputsProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-3">
+      {addresses.map((address, index) => (
+        <div key={index} className="space-y-1">
+          <Field data-invalid={touched[index] && errors[index] !== undefined}>
+            <FieldLabel htmlFor={`sweep-destination-${index}`}>
+              {t('scheduler.label_destination_input', { destination: index + 1 })}
+            </FieldLabel>
+            <Input
+              id={`sweep-destination-${index}`}
+              value={address}
+              onChange={(event) => onChange(index, event.currentTarget.value)}
+              onBlur={() => onBlur(index)}
+              className="font-mono"
+              placeholder={t('scheduler.placeholder_destination_input')}
+              disabled={disabled}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </Field>
+          {touched[index] && errors[index] && <div className="text-destructive text-xs">{errors[index]}</div>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -1,47 +1,358 @@
-import { useState } from 'react'
-import { AlertTriangleIcon } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  getscheduleOptions,
+  runscheduleMutation,
+  stopcoinjoinOptions,
+} from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import type { ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { HourglassIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { useStore } from 'zustand'
 import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
+import { SweepDestinationInputs } from '@/components/sweep/SweepDestinationInputs'
+import { SweepPreconditionAlert } from '@/components/sweep/SweepPreconditionAlert'
+import { SweepScheduleProgress } from '@/components/sweep/SweepScheduleProgress'
+import { SweepStartConfirmDialog } from '@/components/sweep/SweepStartConfirmDialog'
+import { buildDestinationErrors, normalizeDestinationAddresses } from '@/components/sweep/destinationValidation'
+import { buildSweepPreconditionSummary } from '@/components/sweep/preconditions'
+import { isScheduleValue, type Schedule } from '@/components/sweep/scheduleUtils'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Balance } from '@/components/ui/jam/Balance'
 import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
 import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from '@/components/ui/jam/PageTitle'
+import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
+import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import { useRefreshSession } from '@/hooks/useRefreshSession'
 import type { WalletFileName } from '@/lib/utils'
+import { jmSessionStore } from '@/store/jmSessionStore'
+import { Spinner } from '../ui/spinner'
 
 interface SweepPageProps {
   walletFileName: WalletFileName
 }
 
+const DESTINATION_ADDRESS_COUNT = 3
+const WAIT_FOR_UPDATE_SESSION_POLLING_INTERVAL = 3_000
+const WAIT_FOR_UPDATE_SESSION_POLLING_DELAY = 1_000
+
+const initialDestinationAddresses = () => Array.from({ length: DESTINATION_ADDRESS_COUNT }, () => '')
+const initialTouchedValues = () => Array.from({ length: DESTINATION_ADDRESS_COUNT }, () => false)
+
+const toErrorReason = (error: unknown, fallback: string): string => {
+  if (typeof error === 'object' && error !== null) {
+    if ('message' in error && typeof error.message === 'string' && error.message.trim() !== '') {
+      return error.message
+    }
+    if ('error_description' in error && typeof error.error_description === 'string' && error.error_description !== '') {
+      return error.error_description
+    }
+  }
+  return fallback
+}
+
 export const SweepPage = ({ walletFileName }: SweepPageProps) => {
   const { t } = useTranslation()
+  const client = useApiClient()
+  const jmSession = useStore(jmSessionStore, (state) => state.state)
+  const walletInfo = useJamWalletInfoContext()
+
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
+  const [showScheduleConfirmDialog, setShowScheduleConfirmDialog] = useState(false)
+  const [destinationAddresses, setDestinationAddresses] = useState(initialDestinationAddresses)
+  const [destinationTouched, setDestinationTouched] = useState(initialTouchedValues)
+  const [alertMessage, setAlertMessage] = useState<string>()
+  const [localSchedule, setLocalSchedule] = useState<Schedule>()
 
   const { maxFeesConfigMissing, isLoading } = useFeeConfigValidation({ walletFileName })
+  const allUtxos = useMemo(() => {
+    return walletInfo.jars.flatMap((jar) => jar.utxos)
+  }, [walletInfo.jars])
 
-  if (isLoading) {
+  const preconditionSummary = useMemo(() => {
+    return buildSweepPreconditionSummary(allUtxos)
+  }, [allUtxos])
+
+  const destinationErrors = useMemo(() => {
+    return buildDestinationErrors(destinationAddresses, walletInfo.addressSummary, t)
+  }, [destinationAddresses, walletInfo.addressSummary, t])
+
+  const normalizedDestinationAddresses = useMemo(() => {
+    return normalizeDestinationAddresses(destinationAddresses)
+  }, [destinationAddresses])
+
+  const hasDestinationErrors = destinationErrors.some((error) => error !== undefined)
+  const allDestinationAddressesPresent = normalizedDestinationAddresses.every((address) => address !== '')
+
+  const getScheduleQueryOptions = useMemo(
+    () =>
+      getscheduleOptions({
+        client,
+        path: { walletname: encodeURIComponent(walletFileName) },
+      }),
+    [client, walletFileName],
+  )
+
+  const getScheduleQuery = useQuery({
+    ...getScheduleQueryOptions,
+    retry: false,
+    enabled: jmSession?.coinjoin_in_process === true,
+    refetchInterval: jmSession?.coinjoin_in_process === true ? WAIT_FOR_UPDATE_SESSION_POLLING_INTERVAL : false,
+    refetchIntervalInBackground: true,
+  })
+
+  const stopScheduleQueryOptions = stopcoinjoinOptions({
+    client,
+    path: { walletname: encodeURIComponent(walletFileName) },
+  })
+
+  const stopScheduleQuery = useQuery({
+    ...stopScheduleQueryOptions,
+    enabled: false,
+    retry: false,
+    staleTime: 1,
+    gcTime: 1,
+  })
+
+  const startScheduleMutation = useMutation({
+    ...runscheduleMutation({ client }),
+    retry: false,
+    onMutate: () => {
+      setAlertMessage(undefined)
+    },
+    onSuccess: (result) => {
+      if (isScheduleValue(result.schedule)) {
+        setLocalSchedule(result.schedule)
+      }
+      setShowScheduleConfirmDialog(false)
+    },
+    onError: (error: ErrorMessage) => {
+      const reason = error.message || error.error_description || t('global.errors.reason_unknown')
+      const message = `${t('scheduler.error_starting_schedule_failed')} ${reason}`
+      setAlertMessage(message)
+      toast.error(message)
+    },
+  })
+
+  const stopScheduleMutation = useMutation({
+    mutationFn: async () => {
+      return await stopScheduleQuery.refetch({ throwOnError: true })
+    },
+    retry: false,
+    onMutate: () => {
+      setAlertMessage(undefined)
+    },
+    onSuccess: () => {
+      setLocalSchedule(undefined)
+    },
+    onError: (error: unknown) => {
+      const message = `${t('scheduler.error_stopping_schedule_failed')} ${toErrorReason(error, t('global.errors.reason_unknown'))}`
+      setAlertMessage(message)
+      toast.error(message)
+    },
+  })
+
+  const sessionSchedule = isScheduleValue(jmSession?.schedule) ? jmSession.schedule : undefined
+  const queriedSchedule = isScheduleValue(getScheduleQuery.data?.schedule) ? getScheduleQuery.data.schedule : undefined
+  const currentSchedule = sessionSchedule ?? queriedSchedule ?? localSchedule
+
+  const schedulerRunning = jmSession?.coinjoin_in_process === true && currentSchedule !== undefined
+  const singleCoinJoinRunning = jmSession?.coinjoin_in_process === true && !schedulerRunning
+  const makerRunning = jmSession?.maker_running === true
+  const collaborativeOperationRunning = makerRunning || jmSession?.coinjoin_in_process === true
+
+  const isWaitingSchedulerStart =
+    startScheduleMutation.isPending || (startScheduleMutation.isSuccess && !schedulerRunning)
+  const isWaitingSchedulerStop = stopScheduleMutation.isPending || (stopScheduleMutation.isSuccess && schedulerRunning)
+
+  useRefreshSession({
+    enabled: isWaitingSchedulerStart || isWaitingSchedulerStop,
+    refetchInterval: WAIT_FOR_UPDATE_SESSION_POLLING_INTERVAL,
+    refetchDelay: WAIT_FOR_UPDATE_SESSION_POLLING_DELAY,
+  })
+
+  useEffect(() => {
+    if (schedulerRunning && startScheduleMutation.isSuccess) {
+      startScheduleMutation.reset()
+    }
+  }, [schedulerRunning, startScheduleMutation])
+
+  useEffect(() => {
+    if (!schedulerRunning && stopScheduleMutation.isSuccess) {
+      stopScheduleMutation.reset()
+    }
+  }, [schedulerRunning, stopScheduleMutation])
+
+  const isOperationDisabled =
+    maxFeesConfigMissing || collaborativeOperationRunning || jmSession?.rescanning || !preconditionSummary.isFulfilled
+
+  const isStartDisabled =
+    isOperationDisabled ||
+    isWaitingSchedulerStart ||
+    isWaitingSchedulerStop ||
+    hasDestinationErrors ||
+    !allDestinationAddressesPresent
+
+  const touchAllDestinations = () => {
+    setDestinationTouched((current) => current.map(() => true))
+  }
+
+  const updateDestinationAddress = (index: number, value: string) => {
+    setDestinationAddresses((current) =>
+      current.map((address, currentIndex) => (currentIndex === index ? value : address)),
+    )
+  }
+
+  const markDestinationTouched = (index: number) => {
+    setDestinationTouched((current) =>
+      current.map((touched, currentIndex) => (currentIndex === index ? true : touched)),
+    )
+  }
+
+  const startSchedule = async () => {
+    touchAllDestinations()
+    if (isStartDisabled) {
+      return
+    }
+
+    await startScheduleMutation.mutateAsync({
+      path: { walletname: encodeURIComponent(walletFileName) },
+      body: {
+        destination_addresses: normalizeDestinationAddresses(destinationAddresses),
+      },
+    })
+  }
+
+  const onOpenScheduleConfirm = () => {
+    touchAllDestinations()
+    if (isStartDisabled) {
+      return
+    }
+    setShowScheduleConfirmDialog(true)
+  }
+
+  const stopSchedule = async () => {
+    await stopScheduleMutation.mutateAsync()
+  }
+
+  if (isLoading || walletInfo.isLoading || jmSession === undefined) {
     return <PageLoading />
   }
 
   return (
     <div className="mx-auto max-w-4xl space-y-3 p-4">
+      <FeeLimitDialog
+        open={showFeeConfigDialog}
+        onOpenChange={setShowFeeConfigDialog}
+        walletFileName={walletFileName}
+      />
+      <SweepStartConfirmDialog
+        open={showScheduleConfirmDialog}
+        onOpenChange={setShowScheduleConfirmDialog}
+        onConfirm={startSchedule}
+        disabled={isStartDisabled || isWaitingSchedulerStart}
+        isStarting={isWaitingSchedulerStart}
+      />
+
       <PageTitle title={t('scheduler.title')} subtitle={t('scheduler.subtitle')} />
 
       {maxFeesConfigMissing && (
         <FeeConfigErrorAlert onOpenFeeConfig={() => setShowFeeConfigDialog(true)} className="mb-4" />
       )}
 
-      <Alert variant="warning">
-        <AlertTriangleIcon />
-        <AlertTitle>Under construction</AlertTitle>
-        <AlertDescription>Not yet implemented.</AlertDescription>
-      </Alert>
+      {alertMessage && (
+        <Alert variant="destructive">
+          <AlertTitle>{t('global.error')}</AlertTitle>
+          <AlertDescription>{alertMessage}</AlertDescription>
+        </Alert>
+      )}
 
-      <FeeLimitDialog
-        open={showFeeConfigDialog}
-        onOpenChange={setShowFeeConfigDialog}
-        walletFileName={walletFileName}
-      />
+      {singleCoinJoinRunning && (
+        <Alert variant="warning">
+          <HourglassIcon />
+          <AlertDescription>{t('send.text_coinjoin_already_running')}</AlertDescription>
+        </Alert>
+      )}
+
+      {makerRunning && !schedulerRunning && (
+        <Alert variant="warning">
+          <HourglassIcon />
+          <AlertDescription>{t('send.text_maker_running')}</AlertDescription>
+        </Alert>
+      )}
+
+      {isWaitingSchedulerStart && (
+        <Alert>
+          <Spinner className="motion-reduce:hidden" />
+          <AlertTitle>{t('scheduler.button_start')}</AlertTitle>
+        </Alert>
+      )}
+
+      {isWaitingSchedulerStop && (
+        <Alert>
+          <Spinner className="motion-reduce:hidden" />
+          <AlertTitle>{t('scheduler.button_stop')}</AlertTitle>
+        </Alert>
+      )}
+
+      {schedulerRunning && currentSchedule && (
+        <SweepScheduleProgress schedule={currentSchedule} isStopping={isWaitingSchedulerStop} onStop={stopSchedule} />
+      )}
+
+      {!schedulerRunning && (
+        <>
+          <SweepPreconditionAlert summary={preconditionSummary} />
+
+          <Card>
+            <CardContent className="space-y-5">
+              <div className="bg-muted/50 flex items-center justify-between rounded-lg border px-4 py-3">
+                <div>
+                  <div className="font-medium">{t('scheduler.complete_wallet_title')}</div>
+                  <div className="text-muted-foreground text-sm">{t('scheduler.complete_wallet_subtitle')}</div>
+                </div>
+                <div className="font-semibold">
+                  <Balance valueString={String(walletInfo.walletBalanceSummary.calculatedAvailableBalanceInSats)} />
+                </div>
+              </div>
+
+              <p className="text-muted-foreground text-sm">{t('scheduler.description_destination_addresses')}</p>
+
+              <SweepDestinationInputs
+                addresses={destinationAddresses}
+                errors={destinationErrors}
+                touched={destinationTouched}
+                disabled={isOperationDisabled || isWaitingSchedulerStart || isWaitingSchedulerStop}
+                onChange={updateDestinationAddress}
+                onBlur={markDestinationTouched}
+              />
+
+              <p className="text-muted-foreground text-sm">{t('scheduler.description_fees')}</p>
+
+              <Button
+                type="button"
+                onClick={onOpenScheduleConfirm}
+                disabled={isStartDisabled}
+                size="xxl"
+                className="w-full"
+              >
+                {isWaitingSchedulerStart ? (
+                  <>
+                    <Spinner className="motion-reduce:hidden" />
+                    {t('scheduler.button_start')}
+                  </>
+                ) : (
+                  t('scheduler.button_start')
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import {
-  getscheduleOptions,
-  runscheduleMutation,
-  stopcoinjoinOptions,
-} from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
-import type { ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { runscheduleMutation, stopcoinjoinOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import { getschedule, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { HourglassIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -89,21 +85,29 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
   const hasDestinationErrors = destinationErrors.some((error) => error !== undefined)
   const allDestinationAddressesPresent = normalizedDestinationAddresses.every((address) => address !== '')
 
-  const getScheduleQueryOptions = useMemo(
-    () =>
-      getscheduleOptions({
-        client,
-        path: { walletname: encodeURIComponent(walletFileName) },
-      }),
-    [client, walletFileName],
-  )
-
   const getScheduleQuery = useQuery({
-    ...getScheduleQueryOptions,
+    queryKey: ['sweep-get-schedule', walletFileName],
     retry: false,
     enabled: jmSession?.coinjoin_in_process === true,
     refetchInterval: jmSession?.coinjoin_in_process === true ? WAIT_FOR_UPDATE_SESSION_POLLING_INTERVAL : false,
     refetchIntervalInBackground: true,
+    queryFn: async ({ signal }) => {
+      const result = await getschedule({
+        client,
+        signal,
+        path: { walletname: encodeURIComponent(walletFileName) },
+        throwOnError: false,
+      })
+
+      if (result.error !== undefined) {
+        if (result.response.status === 404) {
+          return undefined
+        }
+        throw new Error(toErrorReason(result.error, 'Failed to load schedule'))
+      }
+
+      return result.data
+    },
   })
 
   const stopScheduleQueryOptions = stopcoinjoinOptions({

--- a/src/components/sweep/SweepPreconditionAlert.tsx
+++ b/src/components/sweep/SweepPreconditionAlert.tsx
@@ -1,0 +1,84 @@
+import { AlertTriangleIcon } from 'lucide-react'
+import { Trans, useTranslation } from 'react-i18next'
+import type { SweepPreconditionSummary } from '@/components/sweep/preconditions'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { formatSats, shortenStringMiddle } from '@/lib/utils'
+
+interface SweepPreconditionAlertProps {
+  summary: SweepPreconditionSummary
+}
+
+const RETRIES_DOCS_URL =
+  'https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/SOURCING-COMMITMENTS.md'
+
+const RetryLockedUtxoList = ({ summary }: SweepPreconditionAlertProps) => {
+  if (summary.retryLockedUtxos.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <Trans
+        i18nKey="scheduler.precondition.hint_missing_retries"
+        components={[
+          <></>,
+          <a key="retries-doc-link" href={RETRIES_DOCS_URL} target="_blank" rel="noopener noreferrer" />,
+        ]}
+      />
+      <div className="mt-3 rounded-md border p-2">
+        <div className="mb-2 text-xs font-semibold">UTXOs</div>
+        <ul className="space-y-1">
+          {summary.retryLockedUtxos.map((utxo) => (
+            <li key={utxo.utxo} className="bg-muted/50 rounded-sm px-2 py-1 font-mono text-xs">
+              <span className="mr-2 font-semibold">jar {utxo.mixdepth}</span>
+              <span className="mr-2">{formatSats(utxo.value)} sats</span>
+              <span>{shortenStringMiddle(utxo.utxo, 26)}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  )
+}
+
+export const SweepPreconditionAlert = ({ summary }: SweepPreconditionAlertProps) => {
+  const { t } = useTranslation()
+
+  if (summary.isFulfilled) {
+    return null
+  }
+
+  if (summary.numberOfMissingUtxos > 0) {
+    return (
+      <Alert variant="warning">
+        <AlertTriangleIcon />
+        <AlertDescription>
+          {t('scheduler.precondition.hint_missing_utxos', { minConfirmations: summary.options.minConfirmations })}
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (summary.numberOfMissingConfirmations > 0) {
+    return (
+      <Alert variant="warning">
+        <AlertTriangleIcon />
+        <AlertDescription>
+          {t('scheduler.precondition.hint_missing_confirmations', {
+            minConfirmations: summary.options.minConfirmations,
+            amountOfMissingConfirmations: summary.numberOfMissingConfirmations,
+          })}
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <Alert variant="warning">
+      <AlertTriangleIcon />
+      <AlertDescription>
+        <RetryLockedUtxoList summary={summary} />
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/src/components/sweep/SweepScheduleProgress.tsx
+++ b/src/components/sweep/SweepScheduleProgress.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from 'react-i18next'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import { Spinner } from '../ui/spinner'
+import type { Schedule } from './scheduleUtils'
+import { toScheduleProgressSummary } from './scheduleUtils'
+
+interface SweepScheduleProgressProps {
+  schedule: Schedule
+  isStopping: boolean
+  onStop: () => Promise<void>
+}
+
+const SweepProgressBar = ({ schedule }: { schedule: Schedule }) => {
+  const progress = toScheduleProgressSummary(schedule)
+
+  return (
+    <div className="bg-muted flex h-3 w-full overflow-hidden rounded-full">
+      {progress.steps.map((step, index) => (
+        <div
+          key={index}
+          className={cn('border-r-background h-full border-r-[1px] transition-all last:border-r-0', {
+            'bg-primary/35': !step.isComplete && !step.isActive,
+            'bg-primary motion-safe:animate-pulse': step.isActive,
+            'bg-primary': step.isComplete,
+          })}
+          style={{ width: `${step.widthPercent}%` }}
+        />
+      ))}
+    </div>
+  )
+}
+
+export const SweepScheduleProgress = ({ schedule, isStopping, onStop }: SweepScheduleProgressProps) => {
+  const { t } = useTranslation()
+  const progress = toScheduleProgressSummary(schedule)
+  const totalHours = Math.ceil(progress.totalWaitSeconds / 60 / 60)
+  const totalSeconds = Math.ceil(progress.totalWaitSeconds)
+
+  return (
+    <Card>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          {totalHours <= 1 ? (
+            <p className="text-sm">
+              {t('scheduler.progress_tldr_seconds', { length: progress.totalTransactions, seconds: totalSeconds })}
+            </p>
+          ) : (
+            <p className="text-sm">
+              {t('scheduler.progress_tldr_hours', { length: progress.totalTransactions, hours: totalHours })}
+            </p>
+          )}
+          <p className="text-muted-foreground text-xs">{t('scheduler.progress_description')}</p>
+        </div>
+
+        <SweepProgressBar schedule={schedule} />
+
+        {progress.isDone ? (
+          <Alert variant="success">
+            <Spinner className="motion-reduce:hidden" />
+            <AlertTitle>{t('scheduler.progress_done')}</AlertTitle>
+          </Alert>
+        ) : (
+          <Alert>
+            <Spinner className="motion-reduce:hidden" />
+            <AlertTitle>
+              {t('scheduler.progress_current_state', {
+                current: progress.currentTransaction,
+                total: progress.totalTransactions,
+              })}
+            </AlertTitle>
+            <AlertDescription />
+          </Alert>
+        )}
+
+        <Button type="button" onClick={() => void onStop()} disabled={isStopping} size="lg" className="w-full">
+          {isStopping ? (
+            <>
+              <Spinner className="motion-reduce:hidden" />
+              {t('scheduler.button_stop')}
+            </>
+          ) : (
+            t('scheduler.button_stop')
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/sweep/SweepScheduleProgress.tsx
+++ b/src/components/sweep/SweepScheduleProgress.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -38,6 +38,10 @@ export const SweepScheduleProgress = ({ schedule, isStopping, onStop }: SweepSch
   const progress = toScheduleProgressSummary(schedule)
   const totalHours = Math.ceil(progress.totalWaitSeconds / 60 / 60)
   const totalSeconds = Math.ceil(progress.totalWaitSeconds)
+  const highlightedComponents = {
+    '1': <span className="font-semibold" />,
+    '3': <span className="font-semibold" />,
+  }
 
   return (
     <Card>
@@ -45,11 +49,19 @@ export const SweepScheduleProgress = ({ schedule, isStopping, onStop }: SweepSch
         <div className="space-y-1">
           {totalHours <= 1 ? (
             <p className="text-sm">
-              {t('scheduler.progress_tldr_seconds', { length: progress.totalTransactions, seconds: totalSeconds })}
+              <Trans
+                i18nKey="scheduler.progress_tldr_seconds"
+                values={{ length: progress.totalTransactions, seconds: totalSeconds }}
+                components={highlightedComponents}
+              />
             </p>
           ) : (
             <p className="text-sm">
-              {t('scheduler.progress_tldr_hours', { length: progress.totalTransactions, hours: totalHours })}
+              <Trans
+                i18nKey="scheduler.progress_tldr_hours"
+                values={{ length: progress.totalTransactions, hours: totalHours }}
+                components={highlightedComponents}
+              />
             </p>
           )}
           <p className="text-muted-foreground text-xs">{t('scheduler.progress_description')}</p>
@@ -66,10 +78,14 @@ export const SweepScheduleProgress = ({ schedule, isStopping, onStop }: SweepSch
           <Alert>
             <Spinner className="motion-reduce:hidden" />
             <AlertTitle>
-              {t('scheduler.progress_current_state', {
-                current: progress.currentTransaction,
-                total: progress.totalTransactions,
-              })}
+              <Trans
+                i18nKey="scheduler.progress_current_state"
+                values={{
+                  current: progress.currentTransaction,
+                  total: progress.totalTransactions,
+                }}
+                components={highlightedComponents}
+              />
             </AlertTitle>
             <AlertDescription />
           </Alert>

--- a/src/components/sweep/SweepStartConfirmDialog.tsx
+++ b/src/components/sweep/SweepStartConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Spinner } from '../ui/spinner'
+
+interface SweepStartConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => Promise<void>
+  disabled: boolean
+  isStarting: boolean
+}
+
+export const SweepStartConfirmDialog = ({
+  open,
+  onOpenChange,
+  onConfirm,
+  disabled,
+  isStarting,
+}: SweepStartConfirmDialogProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('scheduler.confirm_modal.title')}</DialogTitle>
+        </DialogHeader>
+        <p className="text-muted-foreground text-sm">{t('scheduler.confirm_modal.body')}</p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isStarting}>
+            {t('modal.confirm_button_reject')}
+          </Button>
+          <Button variant="default" onClick={() => void onConfirm()} disabled={disabled}>
+            {isStarting ? (
+              <>
+                <Spinner className="motion-reduce:hidden" />
+                {t('scheduler.button_start')}
+              </>
+            ) : (
+              t('modal.confirm_button_accept')
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/sweep/destinationValidation.test.ts
+++ b/src/components/sweep/destinationValidation.test.ts
@@ -1,0 +1,50 @@
+import type { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+import type { AddressSummary } from '@/context/JamWalletInfoContext'
+import { buildDestinationErrors } from './destinationValidation'
+
+const t = ((key: string) => key) as unknown as TFunction
+
+describe('buildDestinationErrors', () => {
+  it('reports invalid addresses', () => {
+    const errors = buildDestinationErrors(['invalid-address', '', 'also-invalid'], {} as AddressSummary, t)
+
+    expect(errors).toEqual([
+      'scheduler.feedback_invalid_destination_address',
+      'scheduler.feedback_invalid_destination_address',
+      'scheduler.feedback_invalid_destination_address',
+    ])
+  })
+
+  it('reports duplicate addresses', () => {
+    const validAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+    const errors = buildDestinationErrors([validAddress, validAddress, validAddress], {} as AddressSummary, t)
+
+    expect(errors).toEqual([
+      'scheduler.feedback_reused_destination_address',
+      'scheduler.feedback_reused_destination_address',
+      'scheduler.feedback_reused_destination_address',
+    ])
+  })
+
+  it('reports reused addresses from wallet history', () => {
+    const usedAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+    const freshAddress = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+    const addressSummary = {
+      [usedAddress]: {
+        used: true,
+      },
+      [freshAddress]: {
+        used: false,
+      },
+    } as unknown as AddressSummary
+
+    const errors = buildDestinationErrors([usedAddress, freshAddress, freshAddress + 'x'], addressSummary, t)
+
+    expect(errors).toEqual([
+      'scheduler.feedback_reused_destination_address',
+      undefined,
+      'scheduler.feedback_invalid_destination_address',
+    ])
+  })
+})

--- a/src/components/sweep/destinationValidation.ts
+++ b/src/components/sweep/destinationValidation.ts
@@ -1,0 +1,40 @@
+import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
+import type { TFunction } from 'i18next'
+import type { AddressSummary } from '@/context/JamWalletInfoContext'
+
+const normalizeAddress = (value: string): string => value.trim()
+
+export const buildDestinationErrors = (
+  addresses: string[],
+  addressSummary: AddressSummary,
+  t: TFunction,
+): Array<string | undefined> => {
+  const normalizedAddresses = addresses.map((address) => normalizeAddress(address))
+  const counts = normalizedAddresses.reduce((acc, address) => {
+    if (address === '') {
+      return acc
+    }
+
+    acc.set(address, (acc.get(address) ?? 0) + 1)
+    return acc
+  }, new Map<string, number>())
+
+  return normalizedAddresses.map((address) => {
+    if (address === '' || !isValidBitcoinAddress(address)) {
+      return t('scheduler.feedback_invalid_destination_address')
+    }
+
+    const isReusedAddress = addressSummary[address]?.used === true
+    const isDuplicateAddress = (counts.get(address) ?? 0) > 1
+
+    if (isReusedAddress || isDuplicateAddress) {
+      return t('scheduler.feedback_reused_destination_address')
+    }
+
+    return undefined
+  })
+}
+
+export const normalizeDestinationAddresses = (addresses: string[]): string[] => {
+  return addresses.map((address) => normalizeAddress(address))
+}

--- a/src/components/sweep/preconditions.test.ts
+++ b/src/components/sweep/preconditions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { Utxo } from '@/hooks/useQueryUtxos'
+import { buildSweepPreconditionSummary } from './preconditions'
+
+const utxo = (overrides: Partial<Utxo>): Utxo => {
+  return {
+    utxo: 'txid:0',
+    address: 'bc1qexampleaddress000000000000000000000000000',
+    path: "m/84'/0'/0'/0/0",
+    label: '',
+    value: 100_000,
+    tries: 0,
+    tries_remaining: 3,
+    external: false,
+    mixdepth: 0,
+    confirmations: 6,
+    frozen: false,
+    locktime: undefined,
+    ...overrides,
+  } as Utxo
+}
+
+describe('buildSweepPreconditionSummary', () => {
+  it('returns fulfilled when at least one eligible utxo is available', () => {
+    const summary = buildSweepPreconditionSummary([utxo({})])
+
+    expect(summary.isFulfilled).toBe(true)
+    expect(summary.numberOfMissingUtxos).toBe(0)
+    expect(summary.numberOfMissingConfirmations).toBe(0)
+    expect(summary.retryLockedUtxos).toHaveLength(0)
+  })
+
+  it('reports missing confirmations when all eligible utxos are too new', () => {
+    const summary = buildSweepPreconditionSummary([utxo({ confirmations: 2 })], { minConfirmations: 5 })
+
+    expect(summary.isFulfilled).toBe(false)
+    expect(summary.numberOfMissingUtxos).toBe(0)
+    expect(summary.numberOfMissingConfirmations).toBe(3)
+  })
+
+  it('reports retry-locked utxos when one jar has no retries left', () => {
+    const summary = buildSweepPreconditionSummary([
+      utxo({ utxo: 'a:0', mixdepth: 0, tries_remaining: 0 }),
+      utxo({ utxo: 'b:0', mixdepth: 0, tries_remaining: 0 }),
+      utxo({ utxo: 'c:0', mixdepth: 1, tries_remaining: 1 }),
+    ])
+
+    expect(summary.isFulfilled).toBe(false)
+    expect(summary.retryLockedUtxos.map((it) => it.utxo)).toEqual(['a:0', 'b:0'])
+  })
+
+  it('ignores frozen or timelocked utxos when counting eligibility', () => {
+    const summary = buildSweepPreconditionSummary([
+      utxo({ utxo: 'a:0', frozen: true }),
+      utxo({
+        utxo: 'b:0',
+        locktime: '2999-01-01 00:00:00',
+        path: "m/84'/0'/0'/0/0:32503680000",
+      }),
+    ])
+
+    expect(summary.isFulfilled).toBe(false)
+    expect(summary.numberOfMissingUtxos).toBe(1)
+    expect(summary.numberOfMissingConfirmations).toBe(0)
+  })
+})

--- a/src/components/sweep/preconditions.ts
+++ b/src/components/sweep/preconditions.ts
@@ -1,0 +1,85 @@
+import type { Utxo } from '@/hooks/useQueryUtxos'
+import * as fb from '@/lib/fidelityBondUtils'
+
+export interface SweepPreconditionOptions {
+  minNumberOfUtxos: number
+  minConfirmations: number
+}
+
+export interface SweepPreconditionSummary {
+  isFulfilled: boolean
+  options: SweepPreconditionOptions
+  numberOfMissingUtxos: number
+  numberOfMissingConfirmations: number
+  retryLockedUtxos: Utxo[]
+}
+
+const DEFAULT_OPTIONS: SweepPreconditionOptions = {
+  minNumberOfUtxos: 1,
+  minConfirmations: 5,
+}
+
+const isUtxoEligible = (utxo: Utxo): boolean => {
+  return !utxo.frozen && !fb.utxo.isLocked(utxo)
+}
+
+const groupByJarIndex = (utxos: Utxo[]): Map<number, Utxo[]> => {
+  return utxos.reduce((acc, utxo) => {
+    const key = utxo.mixdepth
+    const current = acc.get(key) ?? []
+    current.push(utxo)
+    acc.set(key, current)
+    return acc
+  }, new Map<number, Utxo[]>())
+}
+
+const toRetryLockedUtxos = (eligibleUtxos: Utxo[]): Utxo[] => {
+  const utxosByJar = groupByJarIndex(eligibleUtxos)
+  const blockedUtxos: Utxo[] = []
+
+  for (const jarUtxos of utxosByJar.values()) {
+    const hasAtLeastOneRetry = jarUtxos.some((utxo) => (utxo.tries_remaining ?? 0) > 0)
+    if (!hasAtLeastOneRetry) {
+      blockedUtxos.push(...jarUtxos.filter((utxo) => (utxo.tries_remaining ?? 0) <= 0))
+    }
+  }
+
+  return blockedUtxos
+}
+
+const toNumberOfMissingConfirmations = (utxos: Utxo[], minConfirmations: number): number => {
+  if (utxos.length === 0) {
+    return 0
+  }
+
+  const lowestConfirmations = utxos.reduce((acc, utxo) => {
+    return Math.min(acc, Math.max(0, utxo.confirmations))
+  }, Number.POSITIVE_INFINITY)
+
+  return Math.max(0, minConfirmations - lowestConfirmations)
+}
+
+export const buildSweepPreconditionSummary = (
+  utxos: Utxo[],
+  options: Partial<SweepPreconditionOptions> = {},
+): SweepPreconditionSummary => {
+  const mergedOptions: SweepPreconditionOptions = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  }
+
+  const eligibleUtxos = utxos.filter((utxo) => isUtxoEligible(utxo))
+  const numberOfMissingUtxos = Math.max(0, mergedOptions.minNumberOfUtxos - eligibleUtxos.length)
+  const numberOfMissingConfirmations =
+    numberOfMissingUtxos > 0 ? 0 : toNumberOfMissingConfirmations(eligibleUtxos, mergedOptions.minConfirmations)
+
+  const retryLockedUtxos = toRetryLockedUtxos(eligibleUtxos)
+
+  return {
+    isFulfilled: numberOfMissingUtxos === 0 && numberOfMissingConfirmations === 0 && retryLockedUtxos.length === 0,
+    options: mergedOptions,
+    numberOfMissingUtxos,
+    numberOfMissingConfirmations,
+    retryLockedUtxos,
+  }
+}

--- a/src/components/sweep/scheduleUtils.test.ts
+++ b/src/components/sweep/scheduleUtils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isScheduleLikelyCompletedSuccessfully,
+  isScheduleValue,
+  toScheduleProgressSummary,
+  type Schedule,
+} from './scheduleUtils'
+
+describe('scheduleUtils', () => {
+  it('identifies valid schedule values', () => {
+    expect(isScheduleValue([[0, 0, 8, 'INTERNAL', 10, 16, 0]])).toBe(true)
+    expect(isScheduleValue(undefined)).toBe(false)
+    expect(isScheduleValue([{}])).toBe(false)
+  })
+
+  it('creates progress summary from schedule entries', () => {
+    const schedule: Schedule = [
+      [0, 0, 8, 'INTERNAL', 10, 16, 1],
+      [1, 0, 8, 'INTERNAL', 5, 16, 0],
+      [2, 0, 8, 'bc1qdestination', 1, 16, 0],
+    ]
+
+    const summary = toScheduleProgressSummary(schedule)
+
+    expect(summary.totalTransactions).toBe(3)
+    expect(summary.completedTransactions).toBe(1)
+    expect(summary.currentTransaction).toBe(2)
+    expect(summary.isDone).toBe(false)
+    expect(summary.steps).toHaveLength(3)
+    expect(summary.steps[1].isActive).toBe(true)
+  })
+
+  it('falls back to frozen-utxo check when last schedule entry is stale', () => {
+    const schedule: Schedule = [
+      [0, 0, 8, 'INTERNAL', 10, 16, 1],
+      [1, 0, 8, 'bc1qdestination', 0, 16, 0],
+    ]
+
+    expect(isScheduleLikelyCompletedSuccessfully(schedule, false)).toBe(false)
+    expect(isScheduleLikelyCompletedSuccessfully(schedule, true)).toBe(true)
+  })
+})

--- a/src/components/sweep/scheduleUtils.ts
+++ b/src/components/sweep/scheduleUtils.ts
@@ -1,0 +1,115 @@
+export type ScheduleEntry = Array<string | number>
+export type Schedule = ScheduleEntry[]
+
+export interface ScheduleProgressStep {
+  widthPercent: number
+  isComplete: boolean
+  isActive: boolean
+  isFirst: boolean
+  isLast: boolean
+}
+
+export interface ScheduleProgressSummary {
+  totalWaitSeconds: number
+  totalTransactions: number
+  completedTransactions: number
+  currentTransaction: number
+  isDone: boolean
+  steps: ScheduleProgressStep[]
+}
+
+const MIN_STEP_WIDTH_PERCENT = 8
+
+const toNumberOrDefault = (value: unknown, fallback: number): number => {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+const getScheduleEntryWaitMinutes = (entry: ScheduleEntry): number => {
+  return Math.max(0, toNumberOrDefault(entry[4], 0))
+}
+
+const getScheduleEntryState = (entry: ScheduleEntry): string | number => {
+  return entry[6] ?? 0
+}
+
+const isScheduleEntryConfirmed = (entry: ScheduleEntry): boolean => {
+  return getScheduleEntryState(entry) === 1
+}
+
+export const isScheduleEntrySuccessful = (entry: ScheduleEntry): boolean => {
+  const state = getScheduleEntryState(entry)
+  return state === 1 || typeof state === 'string'
+}
+
+export const isScheduleValue = (value: unknown): value is Schedule => {
+  return Array.isArray(value) && value.every((entry) => Array.isArray(entry))
+}
+
+export const toScheduleProgressSummary = (schedule: Schedule): ScheduleProgressSummary => {
+  if (schedule.length === 0) {
+    return {
+      totalWaitSeconds: 0,
+      totalTransactions: 0,
+      completedTransactions: 0,
+      currentTransaction: 0,
+      isDone: true,
+      steps: [],
+    }
+  }
+
+  const completedTransactions = schedule.reduce((acc, entry) => {
+    return acc + (isScheduleEntryConfirmed(entry) ? 1 : 0)
+  }, 0)
+
+  const totalWaitSeconds = Math.max(
+    1,
+    schedule.slice(0, Math.max(0, schedule.length - 1)).reduce((acc, entry) => {
+      return acc + getScheduleEntryWaitMinutes(entry) * 60
+    }, 0),
+  )
+
+  const isDone = completedTransactions >= schedule.length
+
+  const steps: ScheduleProgressStep[] = schedule.map((_entry, index) => {
+    const widthPercent =
+      index === 0
+        ? MIN_STEP_WIDTH_PERCENT
+        : Math.max(
+            MIN_STEP_WIDTH_PERCENT,
+            ((Math.max(1, getScheduleEntryWaitMinutes(schedule[index - 1])) * 60) / totalWaitSeconds) * 100,
+          )
+
+    return {
+      widthPercent,
+      isComplete: completedTransactions > index,
+      isActive: !isDone && completedTransactions === index,
+      isFirst: index === 0,
+      isLast: index === schedule.length - 1,
+    }
+  })
+
+  return {
+    totalWaitSeconds,
+    totalTransactions: schedule.length,
+    completedTransactions: Math.min(completedTransactions, schedule.length),
+    currentTransaction: Math.min(completedTransactions + 1, schedule.length),
+    isDone,
+    steps,
+  }
+}
+
+export const isScheduleLikelyCompletedSuccessfully = (schedule: Schedule, allUtxosFrozen: boolean): boolean => {
+  if (schedule.length === 0) {
+    return false
+  }
+
+  const entriesBeforeLastSucceeded = schedule.slice(0, -1).every((entry) => isScheduleEntrySuccessful(entry))
+  const lastEntry = schedule.at(-1)
+  if (lastEntry === undefined) {
+    return false
+  }
+
+  const lastEntrySucceeded = isScheduleEntrySuccessful(lastEntry)
+
+  return entriesBeforeLastSucceeded && (lastEntrySucceeded || allUtxosFrozen)
+}


### PR DESCRIPTION
this PR makes the v2 Sweep page fully functional and splits logic into smaller components/helpers for easier maintenance and rollback.

what changed:

Implemented full Sweep flow in v2 (start, progress, stop)
Added sweep precondition handling (UTXO confirmations and retry-locked checks)
Added destination validations (invalid address + reused address checks)
Added dedicated Sweep UI components:
destination inputs
precondition alert
start confirmation dialog
schedule progress card
Added utility modules for schedule parsing, precondition evaluation, and destination normalization/validation
Improved error handling:
render backend/UX errors clearly
treat missing active schedule (404) as expected state (no noisy console error)
Fixed scheduler progress translation rendering (no raw <1>/<3> placeholders)

tests:

Added unit tests for:
schedule utils
preconditions
destination validation

fixes #1090 
@theborakompanioni @saurabhraghuvanshii 