### PR TITLE
feat(earn): add earnings report sheet and parser

### DIFF
--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { startmakerMutation, stopmakerOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { ErrorMessage, StartMakerRequest } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { RefreshCwIcon, ShuffleIcon, UnlockIcon } from 'lucide-react'
+import { FileTextIcon, RefreshCwIcon, ShuffleIcon, UnlockIcon } from 'lucide-react'
 import type { SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -31,6 +31,7 @@ import type { Milliseconds } from '@/types/global'
 import { Spinner } from '../ui/spinner'
 import { CreateFidelityBondDialog } from './CreateFidelityBondDialog'
 import { EarnForm, type EarnFormValues } from './EarnForm'
+import { EarnReportSheet } from './EarnReportSheet'
 import { FidelityBondCard } from './FidelityBondCard'
 import { MoveToJarDialog } from './MoveToJarDialog'
 import { OfferCard } from './OfferCard'
@@ -75,6 +76,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   const [moveToJarUtxo, setMoveToJarUtxo] = useState<FidelityBondUtxo | undefined>()
   const [renewBondUtxo, setRenewBondUtxo] = useState<FidelityBondUtxo | undefined>()
   const [showCreateFidelityBondDialog, setShowCreateFidelityBondDialog] = useState(false)
+  const [showEarnReport, setShowEarnReport] = useState(false)
 
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
   const { maxFeesConfigMissing } = useFeeConfigValidation({ walletFileName })
@@ -175,6 +177,14 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   return (
     <div className="mx-auto max-w-4xl space-y-3 p-4">
       <PageTitle title={t('earn.title')} subtitle={t('earn.subtitle')} />
+
+      {/* Earn Report Button */}
+      <div className="flex justify-end">
+        <Button variant="outline" size="sm" onClick={() => setShowEarnReport(true)}>
+          <FileTextIcon />
+          {t('earn.button_show_report')}
+        </Button>
+      </div>
 
       {/* Fee Config Error Alert */}
       {maxFeesConfigMissing && (
@@ -364,6 +374,9 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
           </CardContent>
         </Card>
       )}
+
+      {/* Earn Report Sheet */}
+      <EarnReportSheet open={showEarnReport} onOpenChange={setShowEarnReport} />
     </div>
   )
 }

--- a/src/components/earn/EarnReportChart.tsx
+++ b/src/components/earn/EarnReportChart.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Balance } from '@/components/ui/jam/Balance'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { EarnReportEntry } from '@/hooks/useQueryYieldgenReport'
+
+const MS_PER_DAY = 24 * 60 * 60 * 1_000
+const CHART_DAYS = 30
+
+interface DayBucket {
+  label: string
+  earned: number
+  count: number
+}
+
+// Group entries into daily buckets for the past N days
+const bucketByDay = (entries: EarnReportEntry[], days: number): DayBucket[] => {
+  const now = new Date()
+  const buckets: DayBucket[] = []
+
+  for (let index = days - 1; index >= 0; index--) {
+    const dayStart = new Date(now.getTime() - index * MS_PER_DAY)
+    dayStart.setHours(0, 0, 0, 0)
+    const dayEnd = new Date(dayStart.getTime() + MS_PER_DAY)
+
+    const dayEntries = entries.filter(
+      (entry) => entry.timestamp >= dayStart && entry.timestamp < dayEnd && entry.earnedAmount != null,
+    )
+
+    buckets.push({
+      label: dayStart.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+      earned: dayEntries.reduce((sum, entry) => sum + (entry.earnedAmount ?? 0), 0),
+      count: dayEntries.length,
+    })
+  }
+
+  return buckets
+}
+
+interface EarnReportChartProps {
+  entries: EarnReportEntry[]
+}
+
+export const EarnReportChart = ({ entries }: EarnReportChartProps) => {
+  const { t } = useTranslation()
+  const buckets = useMemo(() => bucketByDay(entries, CHART_DAYS), [entries])
+  const maxEarned = useMemo(() => Math.max(...buckets.map((bucket) => bucket.earned), 1), [buckets])
+  const hasData = buckets.some((bucket) => bucket.earned > 0)
+
+  if (!hasData) return null
+
+  return (
+    <div className="space-y-2">
+      <div className="text-muted-foreground text-xs font-medium">{t('earn.report.chart_title_30d')}</div>
+      <TooltipProvider delayDuration={0}>
+        <div className="flex h-24 items-end gap-px">
+          {buckets.map((bucket) => {
+            const heightPercent = maxEarned > 0 ? (bucket.earned / maxEarned) * 100 : 0
+
+            return (
+              <Tooltip key={bucket.label}>
+                <TooltipTrigger asChild>
+                  <div className="flex min-w-0 flex-1 cursor-pointer flex-col justify-end" style={{ height: '100%' }}>
+                    <div
+                      className="bg-primary/70 hover:bg-primary rounded-t-sm transition-colors"
+                      style={{ height: `${Math.max(heightPercent, bucket.earned > 0 ? 4 : 0)}%` }}
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  <div className="font-medium">{bucket.label}</div>
+                  <div>
+                    <Balance valueString={String(bucket.earned)} showBalance={true} enableVisibilityToggle={false} />
+                  </div>
+                  <div className="text-muted-foreground">
+                    {t('earn.report.chart_tooltip_txs', { count: bucket.count })}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            )
+          })}
+        </div>
+      </TooltipProvider>
+    </div>
+  )
+}

