### PR TITLE
chore(onboarding): move Tour action from footer to settings sidebar

### DIFF
--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -1,19 +1,11 @@
 import { useState, type ComponentProps } from 'react'
-import {
-  AlertTriangleIcon,
-  BlocksIcon,
-  BookOpenIcon,
-  FileQuestionMarkIcon,
-  ScrollTextIcon,
-  SparklesIcon,
-} from 'lucide-react'
+import { AlertTriangleIcon, BlocksIcon, BookOpenIcon, FileQuestionMarkIcon, ScrollTextIcon } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
 import { useStore } from 'zustand'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogFooter } from '@/components/ui/dialog'
 import { JmWebsocketInfo } from '@/components/ui/jam/JmWebsocketInfo'
-import { POST_LOGIN_TOUR_EVENT } from '@/constants/onboarding'
 import type { JmWebsocket } from '@/hooks/useJmWebsocket'
 import type { SemanticVersion } from '@/lib/utils'
 import { jmSessionStore } from '@/store/jmSessionStore'
@@ -92,15 +84,6 @@ export function AppFooter({
           </Trans>
         </div>
         <div className="flex flex-1 items-center justify-start gap-2 sm:justify-center" data-tour-id="footer-tools">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => window.dispatchEvent(new CustomEvent(POST_LOGIN_TOUR_EVENT))}
-            title="Tour"
-          >
-            <SparklesIcon />
-            <span className="hidden sm:inline-block">Tour</span>
-          </Button>
           <Button variant="outline" size="sm" onClick={onClickCheatsheet} title={t('footer.cheatsheet')}>
             <FileQuestionMarkIcon />
             <span className="hidden sm:inline-block">{t('footer.cheatsheet')}</span>

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
   PackageSearchIcon,
   ServerIcon,
   SettingsIcon,
+  SparklesIcon,
   TerminalIcon,
   UploadIcon,
   WalletIcon,
@@ -36,6 +37,7 @@ import {
 } from '@/components/ui/sidebar'
 import { useSidebar } from '@/components/ui/use-sidebar'
 import { isDebugFeatureEnabled, isDevMode } from '@/constants/debugFeatures'
+import { POST_LOGIN_TOUR_EVENT } from '@/constants/onboarding'
 import { routes } from '@/constants/routes'
 import { useFeatures } from '@/hooks/useFeatures'
 import { jamSettingsStore } from '@/store/jamSettingsStore'
@@ -92,6 +94,15 @@ export function AppSidebar({ side }: Pick<React.ComponentProps<typeof Sidebar>, 
   const settingsItems = useMemo(
     () => [
       {
+        title: /*TODO: i18n t('sidebar.item_tour.label')*/ 'Tour',
+        url: routes.home,
+        icon: SparklesIcon,
+        onClick: () => {
+          window.dispatchEvent(new CustomEvent(POST_LOGIN_TOUR_EVENT))
+          toggleSidebar()
+        },
+      },
+      {
         title: /*TODO: i18n t('sidebar.item_rescan.label')*/ t('settings.rescan_chain'),
         url: routes.rescan,
         icon: PackageSearchIcon,
@@ -106,7 +117,7 @@ export function AppSidebar({ side }: Pick<React.ComponentProps<typeof Sidebar>, 
             },
           ]),
     ],
-    [t, isFeatureEnabled],
+    [t, isFeatureEnabled, toggleSidebar],
   )
 
   const devItems = useMemo(
@@ -188,7 +199,7 @@ export function AppSidebar({ side }: Pick<React.ComponentProps<typeof Sidebar>, 
                   {settingsItems.map((item) => (
                     <SidebarMenuSubItem key={item.title}>
                       <SidebarMenuSubButton asChild title={item.title}>
-                        <Link to={item.url}>
+                        <Link to={item.url} onClick={item.onClick}>
                           <item.icon />
                           <span>{item.title}</span>
                         </Link>


### PR DESCRIPTION
follow-up from review discussion in #1081, where tbk asked to move tour access from footer into settings.
<img width="1440" height="900" alt="Screenshot 2026-02-17 at 1130 07 AM" src="https://github.com/user-attachments/assets/44b97c99-7438-4dca-8b34-63b8f69bb447" />


fixes #1094 
ping @theborakompanioni @saurabhraghuvanshii 
