### PR TITLE
fix(onboarding): follow up for #1081 (splash links + onboarding story separation)

### DIFF
--- a/src/components/login/LoginCard.tsx
+++ b/src/components/login/LoginCard.tsx
@@ -21,6 +21,7 @@ type LoginCardProps = Omit<LoginFormProps, 'loading' | 'onSubmit'> &
     listWalletsLoading: boolean
     listWalletsError?: ErrorMessage
     onReloadClick: () => Promise<void>
+    enableOnboardingDialog?: boolean
   }
 
 const ONBOARDING_DISMISSED_STORAGE_KEY = 'jam:v2:onboarding:dismissed'
@@ -49,6 +50,7 @@ export const LoginCard = ({
   listWalletsFetching,
   listWalletsError,
   onReloadClick,
+  enableOnboardingDialog = true,
 }: LoginCardProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -94,9 +96,11 @@ export const LoginCard = ({
           ) : wallets && wallets.length > 0 ? (
             <CardDescription>{/*TODO: i18n */}Select a wallet and enter your password to continue.</CardDescription>
           ) : undefined}
-          <Button variant="link" size="sm" className="h-auto px-0" onClick={() => setShowOnboarding(true)}>
-            {t('onboarding.splashscreen_button_get_started')}
-          </Button>
+          {enableOnboardingDialog ? (
+            <Button variant="link" size="sm" className="h-auto px-0" onClick={() => setShowOnboarding(true)}>
+              {t('onboarding.splashscreen_button_get_started')}
+            </Button>
+          ) : null}
         </CardHeader>
 
         <CardContent className="space-y-6">
@@ -162,7 +166,7 @@ export const LoginCard = ({
         </CardContent>
       </Card>
 
-      <OnboardingDialog open={showOnboarding} onOpenChange={onOnboardingOpenChange} />
+      {enableOnboardingDialog ? <OnboardingDialog open={showOnboarding} onOpenChange={onOnboardingOpenChange} /> : null}
     </>
   )
 }

--- a/src/components/login/OnboardingDialog.tsx
+++ b/src/components/login/OnboardingDialog.tsx
@@ -106,27 +106,30 @@ export const OnboardingDialog = ({ open, onOpenChange }: OnboardingDialogProps) 
               <div className="space-y-2 rounded-lg border p-4">
                 <Badge variant="destructive">{t('onboarding.splashscreen_warning_title')}</Badge>
                 <p className="text-muted-foreground text-sm leading-relaxed">
-                  <Trans i18nKey="onboarding.splashscreen_warning_text">
-                    While JoinMarket is tried and tested, Jam is not. It is beta software, so please{' '}
-                    <a
-                      href="https://github.com/joinmarket-webui/jam/issues"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary underline underline-offset-4"
-                    >
-                      help to improve the project on GitHub
-                    </a>{' '}
-                    and{' '}
-                    <a
-                      href="https://jamdocs.org"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary underline underline-offset-4"
-                    >
-                      read the documentation
-                    </a>
-                    .
-                  </Trans>
+                  <Trans
+                    i18nKey="onboarding.splashscreen_warning_text"
+                    components={[
+                      <span key="unused-placeholder" />,
+                      <a
+                        key="github-link"
+                        href="https://github.com/joinmarket-webui/jam/issues"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline underline-offset-4"
+                      >
+                        help to improve the project on GitHub
+                      </a>,
+                      <a
+                        key="docs-link"
+                        href="https://jamdocs.org"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline underline-offset-4"
+                      >
+                        read the documentation
+                      </a>,
+                    ]}
+                  />
                 </p>
               </div>
             </div>

--- a/src/stories/jam/pages/login/LoginCard.stories.tsx
+++ b/src/stories/jam/pages/login/LoginCard.stories.tsx
@@ -6,6 +6,13 @@ const meta: Meta<typeof LoginCard> = {
   title: 'Page/Login/LoginCard',
   component: LoginCard,
   tags: ['autodocs'],
+  args: {
+    isSubmitting: false,
+    listWalletsFetching: false,
+    listWalletsLoading: false,
+    enableOnboardingDialog: false,
+    onReloadClick: async () => alert('Reload clicked!'),
+  },
 }
 export default meta
 
@@ -24,7 +31,6 @@ export const Default: Story = {
     activeWallet: undefined,
     makerRunning: false,
     coinjoinInProgress: false,
-    disabled: false,
     onSubmit: async () => alert('Submit clicked!'),
   },
   argTypes: {
@@ -41,7 +47,6 @@ export const Empty: Story = {
     activeWallet: undefined,
     makerRunning: false,
     coinjoinInProgress: false,
-    disabled: false,
     onSubmit: async () => alert('Submit clicked!'),
   },
 }
@@ -64,6 +69,5 @@ export const Error: Story = {
       message: 'Wallet loading failed.',
       error_description: '500 Server Error',
     },
-    onReloadClick: async () => alert('Reload clicked!'),
   },
 }

--- a/src/stories/jam/pages/login/OnboardingDialog.stories.tsx
+++ b/src/stories/jam/pages/login/OnboardingDialog.stories.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { OnboardingDialog } from '@/components/login/OnboardingDialog'
+import { Button } from '@/components/ui/button'
+
+const meta: Meta<typeof OnboardingDialog> = {
+  title: 'Page/Login/OnboardingDialog',
+  component: OnboardingDialog,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof OnboardingDialog>
+
+const OnboardingDialogDemo = () => {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <div className="space-y-4">
+      <Button onClick={() => setOpen(true)}>Open onboarding dialog</Button>
+      <OnboardingDialog open={open} onOpenChange={setOpen} />
+    </div>
+  )
+}
+
+export const Default: Story = {
+  render: () => <OnboardingDialogDemo />,
+}


### PR DESCRIPTION
follow-up pr for onboarding review comments from #1081.

what i changed
fixed splash warning text link rendering on login onboarding dialog
removed broken/trailing text issue in warning copy
separated onboarding dialog story from logincard docs flow in storybook so they are not mixed

fixes #1096
ping @theborakompanioni @saurabhraghuvanshii 