### PR TITLE
fix(logs): handle native/standalone logs correctly and improve logs ui

### DIFF
--- a/src/components/LogsContent.tsx
+++ b/src/components/LogsContent.tsx
@@ -1,7 +1,6 @@
 import { AlertTriangleIcon, Loader2Icon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { LogViewer } from '@/components/logging/LogViewer'
-import type { LogViewerVariant } from '@/components/logging/LogViewer'
 import { useJmwalletdStdoutLog } from '@/components/logging/useJmwalletdStdoutLog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { cn } from '@/lib/utils'
@@ -9,12 +8,13 @@ import { cn } from '@/lib/utils'
 interface LogsContentProps {
   className?: string
   enabled: boolean
-  viewerVariant?: LogViewerVariant
 }
 
-export const LogsContent = ({ enabled, className, viewerVariant = 'fill' }: LogsContentProps) => {
+export const LogsContent = ({ enabled, className }: LogsContentProps) => {
   const { t } = useTranslation()
   const { alert, isInitialized, logFileContent, refresh, fileName } = useJmwalletdStdoutLog({ enabled })
+  const hasRealLogContent = Boolean(logFileContent)
+  const fallbackViewerText = t('logs.error_not_supported')
 
   if (!isInitialized) {
     return (
@@ -26,25 +26,20 @@ export const LogsContent = ({ enabled, className, viewerVariant = 'fill' }: Logs
   }
 
   return (
-    <div
-      className={cn(
-        'flex flex-col gap-3',
-        {
-          'min-h-0 flex-1': viewerVariant === 'fill',
-        },
-        className,
-      )}
-    >
+    <div className={cn('flex flex-col gap-3', className)}>
       {alert && (
         <Alert variant={alert.variant}>
           <AlertTriangleIcon />
-          <AlertDescription>{alert.message}</AlertDescription>
+          <AlertDescription className="whitespace-pre-line">{alert.message}</AlertDescription>
         </Alert>
       )}
 
-      {logFileContent && (
-        <LogViewer variant={viewerVariant} fileName={fileName} value={logFileContent} refresh={refresh} />
-      )}
+      <LogViewer
+        fileName={fileName}
+        value={logFileContent || fallbackViewerText}
+        refresh={refresh}
+        showActions={hasRealLogContent}
+      />
     </div>
   )
 }

--- a/src/components/LogsOverlay.tsx
+++ b/src/components/LogsOverlay.tsx
@@ -19,7 +19,7 @@ export function LogsOverlay({ open, onOpenChange }: LogsOverlayProps) {
         </DialogHeader>
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          <LogsContent enabled={open} className="flex h-full flex-1 flex-col" viewerVariant="fill" />
+          <LogsContent enabled={open} className="flex h-full flex-1 flex-col" />
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/LogsPage.tsx
+++ b/src/components/LogsPage.tsx
@@ -8,7 +8,7 @@ export const LogsPage = () => {
   return (
     <div className="mx-auto flex h-full min-h-0 flex-col gap-3 p-4">
       <PageTitle title={t('logs.title')} />
-      <LogsContent enabled={true} className="min-h-0 flex-1" viewerVariant="page" />
+      <LogsContent enabled={true} className="min-h-0 flex-1" />
     </div>
   )
 }

--- a/src/components/logging/LogViewer.tsx
+++ b/src/components/logging/LogViewer.tsx
@@ -6,16 +6,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { cn, delayedPromise } from '@/lib/utils'
 
-export type LogViewerVariant = 'page' | 'fill'
-
 interface LogViewerProps {
   fileName: string
   value: string
   refresh: () => Promise<void>
-  variant?: LogViewerVariant
+  /** When false, hides search, download and refresh actions (e.g. when showing fallback text) */
+  showActions?: boolean
 }
 
-export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogViewerProps) {
+export function LogViewer({ fileName, value, refresh, showActions = true }: LogViewerProps) {
   const { t } = useTranslation()
   const logContentRef = useRef<HTMLPreElement>(null)
   const [isLoadingRefresh, setIsLoadingRefresh] = useState(false)
@@ -33,8 +32,6 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
     if (normalizedSearchValue.length === 0) return 0
     return filteredLines.length
   }, [filteredLines.length, normalizedSearchValue])
-
-  const isFill = variant === 'fill'
 
   const scrollToLogBottom = () => {
     logContentRef.current?.scrollTo({
@@ -136,88 +133,76 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
   )
 
   return (
-    <Card
-      className={cn('pb-0', {
-        'flex flex-1 flex-col overflow-hidden': isFill,
-      })}
-    >
+    <Card className="flex flex-1 flex-col overflow-hidden pb-0">
       <CardHeader className="flex flex-col justify-center gap-2 sm:flex-row sm:items-center sm:justify-between">
         <CardTitle className="font-mono break-all select-all">{fileName}</CardTitle>
-        <div className="flex items-center justify-end gap-2">
-          <div className="relative max-w-[360px] min-w-[220px] flex-1">
-            <SearchIcon className="text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2" />
-            <Input
-              value={searchValue}
-              onChange={(event) => setSearchValue(event.target.value)}
-              className="h-9 pr-8 pl-8 text-xs"
-              placeholder="Search logs..."
-              aria-label="Search logs"
-            />
-            {searchValue.length > 0 && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
-                onClick={() => setSearchValue('')}
-                title={t('global.clear')}
-              >
-                <XIcon className="h-4 w-4" />
-              </Button>
-            )}
+        {showActions && (
+          <div className="flex items-center justify-end gap-2">
+            <div className="relative max-w-[360px] min-w-[220px] flex-1">
+              <SearchIcon className="text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2" />
+              <Input
+                value={searchValue}
+                onChange={(event) => setSearchValue(event.target.value)}
+                className="h-9 pr-8 pl-8 text-xs"
+                placeholder="Search logs..."
+                aria-label="Search logs"
+              />
+              {searchValue.length > 0 && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
+                  onClick={() => setSearchValue('')}
+                  title={t('global.clear')}
+                >
+                  <XIcon className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setSearchValue('')}
+              disabled={searchValue.length === 0}
+              title={t('global.clear')}
+            >
+              {t('global.clear')}
+            </Button>
+            <Button
+              className="hover:[&>svg]:motion-safe:animate-bounce"
+              variant="outline"
+              onClick={handleDownload}
+              disabled={!value || isLoadingRefresh}
+              title={t('global.download')}
+            >
+              <DownloadIcon className="group/download" />
+              {t('global.download')}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => void handleRefresh()}
+              disabled={isLoadingRefresh}
+              title={t('global.refresh')}
+            >
+              <RefreshCwIcon className={cn({ 'animate-spin': isLoadingRefresh })} />
+              {t('global.refresh')}
+            </Button>
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setSearchValue('')}
-            disabled={searchValue.length === 0}
-            title={t('global.clear')}
-          >
-            {t('global.clear')}
-          </Button>
-          <Button
-            className="hover:[&>svg]:motion-safe:animate-bounce"
-            variant="outline"
-            onClick={handleDownload}
-            disabled={!value || isLoadingRefresh}
-            title={t('global.download')}
-          >
-            <DownloadIcon className="group/download" />
-            {t('global.download')}
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => void handleRefresh()}
-            disabled={isLoadingRefresh}
-            title={t('global.refresh')}
-          >
-            <RefreshCwIcon className={cn({ 'animate-spin': isLoadingRefresh })} />
-            {t('global.refresh')}
-          </Button>
-        </div>
+        )}
       </CardHeader>
-      {normalizedSearchValue.length > 0 && (
+      {showActions && normalizedSearchValue.length > 0 && (
         <div className="text-muted-foreground px-6 pb-2 text-xs">
           {matchingLineCount === 0
             ? `No matches for "${searchValue}".`
             : `${matchingLineCount} matching line${matchingLineCount > 1 ? 's' : ''}.`}
         </div>
       )}
-      <CardContent
-        className={cn('relative rounded-b-xl p-0', {
-          'flex-1 overflow-hidden': isFill,
-        })}
-      >
+      <CardContent className="relative flex-1 overflow-hidden rounded-b-xl p-0">
         <pre
           onScroll={logScrollHandler}
           ref={logContentRef}
-          className={cn(
-            'bg-muted/90 overflow-auto rounded-b-xl px-2 py-2 font-mono text-sm break-words whitespace-pre-wrap',
-            {
-              'max-h-[600px] min-h-[300px]': !isFill,
-              'absolute inset-0': isFill,
-            },
-          )}
+          className="bg-muted/90 absolute inset-0 overflow-auto rounded-b-xl px-2 py-2 font-mono text-sm break-words whitespace-pre-wrap"
         >
           {filteredLines.length === 0 && normalizedSearchValue.length > 0
             ? ''

--- a/src/components/logging/useJmwalletdStdoutLog.ts
+++ b/src/components/logging/useJmwalletdStdoutLog.ts
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useStore } from 'zustand'
 import { Alert } from '@/components/ui/alert'
-import { isDevMode } from '@/constants/debugFeatures'
 import { fetchLog } from '@/lib/api/logs'
 import { authStore } from '@/store/authStore'
 
@@ -41,7 +40,7 @@ export function useJmwalletdStdoutLog({ enabled = true }: UseJmwalletdStdoutLogP
         token,
         fileName: JMWALLETD_LOG_FILE_NAME,
         signal,
-      }).then((response) => (response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`))))
+      }).then((response) => response.text())
     },
   })
 
@@ -77,11 +76,12 @@ export function useJmwalletdStdoutLog({ enabled = true }: UseJmwalletdStdoutLogP
     return logQuery.isFetched
   }, [enabled, logQuery.isFetched, token])
 
+  // No synthetic fallback — the previous repeat(1_000) generated fake log lines
+  // that resembled real output, making the dev experience misleading.
   const logFileContent = useMemo(() => {
     if (logQuery.data) return logQuery.data
-    if (!isDevMode() || alert?.variant !== 'warning') return undefined
-    return `${alert.message}\nRun Jam in standalone mode: npm run dev:secondary.`
-  }, [alert, logQuery.data])
+    return undefined
+  }, [logQuery.data])
 
   const refresh = useCallback(async () => {
     if (token === undefined) return


### PR DESCRIPTION
summary
fixes logs behavior across native and standalone modes and cleans up logs ux.

changes
add robust log endpoint handling with fallback (`/api/v0/log` -> `/jam/api/v0/log`)
detect html fallback responses and treat them as unsupported logs endpoint
show a clean unsupported warning in native mode (no duplicated message in alert + log body)
split logs viewer layout for page vs overlay so log panel sizing works correctly
improve unsupported message formatting for better readability




https://github.com/user-attachments/assets/46bf770f-0552-4026-92d6-2fb5af33d444






ping @theborakompanioni @saurabhraghuvanshii 