--- a/src/components/earn/EarnReportSheet.tsx
+++ b/src/components/earn/EarnReportSheet.tsx
@@ -13,16 +13,19 @@ import { useQueryYieldgenReport, type EarnReportEntry } from '@/hooks/useQueryYi
 import type { AmountSats } from '@/types/global'
 import { EarnReportChart } from './EarnReportChart'
 
-// Compute sum of earned amounts over entries matching a time filter
+// Bitcoin genesis block date — used as the default 'since' for all-time sums
+const BITCOIN_GENESIS_DATE = new Date('2009-01-03T18:15:05Z')
+
+// Compute sum of earned amounts since a given date.
+// Accepts an optional ms offset from now; defaults to genesis day (all-time).
 const sumEarned = (entries: EarnReportEntry[], sinceMs?: number): AmountSats => {
-  const filtered =
-    sinceMs != null ? entries.filter((entry) => entry.timestamp.getTime() > Date.now() - sinceMs) : entries
-  return filtered.reduce((sum, entry) => sum + (entry.earnedAmount ?? 0), 0)
+  const since = sinceMs != null ? new Date(Date.now() - sinceMs) : BITCOIN_GENESIS_DATE
+  return entries.filter((entry) => entry.timestamp >= since).reduce((sum, entry) => sum + (entry.earnedAmount ?? 0), 0)
 }
 
 const MS_90_DAYS = 90 * 24 * 60 * 60 * 1_000
 const MS_30_DAYS = 30 * 24 * 60 * 60 * 1_000
-const MS_24_HOURS = 1 * 24 * 60 * 60 * 1_000
+const MS_24_HOURS = 24 * 60 * 60 * 1_000
 
 type SortKey = 'timestamp' | 'earnedAmount' | 'cjTotalAmount' | 'inputCount' | 'inputAmount'
 type SortDirection = 'asc' | 'desc'
@@ -65,7 +68,7 @@ export const EarnReportSheet = ({ open, onOpenChange }: EarnReportSheetProps) =>
     ])
   }, [])
 
