### PR TITLE
test(hash): make hashpassword test timeout stable

### DIFF
--- a/src/lib/hash.test.ts
+++ b/src/lib/hash.test.ts
@@ -6,7 +6,7 @@ describe('hash', () => {
     expect(DEFAULT_PBKDF_ITERATIONS).toBe(210_000)
   })
 
-  it('hashPassword', async () => {
+  it('hashPassword', { timeout: 20_000 }, async () => {
     expect(await hashPassword('', '', 1)).toBe('6d2ecbbbfb2e6dcd7056faf9af6aa06eae594391db983279a6bf27e0eb228614')
     expect(await hashPassword('password', 'salt', 1)).toBe(
       '867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252',


### PR DESCRIPTION
closes #1138 

this fixes flaky pre-push/test failures caused by [hash.test.ts](app://-/index.html#) timing out at the default 5000ms on slower environments.
ping @saurabhraghuvanshii @theborakompanioni 