### PR TITLE
feat(logs): improve logs viewer ux with search highlight and smoother refresh

### DIFF
--- a/src/components/LogsContent.tsx
+++ b/src/components/LogsContent.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangleIcon, Loader2Icon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { LogViewer } from '@/components/logging/LogViewer'
+import type { LogViewerVariant } from '@/components/logging/LogViewer'
 import { useJmwalletdStdoutLog } from '@/components/logging/useJmwalletdStdoutLog'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { cn } from '@/lib/utils'
@@ -8,9 +9,10 @@ import { cn } from '@/lib/utils'
 interface LogsContentProps {
   className?: string
   enabled: boolean
+  viewerVariant?: LogViewerVariant
 }
 
-export const LogsContent = ({ enabled, className }: LogsContentProps) => {
+export const LogsContent = ({ enabled, className, viewerVariant = 'fill' }: LogsContentProps) => {
   const { t } = useTranslation()
   const { alert, isInitialized, logFileContent, refresh, fileName } = useJmwalletdStdoutLog({ enabled })
 
@@ -24,7 +26,15 @@ export const LogsContent = ({ enabled, className }: LogsContentProps) => {
   }
 
   return (
-    <div className={cn('flex flex-col gap-3', className)}>
+    <div
+      className={cn(
+        'flex flex-col gap-3',
+        {
+          'min-h-0 flex-1': viewerVariant === 'fill',
+        },
+        className,
+      )}
+    >
       {alert && (
         <Alert variant={alert.variant}>
           <AlertTriangleIcon />
@@ -32,7 +42,9 @@ export const LogsContent = ({ enabled, className }: LogsContentProps) => {
         </Alert>
       )}
 
-      {logFileContent && <LogViewer variant="fill" fileName={fileName} value={logFileContent} refresh={refresh} />}
+      {logFileContent && (
+        <LogViewer variant={viewerVariant} fileName={fileName} value={logFileContent} refresh={refresh} />
+      )}
     </div>
   )
 }

--- a/src/components/LogsOverlay.tsx
+++ b/src/components/LogsOverlay.tsx
@@ -18,8 +18,8 @@ export function LogsOverlay({ open, onOpenChange }: LogsOverlayProps) {
           </DialogTitle>
         </DialogHeader>
 
-        <div className="overflow-hidden">
-          <LogsContent enabled={open} className="flex h-full flex-col" />
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <LogsContent enabled={open} className="flex h-full flex-1 flex-col" viewerVariant="fill" />
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/LogsPage.tsx
+++ b/src/components/LogsPage.tsx
@@ -6,9 +6,9 @@ export const LogsPage = () => {
   const { t } = useTranslation()
 
   return (
-    <div className="mx-auto space-y-3 p-4">
+    <div className="mx-auto flex h-full min-h-0 flex-col gap-3 p-4">
       <PageTitle title={t('logs.title')} />
-      <LogsContent enabled={true} />
+      <LogsContent enabled={true} className="min-h-0 flex-1" viewerVariant="page" />
     </div>
   )
 }

--- a/src/components/logging/LogViewer.tsx
+++ b/src/components/logging/LogViewer.tsx
@@ -1,11 +1,12 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
-import { RefreshCwIcon, DownloadIcon, ArrowDownIcon } from 'lucide-react'
+import { useState, useCallback, useEffect, useRef, useMemo, type ReactNode } from 'react'
+import { RefreshCwIcon, DownloadIcon, ArrowDownIcon, SearchIcon, XIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { cn, delayedPromise } from '@/lib/utils'
 
-type LogViewerVariant = 'page' | 'fill'
+export type LogViewerVariant = 'page' | 'fill'
 
 interface LogViewerProps {
   fileName: string
@@ -18,8 +19,20 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
   const { t } = useTranslation()
   const logContentRef = useRef<HTMLPreElement>(null)
   const [isLoadingRefresh, setIsLoadingRefresh] = useState(false)
+  const [searchValue, setSearchValue] = useState('')
   const [logScrollProgress, setLogScrollProgress] = useState(0)
+  const [hasAutoScrolledInitially, setHasAutoScrolledInitially] = useState(false)
   const isScrolledToLogBottom = useMemo(() => logScrollProgress >= 0.995, [logScrollProgress])
+  const normalizedSearchValue = useMemo(() => searchValue.trim().toLowerCase(), [searchValue])
+  const allLines = useMemo(() => value.split('\n'), [value])
+  const filteredLines = useMemo(() => {
+    if (normalizedSearchValue.length === 0) return allLines
+    return allLines.filter((line) => line.toLowerCase().includes(normalizedSearchValue))
+  }, [allLines, normalizedSearchValue])
+  const matchingLineCount = useMemo(() => {
+    if (normalizedSearchValue.length === 0) return 0
+    return filteredLines.length
+  }, [filteredLines.length, normalizedSearchValue])
 
   const isFill = variant === 'fill'
 
@@ -36,13 +49,28 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
     const scrollHeight = event.currentTarget.scrollHeight
 
     const scrollTop = event.currentTarget.scrollTop
+    if (scrollHeight <= 0) {
+      setLogScrollProgress(1)
+      return
+    }
     setLogScrollProgress((scrollTop + containerHeight) / scrollHeight)
   }
 
   useEffect(() => {
-    if (!value) return
-    scrollToLogBottom()
-  }, [value])
+    if (filteredLines.length === 0) return
+    if (normalizedSearchValue.length > 0) {
+      logContentRef.current?.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      })
+      setLogScrollProgress(0)
+      return
+    }
+    if (!hasAutoScrolledInitially || isScrolledToLogBottom) {
+      scrollToLogBottom()
+      if (!hasAutoScrolledInitially) setHasAutoScrolledInitially(true)
+    }
+  }, [filteredLines.length, hasAutoScrolledInitially, isScrolledToLogBottom, normalizedSearchValue])
 
   const handleRefresh = useCallback(async () => {
     if (isLoadingRefresh) return
@@ -70,6 +98,43 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
     }, 0)
   }, [fileName, value])
 
