### PR TITLE
Validate send amount against source jar balance

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -204,6 +204,24 @@ const sendFormSchema = (
 
       return new yup.ValidationError(errorMessage, root.destination.address, 'destination.address', undefined, true)
     })
+    .test('amount-exceeds-balance-test', function (root) {
+      if (root.amount.isSweep) return true
+      if (root.amount.amount === undefined || root.amount.amount === null) return true
+
+      const sourceJar = jars.find((it) => it.jarIndex === root.source.fromJar)
+      if (!sourceJar) return true
+
+      const available = sourceJar.balanceSummary.calculatedAvailableBalanceInSats
+      if (root.amount.amount <= available) return true
+
+      return new yup.ValidationError(
+        t('send.feedback_amount_exceeds_balance'),
+        root.amount.amount,
+        'amount.amount',
+        undefined,
+        true,
+      )
+    })
 }
 
 const FieldPrefixSatSymbol = (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -376,6 +376,7 @@
     "label_amount_input": "Amount",
     "placeholder_amount_input": "Enter amount in sats or BTC...",
     "feedback_invalid_amount": "Please provide a valid amount.",
+    "feedback_amount_exceeds_balance": "Amount exceeds the available balance in the selected jar.",
     "sending_options": "Sending options",
     "toggle_coinjoin": "Send as collaborative transaction",
     "toggle_coinjoin_subtitle": "Collaborative transactions improve the privacy of yourself and others.",


### PR DESCRIPTION
Adds client side validation to reject amounts exceeding the selected jar’s available balance