### PR TITLE
memoize router creation using useMemo

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -87,7 +87,7 @@ export default function App() {
     [reloadCurrentWalletInfo],
   )
 
-  const router = createBrowserRouter(
+  const router = useMemo(()=>createBrowserRouter(
     createRoutesFromElements(
       <Route
         id="base"
@@ -218,7 +218,7 @@ export default function App() {
         v7_normalizeFormMethod: true,
       },
     },
-  )
+  ), [currentWallet, sessionConnectionError]);
 
   if (settings.showOnboarding === true) {
     return (


### PR DESCRIPTION
This PR memoizes router creation using `useMemo` . prevents router from being recreated every time app state other than the dependencies change.

while this works, i think there are other better options, maybe. like moving to react 19 which does memoization automatically (not really sure if the compiler would memoize cases like these). or just removing conditional routing and adding state guards in the components for the routes.

fixes #1155 