-  const allEntries = [...(entries ?? []), ...demoEntries]
+  const allEntries = useMemo(() => [...(entries ?? []), ...demoEntries], [entries, demoEntries])
 
   const filteredEntries = useMemo(() => {
     if (search === '') return allEntries

--- a/src/components/earn/EarnReportSheet.tsx
+++ b/src/components/earn/EarnReportSheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { PlusIcon, RefreshCwIcon, SearchIcon } from 'lucide-react'
+import { DownloadIcon, PlusIcon, RefreshCwIcon, SearchIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Alert, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -94,6 +94,30 @@ export const EarnReportSheet = ({ open, onOpenChange }: EarnReportSheetProps) =>
     return sortDirection === 'desc' ? sorted.toReversed() : sorted
   }, [filteredEntries, sortKey, sortDirection])
 
+  // Export visible entries as CSV
+  const downloadCsv = useCallback(() => {
+    const header = 'timestamp,cj_amount,input_count,input_amount,fee,earned,confirm_minutes,notes'
+    const rows = sortedEntries.map((entry) =>
+      [
+        entry.timestamp.toISOString(),
+        entry.cjTotalAmount ?? '',
+        entry.inputCount ?? '',
+        entry.inputAmount ?? '',
+        entry.fee ?? '',
+        entry.earnedAmount ?? '',
+        entry.confirmationDuration ?? '',
+        entry.notes ?? '',
+      ].join(','),
+    )
+    const blob = new Blob([header + '\n' + rows.join('\n')], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `earn-report-${new Date().toISOString().slice(0, 10)}.csv`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }, [sortedEntries])
+
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
       setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
@@ -168,6 +192,10 @@ export const EarnReportSheet = ({ open, onOpenChange }: EarnReportSheetProps) =>
               </div>
               <Button variant="outline" size="icon" onClick={() => void refetch()} disabled={isRefetching}>
                 <RefreshCwIcon className={isRefetching ? 'animate-spin' : ''} />
+              </Button>
+              <Button variant="outline" size="sm" onClick={downloadCsv} disabled={allEntries.length === 0}>
+                <DownloadIcon />
+                {t('earn.report.text_button_download_csv')}
               </Button>
               <Button variant="outline" size="sm" onClick={addDemoEntry}>
                 <PlusIcon />

--- a/src/components/earn/EarnReportSheet.tsx
+++ b/src/components/earn/EarnReportSheet.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useMemo, useState } from 'react'
+import { PlusIcon, RefreshCwIcon, SearchIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Alert, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Balance } from '@/components/ui/jam/Balance'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { Spinner } from '@/components/ui/spinner'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useQueryYieldgenReport, type EarnReportEntry } from '@/hooks/useQueryYieldgenReport'
+import type { AmountSats } from '@/types/global'
+import { EarnReportChart } from './EarnReportChart'
+
+// Compute sum of earned amounts over entries matching a time filter
+const sumEarned = (entries: EarnReportEntry[], sinceMs?: number): AmountSats => {
+  const filtered =
+    sinceMs != null ? entries.filter((entry) => entry.timestamp.getTime() > Date.now() - sinceMs) : entries
+  return filtered.reduce((sum, entry) => sum + (entry.earnedAmount ?? 0), 0)
+}
+
+const MS_90_DAYS = 90 * 24 * 60 * 60 * 1_000
+const MS_30_DAYS = 30 * 24 * 60 * 60 * 1_000
+const MS_24_HOURS = 1 * 24 * 60 * 60 * 1_000
+
+type SortKey = 'timestamp' | 'earnedAmount' | 'cjTotalAmount' | 'inputCount' | 'inputAmount'
+type SortDirection = 'asc' | 'desc'
+
+interface EarnReportSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export const EarnReportSheet = ({ open, onOpenChange }: EarnReportSheetProps) => {
+  const { t } = useTranslation()
+  const { data: entries, isLoading, refetch, isRefetching } = useQueryYieldgenReport({ enabled: open })
+
+  const [search, setSearch] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('timestamp')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  const [demoEntries, setDemoEntries] = useState<EarnReportEntry[]>([])
+
+  // Generate a random demo entry spread over the past 30 days
+  const addDemoEntry = useCallback(() => {
+    const daysAgo = Math.floor(Math.random() * 30)
+    const hoursOffset = Math.floor(Math.random() * 24)
+    const timestamp = new Date(Date.now() - daysAgo * 86_400_000 - hoursOffset * 3_600_000)
+    const cjAmount = Math.floor(Math.random() * 50_000_000) + 1_000_000
+    const inputCount = Math.floor(Math.random() * 4) + 1
+    const earned = Math.floor(Math.random() * 5000) + 100
+
+    setDemoEntries((previous) => [
+      ...previous,
+      {
+        timestamp,
+        cjTotalAmount: cjAmount,
+        inputCount,
+        inputAmount: Math.floor(cjAmount * 0.4),
+        fee: earned,
+        earnedAmount: earned,
+        confirmationDuration: Math.round(Math.random() * 60 * 100) / 100,
+        notes: null,
+      },
+    ])
+  }, [])
+
+  const allEntries = [...(entries ?? []), ...demoEntries]
+
+  const filteredEntries = useMemo(() => {
+    if (search === '') return allEntries
+    const q = search.replace('.', '').toLowerCase()
+    return allEntries.filter(
+      (entry) =>
+        entry.timestamp.toLocaleString().toLowerCase().includes(q) ||
+        entry.cjTotalAmount?.toString().includes(q) ||
+        entry.inputCount?.toString().includes(q) ||
+        entry.inputAmount?.toString().includes(q) ||
+        entry.earnedAmount?.toString().includes(q) ||
+        entry.notes?.toLowerCase().includes(q),
+    )
+  }, [allEntries, search])
+
+  const sortedEntries = useMemo(() => {
+    const sorted = filteredEntries.toSorted((a, b) => {
+      const valA = a[sortKey]
+      const valB = b[sortKey]
+      if (valA == null && valB == null) return 0
+      if (valA == null) return 1
+      if (valB == null) return -1
+      if (sortKey === 'timestamp') return (valA as Date).getTime() - (valB as Date).getTime()
+      return (valA as number) - (valB as number)
+    })
+    return sortDirection === 'desc' ? sorted.toReversed() : sorted
+  }, [filteredEntries, sortKey, sortDirection])
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDirection('desc')
+    }
+  }
+
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return ''
+    return sortDirection === 'asc' ? ' ↑' : ' ↓'
+  }
+
+  const earnedTotal = useMemo(() => sumEarned(allEntries), [allEntries])
+  const earned90Days = useMemo(() => sumEarned(allEntries, MS_90_DAYS), [allEntries])
+  const earned30Days = useMemo(() => sumEarned(allEntries, MS_30_DAYS), [allEntries])
+  const earned24Hours = useMemo(() => sumEarned(allEntries, MS_24_HOURS), [allEntries])
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="flex h-[90vh] flex-col">
+        <SheetHeader>
+          <SheetTitle>{t('earn.report.title')}</SheetTitle>
+          <SheetDescription>
+            {search === ''
+              ? t('earn.report.text_report_summary', { count: allEntries.length })
+              : t('earn.report.text_report_summary_filtered', { count: filteredEntries.length })}
+          </SheetDescription>
+        </SheetHeader>
+
+        {isLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 pb-4">
+            {/* Stats row */}
+            <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+              {(
+                [
+                  { label: t('earn.report.stats.earned_total'), value: earnedTotal },
+                  { label: t('earn.report.stats.earned_90days'), value: earned90Days },
+                  { label: t('earn.report.stats.earned_30days'), value: earned30Days },
+                  { label: t('earn.report.stats.earned_24hours'), value: earned24Hours },
+                ] as const
+              ).map((stat) => (
+                <Card key={stat.label}>
+                  <CardContent className="p-3 text-center">
+                    <div className="text-muted-foreground text-xs">{stat.label}</div>
+                    <div className="mt-1 text-lg font-semibold">
+                      <Balance valueString={String(stat.value)} showBalance={true} />
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            {/* Daily earnings chart */}
+            <EarnReportChart entries={allEntries} />
+
+            {/* Toolbar: search + refresh */}
+            <div className="flex items-center gap-2">
+              <div className="relative flex-1">
+                <SearchIcon className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+                <Input
+                  placeholder={t('earn.report.placeholder_search')}
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  className="pl-8"
+                />
+              </div>
+              <Button variant="outline" size="icon" onClick={() => void refetch()} disabled={isRefetching}>
+                <RefreshCwIcon className={isRefetching ? 'animate-spin' : ''} />
+              </Button>
+              <Button variant="outline" size="sm" onClick={addDemoEntry}>
+                <PlusIcon />
+                {t('earn.report.text_button_generate_demo_report')}
+              </Button>
+            </div>
+
+            {/* Table or empty state */}
+            {allEntries.length === 0 ? (
+              <div className="space-y-2">
+                <Alert variant="default">
+                  <AlertTitle>{t('earn.alert_empty_report')}</AlertTitle>
+                </Alert>
+                <Button variant="outline" size="sm" onClick={addDemoEntry}>
+                  <PlusIcon />
+                  {t('earn.report.text_button_generate_demo_report')}
+                </Button>
+              </div>
+            ) : (
+              <div className="min-h-0 flex-1 overflow-auto rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="cursor-pointer select-none" onClick={() => handleSort('timestamp')}>
+                        {t('earn.report.heading_timestamp')}
+                        {sortIndicator('timestamp')}
+                      </TableHead>
+                      <TableHead
+                        className="cursor-pointer text-right select-none"
+                        onClick={() => handleSort('earnedAmount')}
+                      >
+                        {t('earn.report.heading_earned')}
+                        {sortIndicator('earnedAmount')}
+                      </TableHead>
+                      <TableHead
+                        className="cursor-pointer text-right select-none"
+                        onClick={() => handleSort('cjTotalAmount')}
+                      >
+                        {t('earn.report.heading_cj_amount')}
+                        {sortIndicator('cjTotalAmount')}
+                      </TableHead>
+                      <TableHead
+                        className="cursor-pointer text-right select-none"
+                        onClick={() => handleSort('inputCount')}
+                      >
+                        {t('earn.report.heading_input_count')}
+                        {sortIndicator('inputCount')}
+                      </TableHead>
+                      <TableHead
+                        className="cursor-pointer text-right select-none"
+                        onClick={() => handleSort('inputAmount')}
+                      >
+                        {t('earn.report.heading_input_value')}
+                        {sortIndicator('inputAmount')}
+                      </TableHead>
+                      <TableHead>{t('earn.report.heading_notes')}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sortedEntries.map((entry, i) => (
+                      <TableRow key={i}>
+                        <TableCell title={entry.timestamp.toISOString()}>{entry.timestamp.toLocaleString()}</TableCell>
+                        <TableCell className="text-right">
+                          {entry.earnedAmount != null && (
+                            <Balance valueString={String(entry.earnedAmount)} showBalance={true} />
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {entry.cjTotalAmount != null && (
+                            <Balance valueString={String(entry.cjTotalAmount)} showBalance={true} />
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">{entry.inputCount}</TableCell>
+                        <TableCell className="text-right">
+                          {entry.inputAmount != null && (
+                            <Balance valueString={String(entry.inputAmount)} showBalance={true} />
+                          )}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground max-w-[200px] truncate text-xs">
+                          {entry.notes}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/earn/earnReportParser.test.ts
+++ b/src/components/earn/earnReportParser.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { yieldgenReportToEarnReportEntries } from '@/lib/earnReportParser'
+
+const EXPECTED_HEADER_LINE =
+  'timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n'
+
+describe('yieldgenReportToEarnReportEntries', () => {
+  it('should parse empty data correctly', () => {
+    const entries = yieldgenReportToEarnReportEntries([])
+    expect(entries.length).toBe(0)
+  })
+
+  it('should parse data only containing headers correctly', () => {
+    const entries = yieldgenReportToEarnReportEntries([EXPECTED_HEADER_LINE])
+    expect(entries.length).toBe(0)
+  })
+
+  it('should parse expected data structure correctly', () => {
+    const exampleData = [
+      EXPECTED_HEADER_LINE,
+      '2008/10/31 02:42:54,,,,,,,Connected\n',
+      '2009/01/03 02:54:42,14999989490,4,20000005630,250,250,0.42,\n',
+      '2009/01/03 03:03:32,10000000000,3,15000016390,250,250,0.8,\n',
+      '2009/01/03 03:04:47,4999981140,1,5000016640,250,250,0,\n',
+      '2009/01/03 03:06:07,1132600000,1,2500000000,250,250,13.37,\n',
+      '2009/01/03 03:07:27,8867393010,2,10000000000,250,250,42,\n',
+      '2009/01/03 03:08:52,1132595980,1,1367400250,250,250,0.17,\n',
+    ]
+
+    const entries = yieldgenReportToEarnReportEntries(exampleData)
+
+    expect(entries.length).toBe(7)
+
+    // Connected note entry
+    const firstEntry = entries[0]
+    expect(firstEntry.timestamp.toUTCString()).toBe('Fri, 31 Oct 2008 02:42:54 GMT')
+    expect(firstEntry.cjTotalAmount).toBe(null)
+    expect(firstEntry.inputCount).toBe(null)
+    expect(firstEntry.inputAmount).toBe(null)
+    expect(firstEntry.fee).toBe(null)
+    expect(firstEntry.earnedAmount).toBe(null)
+    expect(firstEntry.confirmationDuration).toBe(null)
+    expect(firstEntry.notes).toBe('Connected\n')
+
+    // Transaction entry
+    const lastEntry = entries.at(-1)!
+    expect(lastEntry.timestamp.toUTCString()).toBe('Sat, 03 Jan 2009 03:08:52 GMT')
+    expect(lastEntry.cjTotalAmount).toBe(1132595980)
+    expect(lastEntry.inputCount).toBe(1)
+    expect(lastEntry.inputAmount).toBe(1367400250)
+    expect(lastEntry.fee).toBe(250)
+    expect(lastEntry.earnedAmount).toBe(250)
+    expect(lastEntry.confirmationDuration).toBe(0.17)
+    expect(lastEntry.notes).toBe('\n')
+  })
+
+  it('should handle unexpected/malformed data in a sane way', () => {
+    const unexpectedHeader = EXPECTED_HEADER_LINE + ',foo,bar'
+    const emptyLine = ''
+    const onlyNewLine = '\n'
+    const shortLine = '2009/01/03 04:04:04,,,'
+    const longLine = '2009/01/03 05:05:05,,,,,,,,,,,,,,,,,,,,,,,'
+    const malformedLine = 'this,is,a,malformed,line,with,some,unexpected,data'
+
+    const exampleData = [unexpectedHeader, emptyLine, onlyNewLine, shortLine, longLine, malformedLine]
+
+    const entries = yieldgenReportToEarnReportEntries(exampleData)
+
+    expect(entries.length).toBe(2)
+
+    const firstEntry = entries[0]
+    expect(firstEntry.timestamp.toUTCString()).toBe('Sat, 03 Jan 2009 05:05:05 GMT')
+    expect(firstEntry.cjTotalAmount).toBe(null)
+    expect(firstEntry.earnedAmount).toBe(null)
+
+    const secondEntry = entries[1]
+    expect(secondEntry.timestamp.toUTCString()).toBe('Invalid Date')
+    expect(secondEntry.cjTotalAmount).toBe(Number.NaN)
+    expect(secondEntry.notes).toBe('unexpected')
+  })
+})

--- a/src/hooks/useQueryYieldgenReport.ts
+++ b/src/hooks/useQueryYieldgenReport.ts
@@ -1,0 +1,33 @@
+import { yieldgenreport } from '@joinmarket-webui/joinmarket-api-ts'
+import { yieldgenreportQueryKey } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import type { ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { useQuery } from '@tanstack/react-query'
+import { useApiClient } from '@/hooks/useApiClient'
+import { yieldgenReportToEarnReportEntries } from '@/lib/earnReportParser'
+
+// Re-export for consumers
+export type { EarnReportEntry } from '@/lib/earnReportParser'
+
+export function useQueryYieldgenReport({ enabled = true }: { enabled?: boolean } = {}) {
+  const client = useApiClient()
+
+  return useQuery<ReturnType<typeof yieldgenReportToEarnReportEntries>, ErrorMessage>({
+    queryKey: yieldgenreportQueryKey(),
+    queryFn: async ({ signal }) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+        const response = await yieldgenreport({ client, signal })
+        // API returns string[] (CSV lines with header)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        return yieldgenReportToEarnReportEntries((response.data ?? []) as string[])
+      } catch (error: unknown) {
+        // 404 is returned until the maker is started at least once
+        if (error && typeof error === 'object' && 'status' in error && (error as { status: number }).status === 404) {
+          return []
+        }
+        throw error
+      }
+    },
+    enabled,
+  })
+}

--- a/src/hooks/useQueryYieldgenReport.ts
+++ b/src/hooks/useQueryYieldgenReport.ts
@@ -1,5 +1,5 @@
-import { yieldgenreport } from '@joinmarket-webui/joinmarket-api-ts'
 import { yieldgenreportQueryKey } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import { yieldgenreport } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import type { ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useQuery } from '@tanstack/react-query'
 import { useApiClient } from '@/hooks/useApiClient'
@@ -15,10 +15,9 @@ export function useQueryYieldgenReport({ enabled = true }: { enabled?: boolean }
     queryKey: yieldgenreportQueryKey(),
     queryFn: async ({ signal }) => {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const response = await yieldgenreport({ client, signal })
         // API returns string[] (CSV lines with header)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+
         return yieldgenReportToEarnReportEntries((response.data ?? []) as string[])
       } catch (error: unknown) {
         // 404 is returned until the maker is started at least once

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -534,7 +534,10 @@
         "earned_90days": "Earned (90 days)",
         "earned_30days": "Earned (30 days)",
         "earned_24hours": "Earned (24 hours)"
-      }
+      },
+      "chart_title_30d": "Daily earnings (30 days)",
+      "chart_tooltip_txs_one": "{{ count }} transaction",
+      "chart_tooltip_txs_other": "{{ count }} transactions"
     },
     "title_fidelity_bonds_zero": "Create a Fidelity Bond",
     "title_fidelity_bonds_one": "Your Fidelity Bond",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -529,6 +529,7 @@
       "heading_earned": "Earned",
       "heading_notes": "Notes",
       "text_button_generate_demo_report": "Generate demo entry",
+      "text_button_download_csv": "Download",
       "stats": {
         "earned_total": "Earned (total)",
         "earned_90days": "Earned (90 days)",

--- a/src/lib/earnReportParser.ts
+++ b/src/lib/earnReportParser.ts
@@ -1,0 +1,47 @@
+import type { AmountSats } from '@/types/global'
+
+type Minutes = number
+
+export interface EarnReportEntry {
+  timestamp: Date
+  cjTotalAmount: AmountSats | null
+  inputCount: number | null
+  inputAmount: AmountSats | null
+  fee: AmountSats | null
+  earnedAmount: AmountSats | null
+  confirmationDuration: Minutes | null
+  notes: string | null
+}
+
+// Yieldgen CSV timestamp format: yyyy/MM/dd HH:mm:ss
+const parseYieldgenTimestamp = (val: string) => {
+  return new Date(Date.parse(`${val} GMT`))
+}
+
+const yieldgenReportLineToEntry = (line: string): EarnReportEntry | null => {
+  if (!line.includes(',')) return null
+
+  const values = line.split(',')
+  if (values.length < 8) return null
+
+  return {
+    timestamp: parseYieldgenTimestamp(values[0]),
+    cjTotalAmount: values[1] !== '' ? Number.parseInt(values[1], 10) : null,
+    inputCount: values[2] !== '' ? Number.parseInt(values[2], 10) : null,
+    inputAmount: values[3] !== '' ? Number.parseInt(values[3], 10) : null,
+    fee: values[4] !== '' ? Number.parseInt(values[4], 10) : null,
+    earnedAmount: values[5] !== '' ? Number.parseInt(values[5], 10) : null,
+    confirmationDuration: values[6] !== '' ? Number.parseFloat(values[6]) : null,
+    notes: values[7] !== '' ? values[7] : null,
+  }
+}
+
+/** Parse yieldgen report CSV lines (including header) into structured entries */
+export const yieldgenReportToEarnReportEntries = (lines: string[]): EarnReportEntry[] => {
+  // Report is "empty" if it just contains the header line
+  const linesWithoutHeader = lines.length <= 1 ? [] : lines.slice(1)
+
+  return linesWithoutHeader
+    .map((line) => yieldgenReportLineToEntry(line))
+    .filter((entry): entry is EarnReportEntry => entry !== null)
+}


### PR DESCRIPTION
closes #1158 
this pr implements the earnings report view for the v2 earn page, allowing users to track their coinjoin yield.

changes i've made here :
- added [earnReportParser.ts](cci:7://file:///Users/parthbandwal/Desktop/JamSoB/jam/src/lib/earnReportParser.ts:0:0-0:0) with unit tests to reliably convert the api's csv response into structured data
- created [useQueryYieldgenReport](cci:1://file:///Users/parthbandwal/Desktop/JamSoB/jam/src/hooks/useQueryYieldgenReport.ts:10:0-31:1) hook using tanstack query to fetch the data seamlessly, handling the 404 state gracefully when a maker hasn't been started
- built the [EarnReportSheet](cci:1://file:///Users/parthbandwal/Desktop/JamSoB/jam/src/components/earn/EarnReportSheet.tsx:34:0-227:1) component which presents the data using standard ui primitives (sheet, table, card)
- included quick stats (total, 90d, 30d, 24h), column sorting, and text filtering for the transaction history
- added a lightweight css-based daily earnings bar chart (30 days) with hover tooltips — no external charting library needed
- wired up a "show earnings report" button on the main earn page

ping @theborakompanioni @saurabhraghuvanshii 