### PR TITLE
chore(ui): add address display chunking

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,9 @@ export default defineConfig(
           varsIgnorePattern: '^_',
           destructuredArrayIgnorePattern: '^_',
           caughtErrorsIgnorePattern: '_ignoredOnPurpose',
+          enableAutofixRemoval: {
+            imports: true,
+          },
         },
       ],
     },

--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -20,6 +20,7 @@ import { jamSettingsStore } from '@/store/jamSettingsStore'
 import type { AmountSats, BitcoinAddress } from '@/types/global'
 import { Badge } from '../ui/badge'
 import { buttonVariants } from '../ui/button-variants'
+import { Address } from '../ui/jam/Address'
 import { CopyButton } from '../ui/jam/CopyButton'
 import { BitcoinQR } from './BitcoinQR'
 import { ReceiveForm } from './ReceiveForm'
@@ -162,7 +163,11 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
             </div>
           ) : (
             <div className="animate-in fade-in space-y-2 text-center duration-1000">
-              <div className="min-h-5 font-mono text-sm break-all select-all">{getAddressMutation.data?.address}</div>
+              <div className="min-h-5">
+                {!getAddressMutation.data?.address ? undefined : (
+                  <Address value={getAddressMutation.data.address} className="text-sm" copyable={true} />
+                )}
+              </div>
               <Badge className="min-h-6 text-sm" variant={sourceJar ? 'default' : 'secondary'}>
                 {sourceJar ? (
                   <>

--- a/src/components/send/PaymentConfirmDialog.tsx
+++ b/src/components/send/PaymentConfirmDialog.tsx
@@ -11,6 +11,7 @@ import { DevBadge } from '../dev/DevBadge'
 import { Button } from '../ui/button'
 import { Card, CardContent, CardHeader } from '../ui/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader } from '../ui/dialog'
+import { Address } from '../ui/jam/Address'
 import { Balance } from '../ui/jam/Balance'
 import { Spinner } from '../ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
@@ -100,12 +101,14 @@ export default function PaymentConfirmDialog({
                   {meta.destinationJar.name}{' '}
                   <span className="text-muted-foreground text-xs">#{meta.destinationJar.jarIndex}</span>
                 </span>
-                <span className="text-muted-foreground text-xs">
-                  <span className="font-mono break-all select-all">{values.destination?.address}</span>
-                </span>
+                <Address
+                  className="text-muted-foreground text-xs"
+                  value={values.destination?.address ?? ''}
+                  copyable={true}
+                />
               </>
             ) : (
-              <span className="font-mono break-all select-all">{values.destination?.address}</span>
+              <Address value={values.destination?.address ?? ''} copyable={true} />
             )}
           </div>
 

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -37,6 +37,7 @@ import { Card, CardContent, CardHeader } from '../ui/card'
 import { Field, FieldLabel } from '../ui/field'
 import { Input } from '../ui/input'
 import { inputVariants } from '../ui/input-variants'
+import { Address } from '../ui/jam/Address'
 import { Balance } from '../ui/jam/Balance'
 import { SatSymbol } from '../ui/jam/CurrencySymbol'
 import { SelectableJar } from '../ui/jam/SelectableJar'
@@ -537,34 +538,38 @@ export function SendForm({
                 hidden: destinationJar === undefined,
               })}
             >
-              <div
-                id="send-destination-address-from-jar"
-                className={cn(
-                  inputVariants(),
-                  'flex items-center justify-between gap-2',
-                  'bg-input/50 dark:bg-input/80 h-auto',
-                )}
-              >
-                <span className="font-mono break-all select-all">{values.destination?.address}</span>
-                <Badge className="text-sm" variant="default">
-                  {destinationJar?.name} <span className="text-xs">#{destinationJar?.jarIndex}</span>
-                </Badge>
-              </div>
+              {destinationJar === undefined || !values.destination?.address ? undefined : (
+                <>
+                  <div
+                    id="send-destination-address-from-jar"
+                    className={cn(
+                      inputVariants(),
+                      'flex items-center justify-between gap-2',
+                      'bg-input/50 dark:bg-input/80 h-auto',
+                    )}
+                  >
+                    <Address value={values.destination.address} copyable={true} />
+                    <Badge className="text-sm" variant="default">
+                      {destinationJar.name} <span className="text-xs">#{destinationJar.jarIndex}</span>
+                    </Badge>
+                  </div>
 
-              <Button
-                id="clear-address-from-jar-selector-trigger"
-                type="button"
-                variant="outline"
-                size="lg"
-                className="h-auto"
-                disabled={disabled}
-                onClick={() => {
-                  setValue('destination.address', '', { shouldValidate: true })
-                  setValue('destination.fromJar', undefined, { shouldValidate: true })
-                }}
-              >
-                <XIcon /> {t('global.clear')}
-              </Button>
+                  <Button
+                    id="clear-address-from-jar-selector-trigger"
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    className="h-auto"
+                    disabled={disabled}
+                    onClick={() => {
+                      setValue('destination.address', '', { shouldValidate: true })
+                      setValue('destination.fromJar', undefined, { shouldValidate: true })
+                    }}
+                  >
+                    <XIcon /> {t('global.clear')}
+                  </Button>
+                </>
+              )}
             </ButtonGroup>
           </Field>
 

--- a/src/components/send/types.d.ts
+++ b/src/components/send/types.d.ts
@@ -10,15 +10,10 @@ export type SourceValue = {
   fromJar: JarIndex
 }
 
-export type DestinationValue =
-  | {
-      address: BitcoinAddress
-      fromJar: undefined
-    }
-  | {
-      address: BitcoinAddress
-      fromJar: JarIndex
-    }
+export type DestinationValue = {
+  address: BitcoinAddress
+  fromJar: JarIndex | undefined
+}
 
 export type AmountValue =
   | {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -14,6 +14,8 @@ import {
   ArrowLeftRightIcon,
   LockKeyholeIcon,
   BookKeyIcon,
+  FoldHorizontalIcon,
+  UnfoldHorizontalIcon,
 } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useTranslation } from 'react-i18next'
@@ -46,7 +48,8 @@ export const SettingsPage = ({ walletFileName, onLockWallet }: SettingPageProps)
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { resolvedTheme, setTheme } = useTheme()
-  const { currency, toggleCurrencyUnit, isPrivate, togglePrivacyMode } = useJamDisplayContext()
+  const { currency, toggleCurrencyUnit, isPrivate, togglePrivacyMode, addressChunkingEnabled, toggleAddressChunking } =
+    useJamDisplayContext()
   const jamSettings = useStore(jamSettingsStore)
 
   const [showSeedDialog, setShowSeedDialog] = useState(false)
@@ -89,6 +92,18 @@ export const SettingsPage = ({ walletFileName, onLockWallet }: SettingPageProps)
             checked={currency === 'btc'}
             onCheckedChange={toggleCurrencyUnit}
             displayToggle={false}
+          />
+          <Separator className="opacity-50" />
+          <SettingSwitch
+            icon={addressChunkingEnabled === true ? UnfoldHorizontalIcon : FoldHorizontalIcon}
+            title={t(
+              addressChunkingEnabled === true
+                ? 'settings.use_address_chunking_enabled'
+                : 'settings.use_address_chunking_disabled',
+            )}
+            checked={addressChunkingEnabled === true}
+            onCheckedChange={toggleAddressChunking}
+            displayToggle={true}
           />
           <Separator className="opacity-50" />
           <SettingSwitch

--- a/src/components/ui/jam/Address.module.css
+++ b/src/components/ui/jam/Address.module.css
@@ -1,0 +1,19 @@
+.bitcoinAddress {
+  word-break: break-all;
+  user-select: all;
+  font-family: var(--font-mono);
+}
+
+.bitcoinAddress.chunked :nth-child(even) {
+  color: var(--muted-foreground);
+  filter: hue-rotate(270deg);
+}
+
+.bitcoinAddress.chunked :nth-child(odd) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.bitcoinAddress.chunked :not(:first-child)::before {
+  font-size: 4px;
+  content: '\202F';
+}

--- a/src/components/ui/jam/Address.module.css
+++ b/src/components/ui/jam/Address.module.css
@@ -6,7 +6,7 @@
 
 .bitcoinAddress.chunked :nth-child(even) {
   color: var(--muted-foreground);
-  filter: hue-rotate(270deg);
+  filter: hue-rotate(45deg);
 }
 
 .bitcoinAddress.chunked :nth-child(odd) {

--- a/src/components/ui/jam/Address.tsx
+++ b/src/components/ui/jam/Address.tsx
@@ -4,15 +4,24 @@ import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import type { BitcoinAddress } from '@/types/global'
 import { buttonVariants } from '../button-variants'
+import styles from './Address.module.css'
 import { CopyButton } from './CopyButton'
 
 type PlainAddressProps = {
   value: BitcoinAddress
   className?: string
+  chunked?: boolean
 }
 
-const PlainAddress = ({ value, className }: PlainAddressProps) => {
-  return <span className={cn('font-mono break-all select-all', className)}>{value}</span>
+const PlainAddress = ({ value, className, chunked = true }: PlainAddressProps) => {
+  const chunks = chunked ? value.match(/.{1,4}/g) : [value]
+  return (
+    <span className={cn(styles.bitcoinAddress, chunked ? styles.chunked : undefined, className)}>
+      {chunks?.map((it, index) => (
+        <span key={index}>{it}</span>
+      ))}
+    </span>
+  )
 }
 
 type CopyableAddressProps = PlainAddressProps
@@ -34,16 +43,10 @@ const CopyableAddress = ({ value, className }: CopyableAddressProps) => {
   )
 }
 
-type AddressProps = {
-  value: BitcoinAddress
-  className?: string
+type AddressProps = CopyableAddressProps & {
   copyable?: boolean
 }
 
-export const Address = ({ value, className, copyable = true }: AddressProps) => {
-  return copyable ? (
-    <CopyableAddress value={value} className={className} />
-  ) : (
-    <PlainAddress value={value} className={className} />
-  )
+export const Address = ({ copyable = true, ...props }: AddressProps) => {
+  return copyable ? <CopyableAddress {...props} /> : <PlainAddress {...props} />
 }

--- a/src/components/ui/jam/Address.tsx
+++ b/src/components/ui/jam/Address.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { useJamDisplayContext } from '@/context/JamDisplayContext'
 import { cn } from '@/lib/utils'
 import type { BitcoinAddress } from '@/types/global'
 import { buttonVariants } from '../button-variants'
@@ -13,10 +14,10 @@ type PlainAddressProps = {
   chunked?: boolean
 }
 
-const PlainAddress = ({ value, className, chunked = true }: PlainAddressProps) => {
+const PlainAddress = ({ value, className, chunked }: PlainAddressProps) => {
   const chunks = chunked ? value.match(/.{1,4}/g) : [value]
   return (
-    <span className={cn(styles.bitcoinAddress, chunked ? styles.chunked : undefined, className)}>
+    <span className={cn(styles.bitcoinAddress, chunked === true ? styles.chunked : undefined, className)}>
       {chunks?.map((it, index) => (
         <span key={index}>{it}</span>
       ))}
@@ -26,13 +27,13 @@ const PlainAddress = ({ value, className, chunked = true }: PlainAddressProps) =
 
 type CopyableAddressProps = PlainAddressProps
 
-const CopyableAddress = ({ value, className }: CopyableAddressProps) => {
+const CopyableAddress = (props: CopyableAddressProps) => {
   const { t } = useTranslation()
   return (
     <div className="flex items-center gap-2">
-      <PlainAddress value={value} className={className} />
+      <PlainAddress {...props} />
       <CopyButton
-        value={value}
+        value={props.value}
         text={<CopyIcon />}
         successText={<CheckIcon className="text-green-500" />}
         className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
@@ -47,6 +48,8 @@ type AddressProps = CopyableAddressProps & {
   copyable?: boolean
 }
 
-export const Address = ({ copyable = true, ...props }: AddressProps) => {
-  return copyable ? <CopyableAddress {...props} /> : <PlainAddress {...props} />
+export const Address = ({ chunked, copyable = true, ...props }: AddressProps) => {
+  const displayContext = useJamDisplayContext()
+  const isChunked = chunked ?? displayContext.addressChunkingEnabled === true
+  return copyable ? <CopyableAddress {...props} chunked={isChunked} /> : <PlainAddress {...props} chunked={isChunked} />
 }

--- a/src/components/ui/jam/Address.tsx
+++ b/src/components/ui/jam/Address.tsx
@@ -1,0 +1,49 @@
+import { CheckIcon, CopyIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+import type { BitcoinAddress } from '@/types/global'
+import { buttonVariants } from '../button-variants'
+import { CopyButton } from './CopyButton'
+
+type PlainAddressProps = {
+  value: BitcoinAddress
+  className?: string
+}
+
+const PlainAddress = ({ value, className }: PlainAddressProps) => {
+  return <span className={cn('font-mono break-all select-all', className)}>{value}</span>
+}
+
+type CopyableAddressProps = PlainAddressProps
+
+const CopyableAddress = ({ value, className }: CopyableAddressProps) => {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-2">
+      <PlainAddress value={value} className={className} />
+      <CopyButton
+        value={value}
+        text={<CopyIcon />}
+        successText={<CheckIcon className="text-green-500" />}
+        className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
+        onSuccess={() => toast.success(t(/*TODO: i18n - distinct key */ 'receive.text_copy_address'))}
+        onError={() => toast.error(/*TODO: i18n - distinct key */ t('receive.error_copy_address_failed'))}
+      />
+    </div>
+  )
+}
+
+type AddressProps = {
+  value: BitcoinAddress
+  className?: string
+  copyable?: boolean
+}
+
+export const Address = ({ value, className, copyable = true }: AddressProps) => {
+  return copyable ? (
+    <CopyableAddress value={value} className={className} />
+  ) : (
+    <PlainAddress value={value} className={className} />
+  )
+}

--- a/src/components/ui/jam/Balance.module.css
+++ b/src/components/ui/jam/Balance.module.css
@@ -1,10 +1,8 @@
 :root {
-  --jam-balance-color: #212529;
   --jam-balance-deemphasize-color: #9eacba;
 }
 
 :root[data-theme='dark'] {
-  --jam-balance-color: #ffffff;
   --jam-balance-deemphasize-color: #555c62;
 }
 

--- a/src/components/wallet/BranchEntryTable.tsx
+++ b/src/components/wallet/BranchEntryTable.tsx
@@ -17,18 +17,15 @@ import {
   type FilterFnOption,
   type Table as TableType,
 } from '@tanstack/react-table'
-import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
 import { TablePagination } from '@/components/ui/jam/TablePagination'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import type { AccountBranch } from '@/context/JamWalletInfoContext'
 import type { UtxoTag } from '@/lib/tags'
 import { cn } from '@/lib/utils'
 import type { AmountSats, BitcoinAddress, HdPath } from '@/types/global'
-import { buttonVariants } from '../ui/button-variants'
+import { Address } from '../ui/jam/Address'
 import { Balance } from '../ui/jam/Balance'
-import { CopyButton } from '../ui/jam/CopyButton'
 import { SortIcon } from '../ui/jam/SortIcon'
 import { StatusBadge } from '../ui/jam/StatusBadge'
 
@@ -115,19 +112,7 @@ export const BranchEntryTable = ({
           // tie-break using derivationIndex
           return a.original.derivationIndex - b.original.derivationIndex
         },
-        cell: (info) => (
-          <div className="flex items-center gap-2">
-            <span className="font-mono text-sm select-all">{info.getValue()}</span>
-            <CopyButton
-              value={info.getValue()}
-              text={<CopyIcon />}
-              successText={<CheckIcon className="text-green-500" />}
-              className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
-              onSuccess={() => toast.success(t('receive.text_copy_address'))}
-              onError={() => toast.error(t('receive.error_copy_address_failed'))}
-            />
-          </div>
-        ),
+        cell: (info) => <Address value={info.getValue()} className="text-sm" copyable={true} />,
         meta: {
           alphabetic: true,
         },

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -23,7 +23,7 @@ import {
   type CellContext,
 } from '@tanstack/react-table'
 import type { TFunction } from 'i18next'
-import { CheckIcon, ChevronDownIcon, CopyIcon, SnowflakeIcon } from 'lucide-react'
+import { ChevronDownIcon, SnowflakeIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { TablePagination } from '@/components/ui/jam/TablePagination'
@@ -32,11 +32,10 @@ import type { Utxo } from '@/hooks/useQueryUtxos'
 import type { UtxoTag } from '@/lib/tags'
 import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
-import { buttonVariants } from '../ui/button-variants'
 import { Card, CardContent } from '../ui/card'
 import { Checkbox } from '../ui/checkbox'
+import { Address } from '../ui/jam/Address'
 import { Balance } from '../ui/jam/Balance'
-import { CopyButton } from '../ui/jam/CopyButton'
 import { SortIcon } from '../ui/jam/SortIcon'
 import { StatusBadge } from '../ui/jam/StatusBadge'
 
@@ -207,19 +206,7 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
         const bid = Number(b.original.utxo.confirmations)
         return aid - bid
       },
-      cell: (info) => (
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-sm select-all">{info.getValue()}</span>
-          <CopyButton
-            value={info.getValue()}
-            text={<CopyIcon />}
-            successText={<CheckIcon className="text-green-500" />}
-            className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
-            onSuccess={() => toast.success(t('receive.text_copy_address'))}
-            onError={() => toast.error(t('receive.error_copy_address_failed'))}
-          />
-        </div>
-      ),
+      cell: (info) => <Address value={info.getValue()} className="text-sm" copyable={true} />,
       meta: {
         alphabetic: true,
       } as UtxoTableColumnMeta,

--- a/src/context/JamDisplayContext.ts
+++ b/src/context/JamDisplayContext.ts
@@ -5,6 +5,8 @@ import type { Currency } from '@/types/global'
 interface JamDisplayContextType {
   currency: Currency
   isPrivate: boolean
+  addressChunkingEnabled: boolean
+  toggleAddressChunking: () => void
   toggleCurrencyUnit: () => void
   togglePrivacyMode: () => void
   toggleDisplayMode: () => void

--- a/src/hooks/useDisplaySettings.ts
+++ b/src/hooks/useDisplaySettings.ts
@@ -4,7 +4,7 @@ import { jamSettingsStore } from '@/store/jamSettingsStore'
 
 export function useDisplaySettings() {
   const {
-    state: { currencyUnit, privateMode },
+    state: { currencyUnit, privateMode, addressChunking },
     update,
   } = useStore(jamSettingsStore, (state) => state)
 
@@ -13,6 +13,10 @@ export function useDisplaySettings() {
     [currencyUnit, update],
   )
   const togglePrivacyMode = useCallback(() => update({ privateMode: !privateMode }), [privateMode, update])
+  const toggleAddressChunking = useCallback(
+    () => update({ addressChunking: !addressChunking }),
+    [addressChunking, update],
+  )
 
   const toggleDisplayMode = useCallback(() => {
     if (privateMode) {
@@ -35,8 +39,10 @@ export function useDisplaySettings() {
   return {
     currency: currencyUnit,
     isPrivate: privateMode,
+    addressChunkingEnabled: addressChunking,
     toggleCurrencyUnit,
     togglePrivacyMode,
     toggleDisplayMode,
+    toggleAddressChunking,
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -237,6 +237,8 @@
     "use_btc": "Display amounts in bitcoin",
     "use_dark_theme": "Switch to dark theme",
     "use_light_theme": "Switch to light theme",
+    "use_address_chunking_enabled": "Address display chunking enabled",
+    "use_address_chunking_disabled": "Address display chunking disabled",
     "label_select_language": "Language",
     "text_help_translate": "Missing your language? Help us out!",
     "show_seed": "Show seed phrase",

--- a/src/store/jamSettingsStore.ts
+++ b/src/store/jamSettingsStore.ts
@@ -6,6 +6,7 @@ import type { Currency } from '@/types/global'
 export type JamSettings = {
   developerMode: boolean
   privateMode: boolean
+  addressChunking: boolean
   currencyUnit: Currency
   cheatsheetForceOpenAt?: number
 }
@@ -19,6 +20,7 @@ interface JamSettingsStoreState {
 const initial: JamSettings = {
   developerMode: isDevMode(),
   privateMode: false,
+  addressChunking: true,
   currencyUnit: 'sats',
   cheatsheetForceOpenAt: undefined,
 }

--- a/src/stories/jam/Address.stories.tsx
+++ b/src/stories/jam/Address.stories.tsx
@@ -32,8 +32,15 @@ export const PlainAddress: Story = {
 
 export const CopyableAddress: Story = {
   args: {
-    value: 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx',
+    ...PlainAddress.args,
     copyable: true,
+  },
+}
+
+export const AddressChunkingDisabled: Story = {
+  args: {
+    ...PlainAddress.args,
+    chunked: false,
   },
 }
 

--- a/src/stories/jam/Address.stories.tsx
+++ b/src/stories/jam/Address.stories.tsx
@@ -5,6 +5,20 @@ const meta: Meta<typeof Address> = {
   title: 'Jam/Address',
   component: Address,
   tags: ['autodocs'],
+  args: {
+    chunked: true,
+    copyable: true,
+  },
+  argTypes: {
+    chunked: {
+      description: 'Enable address chunking',
+      control: 'boolean',
+    },
+    copyable: {
+      description: 'Enable copy to clipboard',
+      control: 'boolean',
+    },
+  },
 }
 export default meta
 
@@ -13,12 +27,22 @@ type Story = StoryObj<typeof Address>
 export const PlainAddress: Story = {
   args: {
     value: 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx',
-    copyable: false,
   },
 }
+
 export const CopyableAddress: Story = {
   args: {
     value: 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx',
     copyable: true,
   },
+}
+
+export const Formats: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Address value="bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx" />
+      <Address value="mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV" />
+      <Address value="2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2" />
+    </div>
+  ),
 }

--- a/src/stories/jam/Address.stories.tsx
+++ b/src/stories/jam/Address.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Address } from '@/components/ui/jam/Address'
+
+const meta: Meta<typeof Address> = {
+  title: 'Jam/Address',
+  component: Address,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Address>
+
+export const PlainAddress: Story = {
+  args: {
+    value: 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx',
+    copyable: false,
+  },
+}
+export const CopyableAddress: Story = {
+  args: {
+    value: 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx',
+    copyable: true,
+  },
+}


### PR DESCRIPTION
Add address chunking (groups of four)

<img width="1089" height="684" alt="image" src="https://github.com/user-attachments/assets/c584ccf8-b800-44da-a379-e17dfe8cfc52" />

@saurabhraghuvanshii What do you think? Good idea? Bad idea?
Concept stolen from Sparrow Wallet.