+  const renderHighlightedLine = useCallback(
+    (line: string): ReactNode => {
+      if (normalizedSearchValue.length === 0) return line
+      const lineLower = line.toLowerCase()
+      const queryLength = normalizedSearchValue.length
+
+      const fragments: ReactNode[] = []
+      let cursor = 0
+      let nextMatchIndex = lineLower.indexOf(normalizedSearchValue, cursor)
+      while (nextMatchIndex >= 0) {
+        if (nextMatchIndex > cursor) {
+          fragments.push(line.slice(cursor, nextMatchIndex))
+        }
+
+        const nextCursor = nextMatchIndex + queryLength
+        fragments.push(
+          <mark
+            key={`${line}-${nextMatchIndex}`}
+            className="light:bg-yellow-400/80 rounded bg-yellow-500/40 px-0.5 text-current"
+          >
+            {line.slice(nextMatchIndex, nextCursor)}
+          </mark>,
+        )
+
+        cursor = nextCursor
+        nextMatchIndex = lineLower.indexOf(normalizedSearchValue, cursor)
+      }
+
+      if (cursor < line.length) {
+        fragments.push(line.slice(cursor))
+      }
+
+      return fragments
+    },
+    [normalizedSearchValue],
+  )
+
   return (
     <Card
       className={cn('pb-0', {
@@ -79,6 +144,37 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
       <CardHeader className="flex flex-col justify-center gap-2 sm:flex-row sm:items-center sm:justify-between">
         <CardTitle className="font-mono break-all select-all">{fileName}</CardTitle>
         <div className="flex items-center justify-end gap-2">
+          <div className="relative max-w-[360px] min-w-[220px] flex-1">
+            <SearchIcon className="text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2" />
+            <Input
+              value={searchValue}
+              onChange={(event) => setSearchValue(event.target.value)}
+              className="h-9 pr-8 pl-8 text-xs"
+              placeholder="Search logs..."
+              aria-label="Search logs"
+            />
+            {searchValue.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
+                onClick={() => setSearchValue('')}
+                title={t('global.clear')}
+              >
+                <XIcon className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setSearchValue('')}
+            disabled={searchValue.length === 0}
+            title={t('global.clear')}
+          >
+            {t('global.clear')}
+          </Button>
           <Button
             className="hover:[&>svg]:motion-safe:animate-bounce"
             variant="outline"
@@ -100,6 +196,13 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
           </Button>
         </div>
       </CardHeader>
+      {normalizedSearchValue.length > 0 && (
+        <div className="text-muted-foreground px-6 pb-2 text-xs">
+          {matchingLineCount === 0
+            ? `No matches for "${searchValue}".`
+            : `${matchingLineCount} matching line${matchingLineCount > 1 ? 's' : ''}.`}
+        </div>
+      )}
       <CardContent
         className={cn('relative rounded-b-xl p-0', {
           'flex-1 overflow-hidden': isFill,
@@ -116,7 +219,14 @@ export function LogViewer({ fileName, value, refresh, variant = 'page' }: LogVie
             },
           )}
         >
-          {value}
+          {filteredLines.length === 0 && normalizedSearchValue.length > 0
+            ? ''
+            : filteredLines.map((line, index) => (
+                <span key={`${line}-${index}`}>
+                  {renderHighlightedLine(line)}
+                  {index < filteredLines.length - 1 ? '\n' : null}
+                </span>
+              ))}
         </pre>
         <Button
           className={cn('absolute top-2 right-2 size-12', {

--- a/src/components/logging/useJmwalletdStdoutLog.ts
+++ b/src/components/logging/useJmwalletdStdoutLog.ts
@@ -24,10 +24,17 @@ export function useJmwalletdStdoutLog({ enabled = true }: UseJmwalletdStdoutLogP
   const { t } = useTranslation()
   const token = authState?.auth?.token
 
-  const logQuery = useQuery({
-    queryKey: ['logs', JMWALLETD_LOG_FILE_NAME, token],
+  const logQuery = useQuery<string>({
+    queryKey: ['logs', JMWALLETD_LOG_FILE_NAME],
     enabled: enabled && token !== undefined,
     retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: (query) => {
+      if (!enabled || token === undefined) return false
+      if (query.state.error) return false
+      return 2_500
+    },
+    placeholderData: (previousData) => previousData,
     queryFn: ({ signal }) => {
       if (token === undefined) return Promise.resolve('')
       return fetchLog({
@@ -73,7 +80,7 @@ export function useJmwalletdStdoutLog({ enabled = true }: UseJmwalletdStdoutLogP
   const logFileContent = useMemo(() => {
     if (logQuery.data) return logQuery.data
     if (!isDevMode() || alert?.variant !== 'warning') return undefined
-    return `${alert.message}\n`.repeat(1_000)
+    return `${alert.message}\nRun Jam in standalone mode: npm run dev:secondary.`
   }, [alert, logQuery.data])
 
   const refresh = useCallback(async () => {


### PR DESCRIPTION
follow up #1146 
improves logs ux for both footer modal and /logs page.

closess #1149 
what changed:
aligned logs page and modal to use consistent viewer layout behavior
added search input with line filtering and dark yellow match highlight
added clear search actions (inline x + clear button)
added match count/no-match feedback
improved auto-scroll behavior to avoid jumpy movement while reading
reduced flicker during refresh by keeping previous content and decoupling query key from token refresh
simplified non-standalone fallback text


demo - https://www.youtube.com/watch?v=Bce2IeIx7qw
ping @theborakompanioni @saurabhraghuvanshii 