### PR TITLE
Implement offline queue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import ErrorPage from '@/components/error/ErrorPage'
 import ImportWalletPage from '@/components/import/ImportWalletPage'
 import { Layout } from '@/components/layout/Layout'
 import LoginPage from '@/components/login/LoginPage'
+import { OfflineActionQueueWidget } from '@/components/offline/OfflineActionQueueWidget'
 import { OrderbookPage } from '@/components/orderbook/OrderbookPage'
 import { ReceivePage } from '@/components/receive/ReceivePage'
 import { SendPage } from '@/components/send/SendPage'
@@ -39,7 +40,9 @@ import { routes } from '@/constants/routes'
 import { JamDisplayContextProvider } from '@/context/JamDisplayContextProvider'
 import { JamWalletInfoContextProvider } from '@/context/JamWalletInfoContextProvider'
 import { useApiClient } from '@/hooks/useApiClient'
+import { useConnectivitySync } from '@/hooks/useConnectivitySync'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import { useOfflineActionQueueProcessor } from '@/hooks/useOfflineActionQueueProcessor'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
 import { queryClient } from '@/lib/queryClient'
 import { setIntervalDebounced, walletDisplayName, type WalletFileName } from '@/lib/utils'
@@ -228,8 +231,10 @@ function App() {
     <ThemeProvider defaultTheme="dark" enableSystem>
       <JamDisplayContextProvider>
         <QueryClientProvider client={queryClient}>
+          <SyncConnectivityState />
           <RefreshApiToken />
           <RefreshJmSession />
+          <ProcessOfflineActionQueue />
           <HandleJmWebsocketMessages />
           {walletFileName && <LoadFeeConfigData walletFileName={walletFileName} />}
           {lockWalletDialogContext && (
@@ -243,6 +248,7 @@ function App() {
             />
           )}
           <RouterProvider router={router} />
+          <OfflineActionQueueWidget />
           <Toaster closeButton />
         </QueryClientProvider>
       </JamDisplayContextProvider>
@@ -326,6 +332,18 @@ function RefreshJmSession() {
     enabled: true,
     refetchInterval: JAM_JM_SESSION_REFRESH_INTERVAL,
   })
+
+  return <></>
+}
+
+function SyncConnectivityState() {
+  useConnectivitySync()
+
+  return <></>
+}
+
+function ProcessOfflineActionQueue() {
+  useOfflineActionQueueProcessor()
 
   return <></>
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import { useConnectivitySync } from '@/hooks/useConnectivitySync'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { useOfflineActionQueueProcessor } from '@/hooks/useOfflineActionQueueProcessor'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
+import { isConnectivityError } from '@/lib/connectivity'
 import { queryClient } from '@/lib/queryClient'
 import { setIntervalDebounced, walletDisplayName, type WalletFileName } from '@/lib/utils'
 import { authStore } from '@/store/authStore'
@@ -294,11 +295,18 @@ function RefreshApiToken() {
         })
 
         if (!response.data) {
+          const reason = response.error?.message || response.error?.error_description || 'Unknown error.'
+          if (isConnectivityError(reason)) {
+            if (isDevMode) {
+              toast.warning(`[DEV] Token refresh skipped due to connectivity issue: ${reason}`)
+            }
+            return
+          }
+
           clearAuthAndQueryCache()
 
           if (isDevMode) {
-            const message = response.error?.message || response.error?.error_description || 'Unknown error.'
-            toast.error(`[DEV] Error while renewing auth token: ${message}`)
+            toast.error(`[DEV] Error while renewing auth token: ${reason}`)
           }
         } else {
           authStore.getState().update({

--- a/src/components/import/ImportWalletPage.tsx
+++ b/src/components/import/ImportWalletPage.tsx
@@ -21,6 +21,7 @@ import { MAX_WALLET_NAME_LENGTH } from '@/constants/jam'
 import { JM_DEFAULT_WALLET_TYPE, JM_WALLET_FILE_EXTENSION } from '@/constants/jm'
 import { routes } from '@/constants/routes'
 import { useApiClient } from '@/hooks/useApiClient'
+import { useExecuteOrQueueAction } from '@/hooks/useExecuteOrQueueAction'
 import { getErrorReason } from '@/lib/errorReason'
 import { hashPassword } from '@/lib/hash'
 import { withQueryDelay } from '@/lib/queryClient'
@@ -91,6 +92,7 @@ const ImportWalletPage = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const client = useApiClient()
+  const executeOrQueueAction = useExecuteOrQueueAction()
   const updateAuthState = useStore(authStore, (state) => state.update)
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
@@ -128,14 +130,34 @@ const ImportWalletPage = () => {
   const onSubmit: SubmitHandler<ImportWalletFormValues> = async (values) => {
     try {
       const walletFileName = walletDisplayNameToFileName(values.walletName)
-      const response = await recoverWallet.mutateAsync({
-        body: {
-          walletname: walletFileName,
-          password: values.password,
-          wallettype: JM_DEFAULT_WALLET_TYPE,
-          seedphrase: normalizeSeedPhrase(values.seedPhrase),
+      const request = {
+        walletname: walletFileName,
+        password: values.password,
+        wallettype: JM_DEFAULT_WALLET_TYPE,
+        seedphrase: normalizeSeedPhrase(values.seedPhrase),
+      }
+
+      const outcome = await executeOrQueueAction({
+        execute: async () =>
+          await recoverWallet.mutateAsync({
+            body: request,
+          }),
+        queueAction: {
+          type: 'import_wallet',
+          payload: { request },
+          meta: {
+            label: 'Import wallet',
+            summary: values.walletName,
+          },
         },
       })
+
+      if (outcome.status === 'queued') {
+        toast.info('Wallet import queued. It will retry automatically when your connection is restored.')
+        return
+      }
+
+      const response = outcome.data
 
       let hashedPassword: string | undefined
       try {

--- a/src/components/offline/OfflineActionQueueWidget.tsx
+++ b/src/components/offline/OfflineActionQueueWidget.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from 'react'
+import { AlertCircleIcon, CloudOffIcon, ListRestartIcon, RefreshCwIcon, Trash2Icon, WifiIcon } from 'lucide-react'
+import { toast } from 'sonner'
+import { useStore } from 'zustand'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn, shortenStringMiddle } from '@/lib/utils'
+import { selectConnectionUnavailable, connectivityStore } from '@/store/connectivityStore'
+import { getOfflineActionLabel, offlineActionQueueStore, type OfflineAction } from '@/store/offlineActionQueueStore'
+
+const actionStatusLabel: Record<OfflineAction['status'], string> = {
+  queued: 'Queued',
+  retrying: 'Retrying',
+  failed: 'Failed',
+}
+
+const actionStatusBadgeVariant = (status: OfflineAction['status']) => {
+  switch (status) {
+    case 'retrying':
+      return 'secondary' as const
+    case 'failed':
+      return 'destructive' as const
+    case 'queued':
+      return 'outline' as const
+    default:
+      return 'outline' as const
+  }
+}
+
+const formatDateTime = (timestamp: number) => {
+  return new Date(timestamp).toLocaleString()
+}
+
+interface OfflineActionRowProps {
+  action: OfflineAction
+  onRetry: (action: OfflineAction) => void
+  onCancel: (action: OfflineAction) => void
+}
+
+const OfflineActionRow = ({ action, onRetry, onCancel }: OfflineActionRowProps) => {
+  return (
+    <div className="space-y-3 rounded-lg border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{getOfflineActionLabel(action)}</p>
+          {action.meta?.summary && (
+            <p className="text-muted-foreground text-xs" title={action.meta.summary}>
+              {shortenStringMiddle(action.meta.summary, 88)}
+            </p>
+          )}
+        </div>
+        <Badge variant={actionStatusBadgeVariant(action.status)}>{actionStatusLabel[action.status]}</Badge>
+      </div>
+
+      <div className="text-muted-foreground flex flex-wrap gap-3 text-xs">
+        <span>Attempts: {action.attempts}</span>
+        <span>Created: {formatDateTime(action.createdAt)}</span>
+        {action.nextRetryAt && <span>Next retry: {formatDateTime(action.nextRetryAt)}</span>}
+      </div>
+
+      {action.lastError && (
+        <Alert variant="destructive" className="py-2">
+          <AlertCircleIcon />
+          <AlertDescription>{action.lastError}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onRetry(action)}
+          disabled={action.status === 'retrying'}
+          title="Retry this action now"
+        >
+          <ListRestartIcon />
+          Retry now
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => onCancel(action)} title="Cancel this queued action">
+          <Trash2Icon />
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export const OfflineActionQueueWidget = () => {
+  const [open, setOpen] = useState(false)
+
+  const actions = useStore(offlineActionQueueStore, (state) => state.actions)
+  const requestRetry = useStore(offlineActionQueueStore, (state) => state.requestRetry)
+  const removeAction = useStore(offlineActionQueueStore, (state) => state.remove)
+
+  const browserOnline = useStore(connectivityStore, (state) => state.browserOnline)
+  const connectionUnavailable = useStore(connectivityStore, selectConnectionUnavailable)
+
+  const sortedActions = useMemo(() => {
+    return actions.toSorted((a, b) => b.createdAt - a.createdAt)
+  }, [actions])
+
+  const retryingCount = useMemo(() => actions.filter((action) => action.status === 'retrying').length, [actions])
+  const failedCount = useMemo(() => actions.filter((action) => action.status === 'failed').length, [actions])
+  const queuedCount = useMemo(() => actions.filter((action) => action.status === 'queued').length, [actions])
+
+  const shouldShowWidget = connectionUnavailable || actions.length > 0
+
+  const handleRetry = (action: OfflineAction) => {
+    requestRetry(action.id)
+    toast.info(`${getOfflineActionLabel(action)} will retry shortly.`)
+  }
+
+  const handleCancel = (action: OfflineAction) => {
+    removeAction(action.id)
+    toast.info(`${getOfflineActionLabel(action)} was canceled.`)
+  }
+
+  if (!shouldShowWidget) {
+    return null
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={cn('fixed right-4 bottom-4 z-50 h-auto gap-2 px-3 py-2 shadow-lg', {
+          'light:bg-yellow-200 light:text-yellow-900 bg-yellow-700 text-white hover:bg-yellow-600':
+            connectionUnavailable,
+          'light:bg-red-200 light:text-red-900 bg-red-700 text-white hover:bg-red-600': failedCount > 0,
+        })}
+        variant={connectionUnavailable || failedCount > 0 ? 'default' : 'outline'}
+      >
+        {retryingCount > 0 ? <RefreshCwIcon className="motion-safe:animate-spin" /> : <CloudOffIcon />}
+        <span className="text-xs font-medium">Action queue</span>
+        <Badge variant="secondary" className="ml-1">
+          {actions.length}
+        </Badge>
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Offline action queue</DialogTitle>
+            <DialogDescription>
+              Retryable wallet operations are queued here when the app is offline or the API is unreachable.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            {connectionUnavailable ? (
+              <Alert variant="warning">
+                <CloudOffIcon />
+                <AlertTitle>{browserOnline ? 'API unreachable' : 'You are offline'}</AlertTitle>
+                <AlertDescription>
+                  Actions are queued and retried automatically with backoff until connectivity is restored.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <Alert variant="success">
+                <WifiIcon />
+                <AlertTitle>Connection healthy</AlertTitle>
+                <AlertDescription>
+                  {retryingCount > 0
+                    ? 'Queued actions are currently being retried.'
+                    : 'New actions run immediately while queued ones continue in the background.'}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
+              <span>Queued: {queuedCount}</span>
+              <span>Retrying: {retryingCount}</span>
+              <span>Failed: {failedCount}</span>
+            </div>
+
+            {sortedActions.length === 0 ? (
+              <div className="text-muted-foreground rounded-lg border p-4 text-sm">No queued actions.</div>
+            ) : (
+              <div className="space-y-3">
+                {sortedActions.map((action) => (
+                  <OfflineActionRow key={action.id} action={action} onRetry={handleRetry} onCancel={handleCancel} />
+                ))}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -15,6 +15,7 @@ import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from '@/components/ui/jam/PageTitle'
 import { useAddressSummary, useJars, useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
+import { useExecuteOrQueueAction, type ExecuteOrQueueResult } from '@/hooks/useExecuteOrQueueAction'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import type { UtxoId } from '@/hooks/useQueryUtxos'
 import { useWaitForUtxosToBeSpent } from '@/hooks/useWaitForUtxosToBeSpent'
@@ -46,6 +47,7 @@ interface SendPageProps {
 export const SendPage = ({ walletFileName }: SendPageProps) => {
   const { t } = useTranslation()
   const client = useApiClient()
+  const executeOrQueueAction = useExecuteOrQueueAction()
   const jmSession = useStore(jmSessionStore, (state) => state.state)
   const isDeveloperMode = useStore(jamSettingsStore, (state) => state.state.developerMode)
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
@@ -108,7 +110,12 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
 
   useWaitForUtxosToBeSpent(waitForUtxosToBeSpentContext)
 
-  const triggerNonCollarborativeTransaction = useMutation<DirectSendResult, ErrorMessage, SendFormValues, unknown>({
+  const triggerNonCollarborativeTransaction = useMutation<
+    ExecuteOrQueueResult<DirectSendResult>,
+    ErrorMessage,
+    SendFormValues,
+    unknown
+  >({
     mutationFn: async (data: SendFormValues) => {
       if (data.amount === undefined) {
         throw new Error('Cannot trigger non-collaborative transaction: Invalid amount given.')
@@ -128,19 +135,40 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
         destination: data.destination.address,
         mixdepth: data.source.fromJar,
       }
-      const response = await directSendMutation.mutateAsync({
-        path: {
-          walletname: encodeURIComponent(walletFileName),
-        },
-        body,
-      })
 
-      return {
-        request: body,
-        response,
-      }
+      return await executeOrQueueAction({
+        execute: async () => {
+          const response = await directSendMutation.mutateAsync({
+            path: {
+              walletname: encodeURIComponent(walletFileName),
+            },
+            body,
+          })
+
+          return {
+            request: body,
+            response,
+          }
+        },
+        queueAction: {
+          type: 'send',
+          payload: {
+            walletFileName,
+            request: body,
+          },
+          meta: {
+            label: 'Send transaction',
+            summary: `to ${data.destination.address}`,
+          },
+        },
+      })
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
+      if (result.status === 'queued') {
+        toast.info('Send action queued. It will retry automatically when your connection is restored.')
+        return
+      }
+
       /* TODO: i18n */
       toast.success('Successfully sent non-collaborative transaction.')
     },
@@ -156,7 +184,17 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     try {
       setPaymentSuccessfulInfoAlert(undefined)
       const result = await triggerNonCollarborativeTransaction.mutateAsync(data)
-      const tx = result.response.txinfo as Required<JmTxInfo>
+
+      if (result.status === 'queued') {
+        setPaymentSuccessfulInfoAlert({
+          variant: 'warning',
+          title: 'Payment queued',
+          description: 'The action was queued and will be sent automatically when your connection is restored.',
+        })
+        return
+      }
+
+      const tx = result.data.response.txinfo as Required<JmTxInfo>
 
       const output = tx.outputs.find((output) => output.address === data.destination.address)
       setPaymentSuccessfulInfoAlert({
@@ -169,12 +207,12 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
         }),
       })
 
-      const inputUtxoIds = (result.response.txinfo.inputs || []).flatMap((it) =>
+      const inputUtxoIds = (result.data.response.txinfo.inputs || []).flatMap((it) =>
         it?.outpoint !== undefined ? [it.outpoint as UtxoId] : [],
       )
       setWaitForUtxosToBeSpent(inputUtxoIds)
 
-      jmTxStore.getState().add(result.response.txinfo as JmTxInfo)
+      jmTxStore.getState().add(result.data.response.txinfo as JmTxInfo)
     } catch (error: unknown) {
       console.error('Error while sending non-collaborative transaction', error)
     }

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -20,6 +20,7 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { FEE_CONFIG_KEYS, type FeeConfigName } from '@/constants/jm'
 import { useApiClient } from '@/hooks/useApiClient'
+import { useExecuteOrQueueAction } from '@/hooks/useExecuteOrQueueAction'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { factorToPercentage } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
@@ -61,6 +62,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName }: FeeLimitD
   }, [open])
 
   const client = useApiClient()
+  const executeOrQueueAction = useExecuteOrQueueAction()
   const collaboratorFormRef = useRef<CollaboratorFeesFormRef>(null)
   const miningFormRef = useRef<MiningFeesFormRef>(null)
 
@@ -104,14 +106,36 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName }: FeeLimitD
         { key: 'max_sweep_fee_change', value: miningData.maxSweepFeeChange },
       ]
 
-      for (const { key, value } of configUpdates) {
-        await setconfigMutation.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
-          body: {
-            ...FEE_CONFIG_KEYS[key],
-            value,
+      const outcome = await executeOrQueueAction({
+        execute: async () => {
+          for (const { key, value } of configUpdates) {
+            await setconfigMutation.mutateAsync({
+              path: { walletname: encodeURIComponent(walletFileName) },
+              body: {
+                ...FEE_CONFIG_KEYS[key],
+                value,
+              },
+            })
+          }
+          return true
+        },
+        queueAction: {
+          type: 'update_fee_settings',
+          payload: {
+            walletFileName,
+            updates: configUpdates,
           },
-        })
+          meta: {
+            label: 'Update fee settings',
+            summary: `${configUpdates.length} value(s)`,
+          },
+        },
+      })
+
+      if (outcome.status === 'queued') {
+        toast.info('Fee settings update queued. It will retry automatically when your connection is restored.')
+        onOpenChange(false)
+        return
       }
 
       await refetchFeeConfigValues()

--- a/src/components/settings/RescanChainPage.tsx
+++ b/src/components/settings/RescanChainPage.tsx
@@ -16,6 +16,7 @@ import { Label } from '@/components/ui/label'
 import { routes } from '@/constants/routes'
 import { useRescanStatus, type RescanInfo } from '@/context/JamSessionInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
+import { useExecuteOrQueueAction, type ExecuteOrQueueResult } from '@/hooks/useExecuteOrQueueAction'
 import { getErrorReason } from '@/lib/errorReason'
 import { SEGWIT_ACTIVATION_BLOCK } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
@@ -105,21 +106,48 @@ export const RescanChainPage = ({ walletFileName }: RescanChainProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const client = useApiClient()
+  const executeOrQueueAction = useExecuteOrQueueAction()
   const { rescanInfo, setRescanInfo } = useRescanStatus()
 
-  const rescanMutation = useMutation({
+  const rescanMutation = useMutation<ExecuteOrQueueResult<unknown>, unknown, number>({
     mutationFn: async (blockHeight: number) => {
-      const { data } = await rescanblockchain({
-        client,
-        path: {
-          walletname: encodeURIComponent(walletFileName),
-          blockheight: blockHeight,
+      return await executeOrQueueAction({
+        execute: async () => {
+          const { data } = await rescanblockchain({
+            client,
+            path: {
+              walletname: encodeURIComponent(walletFileName),
+              blockheight: blockHeight,
+            },
+            throwOnError: true,
+          })
+
+          return data
         },
-        throwOnError: true,
+        queueAction: {
+          type: 'rescan_chain',
+          payload: {
+            walletFileName,
+            blockHeight,
+          },
+          meta: {
+            label: 'Rescan blockchain',
+            summary: `from block ${blockHeight}`,
+          },
+        },
       })
-      return data
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
+      if (result.status === 'queued') {
+        toast.info('Rescan action queued. It will retry automatically when your connection is restored.')
+        setRescanInfo({
+          updatedAt: Date.now(),
+          rescanning: false,
+          progress: undefined,
+        })
+        return
+      }
+
       toast.success(t('rescan_chain.success_rescan_started'))
       setRescanInfo({
         updatedAt: Date.now(),

--- a/src/hooks/useConnectivitySync.ts
+++ b/src/hooks/useConnectivitySync.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import { connectivityStore } from '@/store/connectivityStore'
+
+export const useConnectivitySync = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const setOnline = () => {
+      connectivityStore.getState().setBrowserOnline(true)
+      connectivityStore.getState().markApiReachable()
+    }
+
+    const setOffline = () => {
+      connectivityStore.getState().setBrowserOnline(false)
+    }
+
+    connectivityStore.getState().setBrowserOnline(window.navigator.onLine)
+
+    window.addEventListener('online', setOnline)
+    window.addEventListener('offline', setOffline)
+
+    return () => {
+      window.removeEventListener('online', setOnline)
+      window.removeEventListener('offline', setOffline)
+    }
+  }, [])
+}

--- a/src/hooks/useExecuteOrQueueAction.ts
+++ b/src/hooks/useExecuteOrQueueAction.ts
@@ -1,0 +1,58 @@
+import { useCallback } from 'react'
+import { useStore } from 'zustand'
+import { isConnectivityError } from '@/lib/connectivity'
+import { selectConnectionUnavailable, connectivityStore } from '@/store/connectivityStore'
+import type { EnqueueOfflineActionInput, OfflineAction } from '@/store/offlineActionQueueStore'
+import { offlineActionQueueStore } from '@/store/offlineActionQueueStore'
+
+export type ExecuteOrQueueResult<TData> =
+  | {
+      status: 'executed'
+      data: TData
+    }
+  | {
+      status: 'queued'
+      action: OfflineAction
+    }
+
+interface ExecuteOrQueueActionOptions<TData> {
+  execute: () => Promise<TData>
+  queueAction: EnqueueOfflineActionInput
+}
+
+export const useExecuteOrQueueAction = () => {
+  const connectionUnavailable = useStore(connectivityStore, selectConnectionUnavailable)
+  const enqueue = useStore(offlineActionQueueStore, (state) => state.enqueue)
+
+  return useCallback(
+    async <TData>({
+      execute,
+      queueAction,
+    }: ExecuteOrQueueActionOptions<TData>): Promise<ExecuteOrQueueResult<TData>> => {
+      if (connectionUnavailable) {
+        return {
+          status: 'queued',
+          action: enqueue(queueAction),
+        }
+      }
+
+      try {
+        const data = await execute()
+        return {
+          status: 'executed',
+          data,
+        }
+      } catch (error) {
+        if (!isConnectivityError(error)) {
+          throw error
+        }
+
+        return {
+          status: 'queued',
+          action: enqueue(queueAction),
+        }
+      }
+    },
+    [connectionUnavailable, enqueue],
+  )
+}

--- a/src/hooks/useOfflineActionQueueProcessor.ts
+++ b/src/hooks/useOfflineActionQueueProcessor.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { useStore } from 'zustand'
+import { useApiClient } from '@/hooks/useApiClient'
+import { calculateOfflineRetryDelay, isConnectivityError } from '@/lib/connectivity'
+import { getErrorReason } from '@/lib/errorReason'
+import { executeOfflineAction } from '@/lib/offlineActionExecutor'
+import { connectivityStore } from '@/store/connectivityStore'
+import { getOfflineActionLabel, offlineActionQueueStore, type OfflineAction } from '@/store/offlineActionQueueStore'
+
+const PROCESSOR_INTERVAL = 1_000
+
+const getNextActionToProcess = (actions: OfflineAction[], now: number): OfflineAction | undefined => {
+  return actions
+    .filter((action) => action.status === 'queued' && (action.nextRetryAt === undefined || action.nextRetryAt <= now))
+    .toSorted((a, b) => {
+      const aWhen = a.nextRetryAt ?? a.createdAt
+      const bWhen = b.nextRetryAt ?? b.createdAt
+      return aWhen - bWhen
+    })[0]
+}
+
+export const useOfflineActionQueueProcessor = () => {
+  const client = useApiClient()
+  const browserOnline = useStore(connectivityStore, (state) => state.browserOnline)
+  const processingActionIdRef = useRef<OfflineAction['id'] | undefined>(undefined)
+
+  useEffect(() => {
+    offlineActionQueueStore.getState().resetRetryingActions()
+  }, [])
+
+  const processNextAction = useCallback(async () => {
+    if (!browserOnline || processingActionIdRef.current !== undefined) {
+      return
+    }
+
+    const now = Date.now()
+    const stateSnapshot = offlineActionQueueStore.getState()
+    const nextAction = getNextActionToProcess(stateSnapshot.actions, now)
+
+    if (!nextAction) {
+      return
+    }
+
+    processingActionIdRef.current = nextAction.id
+    stateSnapshot.markRetrying(nextAction.id)
+
+    try {
+      await executeOfflineAction(client, nextAction)
+      offlineActionQueueStore.getState().remove(nextAction.id)
+
+      toast.success(`${getOfflineActionLabel(nextAction)} completed.`)
+    } catch (error) {
+      const attempts = nextAction.attempts + 1
+      const reason = getErrorReason(error, 'Unknown reason.')
+
+      if (isConnectivityError(error)) {
+        const retryDelay = calculateOfflineRetryDelay(attempts)
+        const nextRetryAt = Date.now() + retryDelay
+
+        offlineActionQueueStore.getState().markQueued(nextAction.id, {
+          attempts,
+          nextRetryAt,
+          error: reason,
+        })
+      } else {
+        offlineActionQueueStore.getState().markFailed(nextAction.id, {
+          attempts,
+          error: reason,
+        })
+
+        toast.error(`${getOfflineActionLabel(nextAction)} failed: ${reason}`)
+      }
+    } finally {
+      processingActionIdRef.current = undefined
+    }
+  }, [browserOnline, client])
+
+  useEffect(() => {
+    void processNextAction()
+
+    const timerId = setInterval(() => {
+      void processNextAction()
+    }, PROCESSOR_INTERVAL)
+
+    return () => {
+      clearInterval(timerId)
+    }
+  }, [processNextAction])
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,8 +2,10 @@ import { createClient } from '@joinmarket-webui/joinmarket-api-ts'
 import type { Client } from '@joinmarket-webui/joinmarket-api-ts/client'
 import type { ClientOptions, UnlockWalletResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { isDevMode } from '@/constants/debugFeatures'
+import { isConnectivityError } from '@/lib/connectivity'
 import { normalizeAppError } from '@/lib/errorReason'
 import { authStore } from '@/store/authStore'
+import { connectivityStore } from '@/store/connectivityStore'
 
 type ApiToken = UnlockWalletResponse['token']
 
@@ -21,7 +23,18 @@ function loggingResponseInterceptor(response: Response) {
 }
 
 function normalizeErrorInterceptor(error: unknown) {
-  return normalizeAppError(error)
+  const normalized = normalizeAppError(error)
+  if (isConnectivityError(normalized)) {
+    connectivityStore.getState().markApiUnreachable()
+  } else {
+    connectivityStore.getState().markApiReachable()
+  }
+  return normalized
+}
+
+function markApiReachableInterceptor(response: Response) {
+  connectivityStore.getState().markApiReachable()
+  return response
 }
 
 const createJamAuthenticationMiddleware = () => {
@@ -45,6 +58,7 @@ export const createApiClient = (): Client => {
 
   const jamAuthMiddleware = createJamAuthenticationMiddleware()
   client.interceptors.request.use(jamAuthMiddleware)
+  client.interceptors.response.use(markApiReachableInterceptor)
   client.interceptors.error.use(normalizeErrorInterceptor)
 
   if (isDevMode()) {

--- a/src/lib/connectivity.test.ts
+++ b/src/lib/connectivity.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { calculateOfflineRetryDelay, isConnectivityError } from './connectivity'
+
+const setNavigatorOnline = (value: boolean) => {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value,
+  })
+}
+
+afterEach(() => {
+  setNavigatorOnline(true)
+})
+
+describe('isConnectivityError', () => {
+  it('returns true when browser is offline', () => {
+    setNavigatorOnline(false)
+    expect(isConnectivityError(new Error('Any error message'))).toBe(true)
+  })
+
+  it('detects common network/unreachable error messages', () => {
+    expect(isConnectivityError(new Error('Failed to fetch'))).toBe(true)
+    expect(isConnectivityError({ message: 'Network request failed' })).toBe(true)
+    expect(isConnectivityError({ message: 'ECONNREFUSED' })).toBe(true)
+  })
+
+  it('returns false for non-connectivity errors', () => {
+    expect(isConnectivityError({ message: 'Request failed with status 400' })).toBe(false)
+  })
+})
+
+describe('calculateOfflineRetryDelay', () => {
+  it('uses exponential backoff with a max cap', () => {
+    expect(calculateOfflineRetryDelay(1)).toBe(2_000)
+    expect(calculateOfflineRetryDelay(2)).toBe(4_000)
+    expect(calculateOfflineRetryDelay(3)).toBe(8_000)
+    expect(calculateOfflineRetryDelay(10)).toBe(60_000)
+  })
+})

--- a/src/lib/connectivity.ts
+++ b/src/lib/connectivity.ts
@@ -1,0 +1,40 @@
+import { normalizeAppError } from '@/lib/errorReason'
+import type { Milliseconds } from '@/types/global'
+
+const CONNECTIVITY_ERROR_PATTERNS = [
+  /failed to fetch/i,
+  /fetch failed/i,
+  /network ?error/i,
+  /network request failed/i,
+  /internet connection appears to be offline/i,
+  /load failed/i,
+  /err_network/i,
+  /econnrefused/i,
+  /connection refused/i,
+  /connection reset/i,
+  /timed out/i,
+]
+
+export const isConnectivityError = (error: unknown): boolean => {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true
+  }
+
+  const normalized = normalizeAppError(error)
+  const combinedMessage = [normalized.message, normalized.error_description].filter(Boolean).join(' ').toLowerCase()
+
+  if (!combinedMessage) {
+    return false
+  }
+
+  return CONNECTIVITY_ERROR_PATTERNS.some((pattern) => pattern.test(combinedMessage))
+}
+
+const RETRY_DELAY_BASE: Milliseconds = 2_000
+const RETRY_DELAY_MAX: Milliseconds = 60_000
+
+export const calculateOfflineRetryDelay = (attemptNumber: number): Milliseconds => {
+  const safeAttemptNumber = Math.max(1, attemptNumber)
+  const exponentialDelay = RETRY_DELAY_BASE * 2 ** (safeAttemptNumber - 1)
+  return Math.min(RETRY_DELAY_MAX, exponentialDelay)
+}

--- a/src/lib/offlineActionExecutor.ts
+++ b/src/lib/offlineActionExecutor.ts
@@ -1,0 +1,89 @@
+import type { Client } from '@joinmarket-webui/joinmarket-api-ts/client'
+import { configsetting, directsend, recoverwallet, rescanblockchain } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { FEE_CONFIG_KEYS } from '@/constants/jm'
+import { hashPassword } from '@/lib/hash'
+import type { WalletFileName } from '@/lib/utils'
+import { authStore } from '@/store/authStore'
+import { jmTxStore, type JmTxInfo } from '@/store/jmTxStore'
+import type { OfflineAction } from '@/store/offlineActionQueueStore'
+
+export const executeOfflineAction = async (client: Client, action: OfflineAction): Promise<void> => {
+  switch (action.type) {
+    case 'send': {
+      const { data } = await directsend({
+        client,
+        throwOnError: true,
+        path: {
+          walletname: encodeURIComponent(action.payload.walletFileName),
+        },
+        body: action.payload.request,
+      })
+
+      const txInfo = data?.txinfo as JmTxInfo | undefined
+      if (txInfo?.txid !== undefined) {
+        jmTxStore.getState().add(txInfo)
+      }
+
+      return
+    }
+    case 'import_wallet': {
+      const { data } = await recoverwallet({
+        client,
+        throwOnError: true,
+        body: action.payload.request,
+      })
+
+      if (!data) {
+        throw new Error('Wallet import returned no data.')
+      }
+
+      let hashedPassword: string | undefined
+      try {
+        hashedPassword = await hashPassword(action.payload.request.password, data.walletname as WalletFileName)
+      } catch (error) {
+        console.warn('Failed to hash password after queued wallet import.', error)
+      }
+
+      authStore.getState().update({
+        walletFileName: data.walletname as WalletFileName,
+        auth: {
+          token: data.token,
+          refresh_token: data.refresh_token,
+        },
+        hashed_password: hashedPassword,
+      })
+      return
+    }
+    case 'rescan_chain': {
+      await rescanblockchain({
+        client,
+        throwOnError: true,
+        path: {
+          walletname: encodeURIComponent(action.payload.walletFileName),
+          blockheight: action.payload.blockHeight,
+        },
+      })
+      return
+    }
+    case 'update_fee_settings': {
+      for (const update of action.payload.updates) {
+        await configsetting({
+          client,
+          throwOnError: true,
+          path: {
+            walletname: encodeURIComponent(action.payload.walletFileName),
+          },
+          body: {
+            ...FEE_CONFIG_KEYS[update.key],
+            value: update.value,
+          },
+        })
+      }
+      return
+    }
+    default: {
+      const exhaustiveTypeCheck: never = action
+      throw new Error(`Unsupported offline action: ${JSON.stringify(exhaustiveTypeCheck)}`)
+    }
+  }
+}

--- a/src/store/connectivityStore.ts
+++ b/src/store/connectivityStore.ts
@@ -1,0 +1,50 @@
+import { createStore } from 'zustand'
+
+interface ConnectivityStoreState {
+  browserOnline: boolean
+  apiReachable: boolean
+  updatedAt: number
+  setBrowserOnline: (online: boolean) => void
+  markApiReachable: () => void
+  markApiUnreachable: () => void
+}
+
+const getInitialBrowserOnline = () => {
+  if (typeof navigator === 'undefined') {
+    return true
+  }
+
+  return navigator.onLine
+}
+
+export const connectivityStore = createStore<ConnectivityStoreState>()((set, get) => ({
+  browserOnline: getInitialBrowserOnline(),
+  apiReachable: true,
+  updatedAt: Date.now(),
+  setBrowserOnline: (online) => {
+    const previous = get().browserOnline
+
+    if (online === previous) {
+      return
+    }
+
+    set(() => ({ browserOnline: online, updatedAt: Date.now() }))
+  },
+  markApiReachable: () => {
+    if (get().apiReachable) {
+      return
+    }
+
+    set(() => ({ apiReachable: true, updatedAt: Date.now() }))
+  },
+  markApiUnreachable: () => {
+    if (!get().apiReachable) {
+      return
+    }
+
+    set(() => ({ apiReachable: false, updatedAt: Date.now() }))
+  },
+}))
+
+export const selectConnectionUnavailable = (state: ConnectivityStoreState) =>
+  !state.browserOnline || !state.apiReachable

--- a/src/store/offlineActionQueueStore.ts
+++ b/src/store/offlineActionQueueStore.ts
@@ -1,0 +1,208 @@
+import type { DirectSendRequest, RecoverWalletRequest } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { createStore } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import type { FeeConfigName } from '@/constants/jm'
+import type { WalletFileName } from '@/lib/utils'
+
+export type OfflineActionType = 'send' | 'import_wallet' | 'rescan_chain' | 'update_fee_settings'
+export type OfflineActionStatus = 'queued' | 'retrying' | 'failed'
+
+interface OfflineActionMeta {
+  label?: string
+  summary?: string
+}
+
+interface OfflineActionBase<Type extends OfflineActionType, Payload> {
+  id: string
+  type: Type
+  payload: Payload
+  status: OfflineActionStatus
+  attempts: number
+  nextRetryAt?: number
+  lastError?: string
+  createdAt: number
+  updatedAt: number
+  meta?: OfflineActionMeta
+}
+
+export type OfflineSendActionPayload = {
+  walletFileName: WalletFileName
+  request: Pick<DirectSendRequest, 'amount_sats' | 'destination' | 'mixdepth'>
+}
+
+export type OfflineImportWalletActionPayload = {
+  request: RecoverWalletRequest
+}
+
+export type OfflineRescanChainActionPayload = {
+  walletFileName: WalletFileName
+  blockHeight: number
+}
+
+export type OfflineFeeSettingsActionPayload = {
+  walletFileName: WalletFileName
+  updates: Array<{ key: FeeConfigName; value: string }>
+}
+
+export type OfflineSendAction = OfflineActionBase<'send', OfflineSendActionPayload>
+export type OfflineImportWalletAction = OfflineActionBase<'import_wallet', OfflineImportWalletActionPayload>
+export type OfflineRescanChainAction = OfflineActionBase<'rescan_chain', OfflineRescanChainActionPayload>
+export type OfflineFeeSettingsAction = OfflineActionBase<'update_fee_settings', OfflineFeeSettingsActionPayload>
+
+export type OfflineAction =
+  | OfflineSendAction
+  | OfflineImportWalletAction
+  | OfflineRescanChainAction
+  | OfflineFeeSettingsAction
+
+export type EnqueueOfflineActionInput =
+  | Pick<OfflineSendAction, 'type' | 'payload' | 'meta'>
+  | Pick<OfflineImportWalletAction, 'type' | 'payload' | 'meta'>
+  | Pick<OfflineRescanChainAction, 'type' | 'payload' | 'meta'>
+  | Pick<OfflineFeeSettingsAction, 'type' | 'payload' | 'meta'>
+
+interface OfflineActionQueueStoreState {
+  actions: OfflineAction[]
+  enqueue: (input: EnqueueOfflineActionInput) => OfflineAction
+  remove: (id: OfflineAction['id']) => void
+  markRetrying: (id: OfflineAction['id']) => void
+  markQueued: (id: OfflineAction['id'], details?: { attempts?: number; nextRetryAt?: number; error?: string }) => void
+  markFailed: (id: OfflineAction['id'], details?: { attempts?: number; error?: string }) => void
+  requestRetry: (id: OfflineAction['id']) => void
+  resetRetryingActions: () => void
+  clear: () => void
+}
+
+const createOfflineActionId = (): OfflineAction['id'] => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+const updateAction = (
+  actions: OfflineAction[],
+  id: OfflineAction['id'],
+  updateFn: (current: OfflineAction) => OfflineAction,
+): OfflineAction[] => {
+  return actions.map((action) => {
+    if (action.id !== id) {
+      return action
+    }
+
+    return updateFn(action)
+  })
+}
+
+const initialActions: OfflineAction[] = []
+
+export const offlineActionQueueStore = createStore<OfflineActionQueueStoreState>()(
+  persist(
+    (set) => ({
+      actions: initialActions,
+      enqueue: (input) => {
+        const now = Date.now()
+        const action: OfflineAction = {
+          ...input,
+          id: createOfflineActionId(),
+          status: 'queued',
+          attempts: 0,
+          createdAt: now,
+          updatedAt: now,
+          nextRetryAt: undefined,
+          lastError: undefined,
+        }
+
+        set((state) => ({ actions: [...state.actions, action] }))
+        return action
+      },
+      remove: (id) => {
+        set((state) => ({ actions: state.actions.filter((action) => action.id !== id) }))
+      },
+      markRetrying: (id) => {
+        set((state) => ({
+          actions: updateAction(state.actions, id, (current) => ({
+            ...current,
+            status: 'retrying',
+            updatedAt: Date.now(),
+          })),
+        }))
+      },
+      markQueued: (id, details) => {
+        set((state) => ({
+          actions: updateAction(state.actions, id, (current) => ({
+            ...current,
+            status: 'queued',
+            attempts: details?.attempts ?? current.attempts,
+            nextRetryAt: details?.nextRetryAt,
+            lastError: details?.error,
+            updatedAt: Date.now(),
+          })),
+        }))
+      },
+      markFailed: (id, details) => {
+        set((state) => ({
+          actions: updateAction(state.actions, id, (current) => ({
+            ...current,
+            status: 'failed',
+            attempts: details?.attempts ?? current.attempts,
+            lastError: details?.error,
+            nextRetryAt: undefined,
+            updatedAt: Date.now(),
+          })),
+        }))
+      },
+      requestRetry: (id) => {
+        set((state) => ({
+          actions: updateAction(state.actions, id, (current) => ({
+            ...current,
+            status: 'queued',
+            nextRetryAt: undefined,
+            lastError: undefined,
+            updatedAt: Date.now(),
+          })),
+        }))
+      },
+      resetRetryingActions: () => {
+        set((state) => ({
+          actions: state.actions.map((action) => {
+            if (action.status !== 'retrying') {
+              return action
+            }
+
+            return {
+              ...action,
+              status: 'queued',
+              updatedAt: Date.now(),
+            }
+          }),
+        }))
+      },
+      clear: () => set({ actions: initialActions }),
+    }),
+    {
+      name: 'jam-offline-action-queue-store',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+)
+
+export const getOfflineActionLabel = (action: Pick<OfflineAction, 'type' | 'meta'>): string => {
+  if (action.meta?.label) {
+    return action.meta.label
+  }
+
+  switch (action.type) {
+    case 'send':
+      return 'Send transaction'
+    case 'import_wallet':
+      return 'Import wallet'
+    case 'rescan_chain':
+      return 'Rescan blockchain'
+    case 'update_fee_settings':
+      return 'Update fee settings'
+    default:
+      return 'Wallet action'
+  }
+}


### PR DESCRIPTION
this pr adds an offline action queue for v2 wallet actions so user operations are not lost when network/api connectivity drops.


what i have changed
added centralized connectivity detection (browser offline + api unreachable)
added persisted offline queue with action payload + metadata + status
added background retry processor with exponential backoff
integrated queue flow for:
  send
  import wallet
  rescan chain
  fee settings updates
added global queue ui showing queued/retrying/failed states
added manual controls: retry now and cancel
fixed token refresh behavior so offline refresh failures do not force logout

@theborakompanioni please give me your feedback : 
does this queue scope look right for v2 (send/import/rescan/fee updates)?
is local persistence policy acceptable for queued actions in this release?
is the offline token-refresh behavior (no forced logout on connectivity failures) acceptable from product/security perspective?
I have sent you one video regarding this on element please go through it also.


fixes #1113 

