### PR TITLE
fix(ui): use stable wallet keys in login and switch wallet lists

### DIFF
--- a/src/components/SwitchWalletPage.tsx
+++ b/src/components/SwitchWalletPage.tsx
@@ -151,9 +151,9 @@ const SwitchWalletPage = ({ walletFileName }: SwitchWalletPageProps) => {
                     </div>
                   ) : (
                     <div className="space-y-2">
-                      {wallets.map((wallet, index) => (
+                      {wallets.map((wallet) => (
                         <div
-                          key={index}
+                          key={wallet}
                           className={`rounded-lg border p-4 ${
                             wallet === walletFileName ? 'bg-primary/5 border-primary/20' : 'bg-muted/30'
                           }`}

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -113,8 +113,8 @@ export const LoginFormComponent = ({
               />
             </SelectTrigger>
             <SelectContent>
-              {wallets?.map((wallet, index) => (
-                <SelectItem key={index} value={wallet} className="text-base">
+              {wallets?.map((wallet) => (
+                <SelectItem key={wallet} value={wallet} className="text-base">
                   {shortenStringMiddle(walletDisplayName(wallet), 32)}
                   {activeWallet === wallet ? (
                     <span className="text-muted-foreground/50 inline-flex items-center gap-1.5 py-1 text-xs">


### PR DESCRIPTION
fixes #1104 

summary
replace index-based react keys with stable wallet-based keys in wallet list rendering.

why i thought doing this :
is becoz wallet order can change (for example when active wallet changes and list is re-sorted). index keys can cause stale row reuse and incorrect visual state.

ping @theborakompanioni @saurabhraghuvanshii 