### PR TITLE
fix(dev): reduce background refresh toast noise

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,11 +267,6 @@ function RefreshApiToken() {
   useEffect(() => {
     if (!hasRefreshToken) return
 
-    const isDevMode = jamSettingsStore.getState().state.developerMode
-    if (isDevMode) {
-      toast.info(`[DEV] setup refresh interval`)
-    }
-
     let intervalId: NodeJS.Timeout
     setIntervalDebounced(
       async () => {
@@ -292,7 +287,9 @@ function RefreshApiToken() {
 
           if (isDevMode) {
             const message = response.error?.message || response.error?.error_description || 'Unknown error.'
-            toast.error(`[DEV] Error while renewing auth token: ${message}`)
+            toast.error(`[DEV] Error while renewing auth token: ${message}`, {
+              id: 'token-renew-error',
+            })
           }
         } else {
           authStore.getState().update({
@@ -301,12 +298,6 @@ function RefreshApiToken() {
               refresh_token: response.data.refresh_token,
             },
           })
-
-          if (isDevMode) {
-            toast.info(`[DEV] Successfully renewed auth token.`, {
-              id: 'token-renew-success',
-            })
-          }
         }
       },
       JAM_API_AUTH_TOKEN_RENEW_INTERVAL,

--- a/src/hooks/useRefreshSession.ts
+++ b/src/hooks/useRefreshSession.ts
@@ -48,13 +48,6 @@ export function useRefreshSession({
   useEffect(() => {
     if (sessionData) {
       jmSessionStore.getState().update(sessionData)
-
-      const isDevMode = jamSettingsStore.getState().state.developerMode
-      if (isDevMode) {
-        toast.info(`[DEV] Successfully refreshed session data.`, {
-          id: 'jm-session-refresh-success',
-        })
-      }
     }
   }, [sessionData])
 
@@ -63,7 +56,9 @@ export function useRefreshSession({
       refetchSessionData().catch(() => {
         const isDevMode = jamSettingsStore.getState().state.developerMode
         if (isDevMode) {
-          toast.error(`[DEV] Error while refreshing session data.`)
+          toast.error(`[DEV] Error while refreshing session data.`, {
+            id: 'jm-session-refresh-error',
+          })
         }
       })
     },


### PR DESCRIPTION
closes #1140 
follow-up cleanup for dev mode notification noise.

removed periodic success toasts from background token/session refresh paths.
kept error feedback in dev mode and deduped error toasts by id so repeated failures do not flood the ui.

ping @theborakompanioni @saurabhraghuvanshii 