### PR TITLE
fix(sweep): return null on 404 schedule query

### DIFF
--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -101,7 +101,7 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
 
       if (result.error !== undefined) {
         if (result.response.status === 404) {
-          return undefined
+          return null
         }
         throw new Error(toErrorReason(result.error, 'Failed to load schedule'))
       }


### PR DESCRIPTION
follow-up after #1093.

fixes #1118
what changed
updated sweep schedule query in `src/components/sweep/SweepPage.tsx`:
  on `404` from `getschedule`, return `null` instead of `undefined`.

ping @theborakompanioni @saurabhraghuvanshii 