### PR TITLE
Wallet load error alert refactor

### DIFF
--- a/src/components/SwitchWalletPage.tsx
+++ b/src/components/SwitchWalletPage.tsx
@@ -1,14 +1,13 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { listwalletsOptions, lockwalletOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
-import type { ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useQuery } from '@tanstack/react-query'
-import { AlertCircleIcon, LockIcon, RefreshCwIcon, UnlockIcon, WalletIcon } from 'lucide-react'
+import { LockIcon, RefreshCwIcon, UnlockIcon, WalletIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { WalletLoadErrorAlert } from '@/components/ui/jam/WalletLoadErrorAlert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { routes } from '@/constants/routes'
 import { useApiClient } from '@/hooks/useApiClient'
@@ -75,14 +74,6 @@ const SwitchWalletPage = ({ walletFileName }: SwitchWalletPageProps) => {
     retry: false,
   })
 
-  const listWalletsErrorAlert: ErrorMessage | undefined = useMemo(() => {
-    if (!listWalletsError) return undefined
-    return {
-      message: t('wallets.error_loading_failed'),
-      error_description: listWalletsError.message || t('global.errors.reason_unknown'),
-    }
-  }, [listWalletsError, t])
-
   const wallets = sortWallets((listWalletsData?.wallets || []) as WalletFileName[], walletFileName)
 
   const handleLockCurrentWallet = async () => {
@@ -128,13 +119,9 @@ const SwitchWalletPage = ({ walletFileName }: SwitchWalletPageProps) => {
           </CardContent>
         ) : (
           <>
-            {listWalletsErrorAlert ? (
+            {listWalletsError ? (
               <CardContent className="space-y-6">
-                <Alert variant="destructive">
-                  <AlertCircleIcon className="h-4 w-4" />
-                  <AlertTitle>{listWalletsErrorAlert.message}</AlertTitle>
-                  <AlertDescription>{listWalletsErrorAlert.error_description}</AlertDescription>
-                </Alert>
+                <WalletLoadErrorAlert reason={listWalletsError.message} iconClassName="h-4 w-4" />
                 <Button variant="ghost" size="sm" onClick={() => void listWalletsRefetch()}>
                   <RefreshCwIcon className="h-4 w-4" /> {t('global.retry')}
                 </Button>

--- a/src/components/import/ImportWalletPage.tsx
+++ b/src/components/import/ImportWalletPage.tsx
@@ -10,12 +10,13 @@ import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import * as yup from 'yup'
 import { useStore } from 'zustand'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Field, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
+import { WalletLoadErrorAlert } from '@/components/ui/jam/WalletLoadErrorAlert'
 import { Spinner } from '@/components/ui/spinner'
 import { Textarea } from '@/components/ui/textarea'
 import { isDebugFeatureEnabled } from '@/constants/debugFeatures'
@@ -197,13 +198,7 @@ const ImportWalletPage = () => {
         </CardHeader>
 
         <CardContent className="space-y-6">
-          {walletsError && (
-            <Alert variant="destructive">
-              <AlertCircleIcon />
-              <AlertTitle>{t('wallets.error_loading_failed')}</AlertTitle>
-              <AlertDescription>{walletsError.message || t('global.errors.reason_unknown')}</AlertDescription>
-            </Alert>
-          )}
+          {walletsError && <WalletLoadErrorAlert reason={walletsError.message} />}
 
           {hasActiveWalletSession ? (
             <Alert variant="warning">

--- a/src/components/login/LoginCard.tsx
+++ b/src/components/login/LoginCard.tsx
@@ -1,11 +1,11 @@
 import { useState, type ComponentProps } from 'react'
 import type { ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
-import { AlertCircleIcon, RefreshCwIcon, WalletIcon } from 'lucide-react'
+import { RefreshCwIcon, WalletIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { WalletLoadErrorAlert } from '@/components/ui/jam/WalletLoadErrorAlert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Spinner } from '@/components/ui/spinner'
 import { routes } from '@/constants/routes'
@@ -106,11 +106,7 @@ export const LoginCard = ({
         <CardContent className="space-y-6">
           {listWalletsError ? (
             <>
-              <Alert variant="destructive">
-                <AlertCircleIcon />
-                <AlertTitle>{t('wallets.error_loading_failed')}</AlertTitle>
-                <AlertDescription>{listWalletsError.message || t('global.errors.reason_unknown')}</AlertDescription>
-              </Alert>
+              <WalletLoadErrorAlert reason={listWalletsError.message} />
               <Button variant="ghost" size="sm" onClick={() => void onReloadClick()} disabled={listWalletsFetching}>
                 <RefreshCwIcon className={cn({ 'motion-safe:animate-spin': listWalletsFetching })} />
                 {t('global.retry')}

--- a/src/components/ui/jam/WalletLoadErrorAlert.tsx
+++ b/src/components/ui/jam/WalletLoadErrorAlert.tsx
@@ -1,0 +1,20 @@
+import { AlertCircleIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+
+interface WalletLoadErrorAlertProps {
+  reason?: string
+  iconClassName?: string
+}
+
+export const WalletLoadErrorAlert = ({ reason, iconClassName }: WalletLoadErrorAlertProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Alert variant="destructive">
+      <AlertCircleIcon className={iconClassName} />
+      <AlertTitle>{t('wallets.error_loading_failed')}</AlertTitle>
+      <AlertDescription>{reason || t('global.errors.reason_unknown')}</AlertDescription>
+    </Alert>
+  )
+}


### PR DESCRIPTION
closes #1133 
refactor repeated wallet-list load failure alerts into a shared WalletLoadErrorAlert component and reuse it in LoginCard, ImportWalletPage, and SwitchWalletPage. This keeps UX/messages consistent and removes duplicated alert markup without changing behavior.

ping @theborakompanioni @saurabhraghuvanshii 

