### PR TITLE
feat(create): verify  menominc step

### DIFF
--- a/src/components/create/CreateStepConfirm.tsx
+++ b/src/components/create/CreateStepConfirm.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import type { TFunction } from 'i18next'
-import { AlertCircleIcon } from 'lucide-react'
+import { AlertCircleIcon, ChevronRightIcon } from 'lucide-react'
 import { useForm, useWatch, type Mode, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -78,6 +78,7 @@ export const CreateStepConfirm = ({
     if (backupConfirmed) return
 
     const toastId = toast.info(/* TODO: i18n */ 'Save Your Seed Phrase', {
+      id: 'save-seed-phrase-reminder',
       icon: <AlertCircleIcon />,
       description: /* TODO: change i18n key ("alert_description") */ t('create_wallet.subtitle_wallet_created'),
       duration: Number.POSITIVE_INFINITY,
@@ -95,12 +96,12 @@ export const CreateStepConfirm = ({
       <div className="space-y-2">
         <div>
           <Label className="text-muted-foreground text-xs">{t('create_wallet.confirmation_label_wallet_name')}</Label>
-          <span className="text-sm font-semibold break-all select-all">{walletFileName}</span>
+          <span className="font-semibold break-all select-all">{walletFileName}</span>
         </div>
         <div>
           <Label className="text-muted-foreground text-xs">{t('create_wallet.confirmation_label_password')}</Label>
           <MaskedText
-            className="font-mono text-sm font-semibold break-all slashed-zero select-none"
+            className="font-mono font-semibold break-all slashed-zero select-none"
             masked={!revealSensitiveInfo}
             maskedText="maskedmaskedmaskedmasked"
           >
@@ -153,6 +154,7 @@ export const CreateStepConfirm = ({
 
       <Button type="submit" className="w-full" size="xxl" disabled={isSubmitting}>
         {t('create_wallet.next_button')}
+        <ChevronRightIcon />
       </Button>
     </form>
   )

--- a/src/components/create/CreateStepVerifyMnemonic.tsx
+++ b/src/components/create/CreateStepVerifyMnemonic.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { CheckCircle2Icon, ChevronLeftIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -7,6 +7,7 @@ import { isDebugFeatureEnabled } from '@/constants/debugFeatures'
 import { cn } from '@/lib/utils'
 import type { MnemonicPhrase } from '@/types/global'
 import { DevBadge } from '../dev/DevBadge'
+import { MaskedText } from '../ui/jam/MaskedText'
 import { Spinner } from '../ui/spinner'
 
 const skipWalletBackupVerification = isDebugFeatureEnabled('skipWalletBackupVerification')
@@ -45,7 +46,6 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
 
       if (word !== expectedWord) {
         setWrongButtonIndex(shuffledIndex)
-        setTimeout(() => setWrongButtonIndex(undefined), 600)
         return
       }
 
@@ -54,6 +54,12 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
     },
     [mnemonicPhrase, selectedWords, pickedIndicesSet, wrongButtonIndex],
   )
+
+  useEffect(() => {
+    if (wrongButtonIndex === undefined) return
+    const timerId = setTimeout(() => setWrongButtonIndex(undefined), 600)
+    return () => clearTimeout(timerId)
+  }, [wrongButtonIndex])
 
   const progress = selectedWords.length
   const total = mnemonicPhrase.length
@@ -81,7 +87,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
           <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
             <div
               className={cn('h-full rounded-full transition-all duration-300 ease-out', {
-                'bg-green-100/50': isCorrect,
+                'bg-green-300/50': isCorrect,
                 'bg-primary': !isCorrect,
               })}
               style={{ width: `${(progress / total) * 100}%` }}
@@ -91,43 +97,45 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
       </div>
 
       <div
-        className={cn('min-h-[100px] rounded-lg border-2 border-dashed p-2.5 transition-colors', {
+        className={cn('h-1 min-h-[150px] rounded-lg border-2 border-dashed p-2.5 transition-colors', {
           'border-destructive/50': wrongButtonIndex !== undefined,
           'border-muted-foreground/20': wrongButtonIndex === undefined,
           'border-green-300/50 bg-green-600/5': allSelected && isCorrect,
         })}
       >
-        <div className="grid grid-cols-3 gap-1.5">
-          {mnemonicPhrase.map((_, index) => {
-            const word = selectedWords[index]
-            const isFilled = word !== undefined
-            return (
-              <div
-                key={index}
-                className={cn('flex items-center gap-0.5 rounded-md px-0.5 py-1.5 font-mono text-xs transition-all', {
-                  'bg-primary/10 text-primary border-primary/20 border': isFilled,
-                  'border-muted bg-muted/30 border border-dashed': !isFilled,
-                })}
-              >
-                <span
-                  className={cn('min-w-8 text-right tabular-nums', {
-                    'text-primary/50': isFilled,
-                    'text-muted-foreground/40': !isFilled,
+        <div className="grid grid-cols-3 gap-1.5 select-none">
+          {!isCorrect &&
+            mnemonicPhrase.map((_, index) => {
+              const word = selectedWords[index]
+              const isFilled = word !== undefined
+              const isHidden = index + 1 < progress
+              return (
+                <div
+                  key={index}
+                  className={cn('flex items-center gap-0.5 rounded-md px-0.5 py-1.5 font-mono text-xs transition-all', {
+                    'bg-primary/10 text-primary border-primary/20 border': isFilled,
+                    'border-muted bg-muted/30 border border-dashed': !isFilled,
                   })}
                 >
-                  {index + 1}.
-                </span>
-                {isFilled ? (
-                  <span className="font-medium">{word}</span>
-                ) : (
-                  <span className="text-muted-foreground/30">···</span>
-                )}
-              </div>
-            )
-          })}
+                  <span
+                    className={cn('min-w-8 text-right tabular-nums', {
+                      'text-primary/50': isFilled,
+                      'text-muted-foreground/40': !isFilled,
+                    })}
+                  >
+                    {index + 1}.
+                  </span>
+                  {isFilled ? (
+                    <span>{isHidden ? <MaskedText masked /> : word}</span>
+                  ) : (
+                    <span className="text-muted-foreground/30">···</span>
+                  )}
+                </div>
+              )
+            })}
         </div>
         {allSelected && isCorrect && (
-          <div className="mt-2.5 flex items-center justify-center gap-1.5 text-sm font-medium text-green-300">
+          <div className="flex h-full items-center justify-center gap-1.5 text-sm font-medium text-green-300">
             <CheckCircle2Icon className="size-4" />
             {t('create_wallet.verify_mnemonic.feedback_mnemonic_confirmed')}
           </div>
@@ -152,7 +160,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
                 })}
                 onClick={() => handleWordClick(word, index)}
               >
-                {isPicked ? '···' : word}
+                {isPicked ? <MaskedText masked /> : word}
               </Button>
             )
           })}
@@ -179,6 +187,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
             className="flex-1"
             variant="secondary"
             size="xxl"
+            disabled={verifyMutation.isPending}
             onClick={() => verifyMutation.mutate({ mustBeCorrect: false })}
           >
             Skip <DevBadge />

--- a/src/components/create/CreateStepVerifyMnemonic.tsx
+++ b/src/components/create/CreateStepVerifyMnemonic.tsx
@@ -7,6 +7,7 @@ import { isDebugFeatureEnabled } from '@/constants/debugFeatures'
 import { cn } from '@/lib/utils'
 import type { MnemonicPhrase } from '@/types/global'
 import { DevBadge } from '../dev/DevBadge'
+import { Spinner } from '../ui/spinner'
 
 const skipWalletBackupVerification = isDebugFeatureEnabled('skipWalletBackupVerification')
 
@@ -190,6 +191,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
           disabled={!isCorrect || verifyMutation.isPending}
           onClick={() => verifyMutation.mutate({ mustBeCorrect: true })}
         >
+          {verifyMutation.isPending && <Spinner className="motion-reduce:hidden" />}
           {t('create_wallet.confirmation_button_fund_wallet')}
         </Button>
       </div>

--- a/src/components/create/CreateStepVerifyMnemonic.tsx
+++ b/src/components/create/CreateStepVerifyMnemonic.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { CheckCircle2Icon, ChevronLeftIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { isDebugFeatureEnabled } from '@/constants/debugFeatures'
+import { cn } from '@/lib/utils'
+import type { MnemonicPhrase } from '@/types/global'
+import { DevBadge } from '../dev/DevBadge'
+
+const skipWalletBackupVerification = isDebugFeatureEnabled('skipWalletBackupVerification')
+
+function shuffleArray(array: string[]): string[] {
+  const result = [...array]
+  for (let i = result.length - 1; i > 0; i--) {
+    const index = Math.floor(Math.random() * (i + 1))
+    ;[result[i], result[index]] = [result[index], result[i]]
+  }
+  return result
+}
+
+interface CreateStepVerifyMnemonicProps {
+  mnemonicPhrase: MnemonicPhrase
+  onVerified: () => Promise<void>
+  onBack: () => void
+}
+
+export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }: CreateStepVerifyMnemonicProps) => {
+  const { t } = useTranslation()
+  const [selectedWords, setSelectedWords] = useState<string[]>([])
+  const [wrongButtonIndex, setWrongButtonIndex] = useState<number>()
+  const [shuffledWords] = useState(() => shuffleArray(mnemonicPhrase))
+
+  const [pickedIndicesOrder, setPickedIndicesOrder] = useState<number[]>([])
+  const pickedIndicesSet = useMemo(() => new Set(pickedIndicesOrder), [pickedIndicesOrder])
+
+  const handleWordClick = useCallback(
+    (word: string, shuffledIndex: number) => {
+      if (pickedIndicesSet.has(shuffledIndex)) return
+      if (wrongButtonIndex !== undefined) return
+
+      const nextPosition = selectedWords.length
+      const expectedWord = mnemonicPhrase[nextPosition]
+
+      if (word !== expectedWord) {
+        setWrongButtonIndex(shuffledIndex)
+        setTimeout(() => setWrongButtonIndex(undefined), 600)
+        return
+      }
+
+      setSelectedWords((previous) => [...previous, word])
+      setPickedIndicesOrder((previous) => [...previous, shuffledIndex])
+    },
+    [mnemonicPhrase, selectedWords, pickedIndicesSet, wrongButtonIndex],
+  )
+
+  const progress = selectedWords.length
+  const total = mnemonicPhrase.length
+  const allSelected = progress === total
+  const isCorrect = allSelected && selectedWords.every((w, i) => w === mnemonicPhrase[i])
+
+  const verifyMutation = useMutation({
+    mutationFn: async ({ mustBeCorrect }: { mustBeCorrect: boolean }) => {
+      if (mustBeCorrect && !isCorrect) return
+      return await onVerified()
+    },
+    retry: false,
+  })
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-3">
+        <p className="text-muted-foreground text-center text-sm">{t('create_wallet.verify_mnemonic.subtitle')}</p>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">
+              {t('create_wallet.verify_mnemonic.progress', { current: progress, total })}
+            </span>
+          </div>
+          <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
+            <div
+              className={cn('h-full rounded-full transition-all duration-300 ease-out', {
+                'bg-green-100/50': isCorrect,
+                'bg-primary': !isCorrect,
+              })}
+              style={{ width: `${(progress / total) * 100}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div
+        className={cn('min-h-[100px] rounded-lg border-2 border-dashed p-2.5 transition-colors', {
+          'border-destructive/50': wrongButtonIndex !== undefined,
+          'border-muted-foreground/20': wrongButtonIndex === undefined,
+          'border-green-300/50 bg-green-600/5': allSelected && isCorrect,
+        })}
+      >
+        <div className="grid grid-cols-3 gap-1.5">
+          {mnemonicPhrase.map((_, index) => {
+            const word = selectedWords[index]
+            const isFilled = word !== undefined
+            return (
+              <div
+                key={index}
+                className={cn('flex items-center gap-0.5 rounded-md px-0.5 py-1.5 font-mono text-xs transition-all', {
+                  'bg-primary/10 text-primary border-primary/20 border': isFilled,
+                  'border-muted bg-muted/30 border border-dashed': !isFilled,
+                })}
+              >
+                <span
+                  className={cn('min-w-8 text-right tabular-nums', {
+                    'text-primary/50': isFilled,
+                    'text-muted-foreground/40': !isFilled,
+                  })}
+                >
+                  {index + 1}.
+                </span>
+                {isFilled ? (
+                  <span className="font-medium">{word}</span>
+                ) : (
+                  <span className="text-muted-foreground/30">···</span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+        {allSelected && isCorrect && (
+          <div className="mt-2.5 flex items-center justify-center gap-1.5 text-sm font-medium text-green-300">
+            <CheckCircle2Icon className="size-4" />
+            {t('create_wallet.verify_mnemonic.feedback_mnemonic_confirmed')}
+          </div>
+        )}
+      </div>
+
+      {!allSelected && (
+        <div className="grid grid-cols-3 gap-2">
+          {shuffledWords.map((word, index) => {
+            const isPicked = pickedIndicesSet.has(index)
+            const isWrong = wrongButtonIndex === index
+            return (
+              <Button
+                key={index}
+                type="button"
+                size="lg"
+                variant={isWrong ? 'destructive' : isPicked ? 'outline' : 'secondary'}
+                disabled={isPicked || wrongButtonIndex !== undefined}
+                className={cn('font-mono text-sm transition-all', {
+                  'pointer-events-none opacity-25': isPicked,
+                  'animate-shake': isWrong,
+                })}
+                onClick={() => handleWordClick(word, index)}
+              >
+                {isPicked ? '···' : word}
+              </Button>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          className={cn('flex-1', {
+            hidden: isCorrect,
+          })}
+          size="xxl"
+          onClick={onBack}
+          disabled={isCorrect || verifyMutation.isPending}
+        >
+          <ChevronLeftIcon />
+          {t('create_wallet.back_button')}
+        </Button>
+        {skipWalletBackupVerification && !isCorrect && (
+          <Button
+            type="button"
+            className="flex-1"
+            variant="secondary"
+            size="xxl"
+            onClick={() => verifyMutation.mutate({ mustBeCorrect: false })}
+          >
+            Skip <DevBadge />
+          </Button>
+        )}
+        <Button
+          type="button"
+          className="flex-1"
+          size="xxl"
+          disabled={!isCorrect || verifyMutation.isPending}
+          onClick={() => verifyMutation.mutate({ mustBeCorrect: true })}
+        >
+          {t('create_wallet.confirmation_button_fund_wallet')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/create/CreateWalletPage.tsx
+++ b/src/components/create/CreateWalletPage.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps } from 'react'
+import type { ComponentProps, PropsWithChildren } from 'react'
 import { useState } from 'react'
 import { listwalletsOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { type CreateWalletResponse, createwallet, session } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useQuery } from '@tanstack/react-query'
-import { CircleCheckBigIcon, WalletIcon } from 'lucide-react'
+import { CircleCheckBigIcon, ShieldCheckIcon, WalletIcon, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
@@ -21,10 +21,25 @@ import { jmSessionStore } from '@/store/jmSessionStore'
 import { AuthPageShell } from '../layout/AuthPageShell'
 import PreventLeavingPageByMistake from '../utils/PreventLeavingPageByMistake'
 import { CreateStepConfirm } from './CreateStepConfirm'
+import { CreateStepVerifyMnemonic } from './CreateStepVerifyMnemonic'
 import { CreateStepWalletDetails } from './CreateStepWalletDetails'
 import { CreateWalletForm } from './CreateWalletForm'
 
 type WalletDetailsValues = Parameters<ComponentProps<typeof CreateWalletForm>['onSubmit']>[0]
+
+const CreateWalletCard = ({ icon: Icon, title, children }: PropsWithChildren<{ icon: LucideIcon; title: string }>) => {
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="flex flex-col items-center space-y-2">
+        <div className="bg-primary/10 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
+          <Icon className="text-primary" />
+        </div>
+        <CardTitle className="text-xl font-bold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">{children}</CardContent>
+    </Card>
+  )
+}
 
 type CreateWalletSuccessInfo = {
   values: WalletDetailsValues
@@ -39,7 +54,7 @@ const CreateWalletPage = () => {
   const jmSession = useStore(jmSessionStore, (state) => state.state)
   const { clear: clearAuthState, update: updateAuthState } = useStore(authStore, (state) => state)
   const [createWalletSuccessInfo, setCreateWalletSuccessInfo] = useState<CreateWalletSuccessInfo>()
-  const [step, setStep] = useState<'wallet_details' | 'confirm'>('wallet_details')
+  const [step, setStep] = useState<'wallet_details' | 'confirm' | 'verify_mnemonic'>('wallet_details')
 
   const listWalletsQuery = useQuery({
     ...listwalletsOptions({ client }),
@@ -108,20 +123,26 @@ const CreateWalletPage = () => {
         response: createData,
         hashedPassword,
       })
+
       setStep('confirm')
     } catch (error: unknown) {
-      /* TODO: i18n */
       const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+      /* TODO: i18n */
       toast.error(`Failed to create wallet: ${reason}`)
     } finally {
       toast.dismiss(durationHintToastId)
     }
   }
 
-  const handleConfirmSeed = async ({ response, hashedPassword }: CreateWalletSuccessInfo) => {
+  const handleConfirmMnemonic = () => {
+    setStep('verify_mnemonic')
+    return Promise.resolve()
+  }
+
+  const handleMnemonicVerified = async ({ response, hashedPassword }: CreateWalletSuccessInfo) => {
     updateAuthState({
       walletFileName: response.walletname as WalletFileName,
-      auth: { token: response.token, refresh_token: response.refresh_token }, // We'll need to unlock it properly later
+      auth: { token: response.token, refresh_token: response.refresh_token },
       hashed_password: hashedPassword,
     })
 
@@ -130,42 +151,39 @@ const CreateWalletPage = () => {
 
   return (
     <AuthPageShell>
-      <Card className="w-full max-w-md">
-        <CardHeader className="flex flex-col items-center space-y-2">
-          <div className="bg-primary/10 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
-            {step === 'wallet_details' && <WalletIcon className="text-primary" />}
-            {step === 'confirm' && <CircleCheckBigIcon className="text-primary" />}
-          </div>
-          <CardTitle className="text-xl font-bold">
-            {step === 'wallet_details' && t('create_wallet.title')}
-            {step === 'confirm' && t('create_wallet.title_wallet_created')}
-          </CardTitle>
-        </CardHeader>
-
-        <CardContent className="space-y-6">
-          {step === 'wallet_details' && (
-            <CreateStepWalletDetails
-              wallets={(listWalletsQuery.data?.wallets ?? []) as WalletFileName[]}
-              onSubmit={handleCreateWallet}
-              sessionInfo={jmSession}
-              submitButtonText={({ isSubmitting }) =>
-                isSubmitting ? t('create_wallet.button_creating') : t('create_wallet.button_create')
-              }
-            />
-          )}
-          {step === 'confirm' && (
-            <>
-              <PreventLeavingPageByMistake />
-              <CreateStepConfirm
-                walletFileName={createWalletSuccessInfo!.response.walletname as WalletFileName}
-                password={createWalletSuccessInfo!.values.password}
-                mnemonicPhrase={createWalletSuccessInfo!.response.seedphrase?.split(/\s+/)}
-                onConfirm={async () => await handleConfirmSeed(createWalletSuccessInfo!)}
-              />
-            </>
-          )}
-        </CardContent>
-      </Card>
+      {step === 'wallet_details' && (
+        <CreateWalletCard icon={WalletIcon} title={t('create_wallet.title')}>
+          <CreateStepWalletDetails
+            wallets={(listWalletsQuery.data?.wallets ?? []) as WalletFileName[]}
+            onSubmit={handleCreateWallet}
+            sessionInfo={jmSession}
+            submitButtonText={({ isSubmitting }) =>
+              isSubmitting ? t('create_wallet.button_creating') : t('create_wallet.button_create')
+            }
+          />
+        </CreateWalletCard>
+      )}
+      {step === 'confirm' && (
+        <CreateWalletCard icon={CircleCheckBigIcon} title={t('create_wallet.title_wallet_created')}>
+          <PreventLeavingPageByMistake />
+          <CreateStepConfirm
+            walletFileName={createWalletSuccessInfo!.response.walletname as WalletFileName}
+            password={createWalletSuccessInfo!.values.password}
+            mnemonicPhrase={createWalletSuccessInfo!.response.seedphrase?.split(/\s+/)}
+            onConfirm={handleConfirmMnemonic}
+          />
+        </CreateWalletCard>
+      )}
+      {step === 'verify_mnemonic' && (
+        <CreateWalletCard icon={ShieldCheckIcon} title={t('create_wallet.verify_mnemonic.title')}>
+          <PreventLeavingPageByMistake />
+          <CreateStepVerifyMnemonic
+            mnemonicPhrase={createWalletSuccessInfo!.response.seedphrase?.split(/\s+/) ?? []}
+            onVerified={async () => await handleMnemonicVerified(createWalletSuccessInfo!)}
+            onBack={() => setStep('confirm')}
+          />
+        </CreateWalletCard>
+      )}
     </AuthPageShell>
   )
 }

--- a/src/components/create/CreateWalletPage.tsx
+++ b/src/components/create/CreateWalletPage.tsx
@@ -1,8 +1,13 @@
 import type { ComponentProps, PropsWithChildren } from 'react'
 import { useState } from 'react'
-import { listwalletsOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
-import { type CreateWalletResponse, createwallet, session } from '@joinmarket-webui/joinmarket-api-ts/jm'
-import { useQuery } from '@tanstack/react-query'
+import {
+  createwalletMutation,
+  listwalletsOptions,
+  sessionOptions,
+  unlockwalletMutation,
+} from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import { lockwallet } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { CircleCheckBigIcon, ShieldCheckIcon, WalletIcon, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -12,12 +17,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { JM_DEFAULT_WALLET_TYPE } from '@/constants/jm'
 import { routes } from '@/constants/routes'
 import { useApiClient } from '@/hooks/useApiClient'
+import { buildAuthHeaderMap, type ApiToken } from '@/lib/config'
 import { getErrorReason } from '@/lib/errorReason'
 import { hashPassword } from '@/lib/hash'
-import { walletDisplayName, walletDisplayNameToFileName } from '@/lib/utils'
+import { delayedPromise, walletDisplayName, walletDisplayNameToFileName } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { authStore } from '@/store/authStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
+import type { MnemonicPhrase } from '@/types/global'
 import { AuthPageShell } from '../layout/AuthPageShell'
 import PreventLeavingPageByMistake from '../utils/PreventLeavingPageByMistake'
 import { CreateStepConfirm } from './CreateStepConfirm'
@@ -42,8 +49,9 @@ const CreateWalletCard = ({ icon: Icon, title, children }: PropsWithChildren<{ i
 }
 
 type CreateWalletSuccessInfo = {
-  values: WalletDetailsValues
-  response: CreateWalletResponse
+  walletFileName: WalletFileName
+  password: WalletDetailsValues['password']
+  mnemonicPhrase: MnemonicPhrase
   hashedPassword?: string
 }
 
@@ -59,8 +67,37 @@ const CreateWalletPage = () => {
   const listWalletsQuery = useQuery({
     ...listwalletsOptions({ client }),
   })
+  const sessionQuery = useQuery({
+    ...sessionOptions({ client }),
+    enabled: false,
+  })
+  const createWalletMutation = useMutation({
+    ...createwalletMutation({ client }),
+    retry: false,
+  })
 
-  const handleCreateWallet = async ({ walletName, password, confirmPassword }: WalletDetailsValues) => {
+  const lockWalletMutation = useMutation({
+    mutationFn: async (parameters: { walletFileName: WalletFileName; token: ApiToken }) => {
+      const { data } = await lockwallet({
+        client,
+        path: { walletname: encodeURIComponent(parameters.walletFileName) },
+        headers: { ...buildAuthHeaderMap(parameters.token) },
+        throwOnError: true,
+      })
+      return data
+    },
+    retry: false,
+  })
+
+  const unlockWalletMutation = useMutation({
+    ...unlockwalletMutation({
+      client,
+      throwOnError: true,
+    }),
+    retry: false,
+  })
+
+  const handleCreateWallet = async ({ walletName, password }: WalletDetailsValues) => {
     const durationHintToastId = toast.loading(t('create_wallet.hint_duration_text'), {
       id: 'alert-wallet-create-creating-duration-hint',
       duration: Number.POSITIVE_INFINITY,
@@ -70,9 +107,9 @@ const CreateWalletPage = () => {
       // Clear any existing local session
       clearAuthState()
 
-      // Check if there's an active session on the server
+      // Step #1: Check if there's an active session on the server
       try {
-        const { data: sessionInfo } = await session({ client })
+        const { data: sessionInfo } = await sessionQuery.refetch()
         if (sessionInfo?.session === true) {
           console.warn('Active session detected:', sessionInfo)
           // TODO: i18n
@@ -95,20 +132,31 @@ const CreateWalletPage = () => {
           )
           return
         }
-      } catch (sessionError) {
+      } catch (sessionError: unknown) {
         console.warn('Could not check session status:', sessionError)
         // Continue anyway, wallet creation might still work
       }
 
+      // Step #2: create wallet
       const walletFileName = walletDisplayNameToFileName(walletName)
-      const { data: createData } = await createwallet({
-        client,
+      const createData = await createWalletMutation.mutateAsync({
         body: {
-          walletname: walletFileName,
+          walletname: encodeURIComponent(walletFileName),
           password,
           wallettype: JM_DEFAULT_WALLET_TYPE,
         },
         throwOnError: true,
+      })
+
+      // Step #3: lock wallet
+      // since wallet is immediately unlocked, let's lock the wallet here.
+      // The token is only a valid certain amount of time, and the user
+      // might take longer than the validitiy time.
+      // after the mnemonic phrase is confirmed, we unlock the wallet again.
+      await delayedPromise(210) // wait some time before locking
+      await lockWalletMutation.mutateAsync({
+        walletFileName,
+        token: createData.token,
       })
 
       let hashedPassword: string | undefined = undefined
@@ -119,9 +167,10 @@ const CreateWalletPage = () => {
       }
 
       setCreateWalletSuccessInfo({
-        values: { walletName, password, confirmPassword },
-        response: createData,
+        walletFileName,
+        password,
         hashedPassword,
+        mnemonicPhrase: createData.seedphrase.split(/\s+/),
       })
 
       setStep('confirm')
@@ -139,14 +188,28 @@ const CreateWalletPage = () => {
     return Promise.resolve()
   }
 
-  const handleMnemonicVerified = async ({ response, hashedPassword }: CreateWalletSuccessInfo) => {
-    updateAuthState({
-      walletFileName: response.walletname as WalletFileName,
-      auth: { token: response.token, refresh_token: response.refresh_token },
-      hashed_password: hashedPassword,
-    })
+  const handleMnemonicVerified = async ({ walletFileName, password, hashedPassword }: CreateWalletSuccessInfo) => {
+    try {
+      const response = await unlockWalletMutation.mutateAsync({
+        path: { walletname: encodeURIComponent(walletFileName) },
+        body: {
+          password,
+        },
+      })
+      updateAuthState({
+        walletFileName: response.walletname as WalletFileName,
+        auth: { token: response.token, refresh_token: response.refresh_token },
+        hashed_password: hashedPassword,
+      })
 
-    await navigate(routes.home)
+      await navigate(routes.home)
+    } catch (error: unknown) {
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+      /* TODO: i18n */
+      toast.error(`Failed to unlock wallet: ${reason}`)
+
+      await navigate(routes.login)
+    }
   }
 
   return (
@@ -167,9 +230,9 @@ const CreateWalletPage = () => {
         <CreateWalletCard icon={CircleCheckBigIcon} title={t('create_wallet.title_wallet_created')}>
           <PreventLeavingPageByMistake />
           <CreateStepConfirm
-            walletFileName={createWalletSuccessInfo!.response.walletname as WalletFileName}
-            password={createWalletSuccessInfo!.values.password}
-            mnemonicPhrase={createWalletSuccessInfo!.response.seedphrase?.split(/\s+/)}
+            walletFileName={createWalletSuccessInfo!.walletFileName}
+            password={createWalletSuccessInfo!.password}
+            mnemonicPhrase={createWalletSuccessInfo!.mnemonicPhrase}
             onConfirm={handleConfirmMnemonic}
           />
         </CreateWalletCard>
@@ -178,7 +241,7 @@ const CreateWalletPage = () => {
         <CreateWalletCard icon={ShieldCheckIcon} title={t('create_wallet.verify_mnemonic.title')}>
           <PreventLeavingPageByMistake />
           <CreateStepVerifyMnemonic
-            mnemonicPhrase={createWalletSuccessInfo!.response.seedphrase?.split(/\s+/) ?? []}
+            mnemonicPhrase={createWalletSuccessInfo!.mnemonicPhrase}
             onVerified={async () => await handleMnemonicVerified(createWalletSuccessInfo!)}
             onBack={() => setStep('confirm')}
           />

--- a/src/components/create/CreateWalletPage.tsx
+++ b/src/components/create/CreateWalletPage.tsx
@@ -141,7 +141,7 @@ const CreateWalletPage = () => {
       const walletFileName = walletDisplayNameToFileName(walletName)
       const createData = await createWalletMutation.mutateAsync({
         body: {
-          walletname: encodeURIComponent(walletFileName),
+          walletname: walletFileName,
           password,
           wallettype: JM_DEFAULT_WALLET_TYPE,
         },
@@ -151,13 +151,18 @@ const CreateWalletPage = () => {
       // Step #3: lock wallet
       // since wallet is immediately unlocked, let's lock the wallet here.
       // The token is only a valid certain amount of time, and the user
-      // might take longer than the validitiy time.
-      // after the mnemonic phrase is confirmed, we unlock the wallet again.
-      await delayedPromise(210) // wait some time before locking
-      await lockWalletMutation.mutateAsync({
-        walletFileName,
-        token: createData.token,
-      })
+      // might take longer for the next steps than the token is valid.
+      // After the mnemonic phrase is confirmed, we unlock the wallet again.
+      try {
+        await delayedPromise(210) // wait some time before locking
+        await lockWalletMutation.mutateAsync({
+          walletFileName,
+          token: createData.token,
+        })
+      } catch (_ignoredOnPurpose: unknown) {
+        // user might face some problem afterwards, but can still write down the mnemonic phrase
+        console.warn('Locking wallet after creation failed, continuing with create flow anyway!')
+      }
 
       let hashedPassword: string | undefined = undefined
       try {
@@ -196,6 +201,7 @@ const CreateWalletPage = () => {
           password,
         },
       })
+
       updateAuthState({
         walletFileName: response.walletname as WalletFileName,
         auth: { token: response.token, refresh_token: response.refresh_token },

--- a/src/components/import/ImportStepConfirm.tsx
+++ b/src/components/import/ImportStepConfirm.tsx
@@ -107,7 +107,7 @@ export const ImportStepConfirm = ({
           <Accordion type="single" collapsible>
             <AccordionItem value="mnemonic">
               <AccordionTrigger>{t('import_wallet.import_details.label_menmonic_phrase')}</AccordionTrigger>
-              <AccordionContent className="bg-muted rounded-lg p-2">
+              <AccordionContent className="bg-muted mb-2 rounded-lg p-2">
                 <SeedPhraseGrid value={importDetails.mnemonicPhrase.split(/\s+/)} masked={!revealSensitiveInfo} />
               </AccordionContent>
             </AccordionItem>

--- a/src/components/import/ImportWalletPage.tsx
+++ b/src/components/import/ImportWalletPage.tsx
@@ -215,7 +215,6 @@ const ImportWalletPage = () => {
 
       const unlockResponse = await unlockWallet.mutateAsync({
         path: { walletname: encodeURIComponent(authState.walletFileName) },
-        headers: { ...buildAuthHeaderMap(authState.auth.token) },
         body: {
           password: walletDetails.password,
         },

--- a/src/components/orderbook/OrderbookChart.tsx
+++ b/src/components/orderbook/OrderbookChart.tsx
@@ -4,83 +4,83 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import type { OrderTableEntry } from './OrderbookTable'
 
 interface FeeBucket {
-    label: string
-    min: number
-    max: number
-    count: number
+  label: string
+  min: number
+  max: number
+  count: number
 }
 
 const FEE_RANGES = [
-    { min: 0, max: 100 },
-    { min: 100, max: 500 },
-    { min: 500, max: 1_000 },
-    { min: 1_000, max: 5_000 },
-    { min: 5_000, max: 10_000 },
-    { min: 10_000, max: Number.POSITIVE_INFINITY },
+  { min: 0, max: 100 },
+  { min: 100, max: 500 },
+  { min: 500, max: 1_000 },
+  { min: 1_000, max: 5_000 },
+  { min: 5_000, max: 10_000 },
+  { min: 10_000, max: Number.POSITIVE_INFINITY },
 ]
 
 const bucketByFeeRange = (entries: OrderTableEntry[]): FeeBucket[] => {
-    const absoluteOffers = entries.filter((entry) => entry.type.isAbsolute)
-    if (absoluteOffers.length === 0) return []
+  const absoluteOffers = entries.filter((entry) => entry.type.isAbsolute)
+  if (absoluteOffers.length === 0) return []
 
-    return FEE_RANGES.map(({ min, max }) => {
-        const count = absoluteOffers.filter((offer) => offer.fee.value >= min && offer.fee.value < max).length
-        const label =
-            max === Number.POSITIVE_INFINITY ? `${min.toLocaleString()}+` : `${min.toLocaleString()} – ${max.toLocaleString()}`
-        return { label, min, max, count }
-    }).filter((bucket) => bucket.count > 0)
+  return FEE_RANGES.map(({ min, max }) => {
+    const count = absoluteOffers.filter((offer) => offer.fee.value >= min && offer.fee.value < max).length
+    const label =
+      max === Number.POSITIVE_INFINITY
+        ? `${min.toLocaleString()}+`
+        : `${min.toLocaleString()} – ${max.toLocaleString()}`
+    return { label, min, max, count }
+  }).filter((bucket) => bucket.count > 0)
 }
 
 interface OrderbookChartProps {
-    entries: OrderTableEntry[]
+  entries: OrderTableEntry[]
 }
 
 export const OrderbookChart = ({ entries }: OrderbookChartProps) => {
-    const { t } = useTranslation()
-    const buckets = useMemo(() => bucketByFeeRange(entries), [entries])
-    const maxCount = useMemo(() => Math.max(...buckets.map((bucket) => bucket.count), 1), [buckets])
+  const { t } = useTranslation()
+  const buckets = useMemo(() => bucketByFeeRange(entries), [entries])
+  const maxCount = useMemo(() => Math.max(...buckets.map((bucket) => bucket.count), 1), [buckets])
 
-    if (buckets.length === 0) {
-        return null
-    }
+  if (buckets.length === 0) {
+    return null
+  }
 
-    return (
-        <div className="space-y-2">
-            <div className="text-muted-foreground text-xs font-medium">{t('orderbook.chart_title')}</div>
-            <TooltipProvider delayDuration={0}>
-                <div className="flex h-24 items-end gap-px">
-                    {buckets.map((bucket) => {
-                        const heightPercent = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0
+  return (
+    <div className="space-y-2">
+      <div className="text-muted-foreground text-xs font-medium">{t('orderbook.chart_title')}</div>
+      <TooltipProvider delayDuration={0}>
+        <div className="flex h-24 items-end gap-px">
+          {buckets.map((bucket) => {
+            const heightPercent = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0
 
-                        return (
-                            <Tooltip key={bucket.label}>
-                                <TooltipTrigger asChild>
-                                    <div className="flex min-w-0 flex-1 cursor-pointer flex-col justify-end" style={{ height: '100%' }}>
-                                        <div
-                                            className="bg-primary/70 hover:bg-primary rounded-t-sm transition-colors"
-                                            style={{ height: `${Math.max(heightPercent, bucket.count > 0 ? 4 : 0)}%` }}
-                                        />
-                                    </div>
-                                </TooltipTrigger>
-                                <TooltipContent side="top" className="text-xs">
-                                    <div className="font-medium">{bucket.label} sats</div>
-                                    <div>
-                                        {t('orderbook.chart_tooltip_offers', { count: bucket.count })}
-                                    </div>
-                                </TooltipContent>
-                            </Tooltip>
-                        )
-                    })}
-                </div>
-                <div className="text-muted-foreground flex justify-between text-[10px]">
-                    {buckets.length > 0 && (
-                        <>
-                            <span>{buckets[0].label}</span>
-                            {buckets.length > 1 && <span>{buckets.at(-1)?.label}</span>}
-                        </>
-                    )}
-                </div>
-            </TooltipProvider>
+            return (
+              <Tooltip key={bucket.label}>
+                <TooltipTrigger asChild>
+                  <div className="flex min-w-0 flex-1 cursor-pointer flex-col justify-end" style={{ height: '100%' }}>
+                    <div
+                      className="bg-primary/70 hover:bg-primary rounded-t-sm transition-colors"
+                      style={{ height: `${Math.max(heightPercent, bucket.count > 0 ? 4 : 0)}%` }}
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  <div className="font-medium">{bucket.label} sats</div>
+                  <div>{t('orderbook.chart_tooltip_offers', { count: bucket.count })}</div>
+                </TooltipContent>
+              </Tooltip>
+            )
+          })}
         </div>
-    )
+        <div className="text-muted-foreground flex justify-between text-[10px]">
+          {buckets.length > 0 && (
+            <>
+              <span>{buckets[0].label}</span>
+              {buckets.length > 1 && <span>{buckets.at(-1)?.label}</span>}
+            </>
+          )}
+        </div>
+      </TooltipProvider>
+    </div>
+  )
 }

--- a/src/constants/debugFeatures.ts
+++ b/src/constants/debugFeatures.ts
@@ -2,7 +2,7 @@ interface DebugFeatures {
   developerMode: boolean
   insecureScheduleTesting: boolean
   allowCreatingExpiredFidelityBond: boolean
-  skipWalletBackupConfirmation: boolean
+  skipWalletBackupVerification: boolean
   devErrorExamplePage: boolean
   devPage: boolean
   devSetupPage: boolean
@@ -18,7 +18,7 @@ const debugFeatures: DebugFeatures = {
   developerMode: developmentMode,
   allowCreatingExpiredFidelityBond: developmentMode,
   insecureScheduleTesting: developmentMode,
-  skipWalletBackupConfirmation: developmentMode,
+  skipWalletBackupVerification: developmentMode,
   devErrorExamplePage: developmentMode,
   devPage: developmentMode,
   devSetupPage: developmentMode,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -168,12 +168,18 @@
     "confirmation_button_fund_wallet": "Fund Wallet",
     "confirm_backup_title": "Confirm seed phrase backup",
     "confirm_backup_subtitle": "Enter each word in sequential order.",
-    "feedback_seed_confirmed": "Seed phrase confirmed.",
     "back_button": "Back",
     "skip_button": "Skip",
     "next_button": "Next",
     "placeholder_seed_word_input": "Word",
-    "hint_duration_text": "Please be patient, this may take a few minutes."
+    "hint_duration_text": "Please be patient, this may take a few minutes.",
+    "verify_mnemonic": {
+      "title": "Verify Mnemonic Phrase",
+      "subtitle": "Tap each word in the correct order to verify you have backed up your mnemonic phrase.",
+      "progress": "{{ current }} of {{ total }}",
+      "error": "Wrong order! Please try again.",
+      "feedback_mnemonic_confirmed": "Mnemonic phrase confirmed."
+    }
   },
   "import_wallet": {
     "alert_other_wallet_unlocked": "Currently <1>{{ walletName }}</1> is active. You need to lock it first. <3>Go back</3>.",

--- a/src/index.css
+++ b/src/index.css
@@ -146,3 +146,32 @@ html body[data-scroll-locked] {
 .animate-slide-down {
   animation: slide-down 0.3s ease-in-out forwards;
 }
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  15% {
+    transform: translateX(-4px);
+  }
+  30% {
+    transform: translateX(4px);
+  }
+  45% {
+    transform: translateX(-4px);
+  }
+  60% {
+    transform: translateX(4px);
+  }
+  75% {
+    transform: translateX(-2px);
+  }
+  90% {
+    transform: translateX(2px);
+  }
+}
+
+.animate-shake {
+  animation: shake 0.4s ease-in-out;
+}

--- a/src/stories/jam/pages/create/CreateStepVerifyMnemonic.stories.tsx
+++ b/src/stories/jam/pages/create/CreateStepVerifyMnemonic.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CreateStepVerifyMnemonic } from '@/components/create/CreateStepVerifyMnemonic'
+import { DUMMY_SEED_PHRASE } from '@/lib/utils'
+
+const meta: Meta<typeof CreateStepVerifyMnemonic> = {
+  title: 'Page/Create/CreateStepVerifyMnemonic',
+  component: CreateStepVerifyMnemonic,
+  tags: ['autodocs'],
+  args: {
+    onVerified: async () => alert('Verified clicked!'),
+    onBack: () => alert('Back clicked!'),
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof CreateStepVerifyMnemonic>
+
+export const Default: Story = {
+  args: {
+    mnemonicPhrase: DUMMY_SEED_PHRASE,
+  },
+}


### PR DESCRIPTION
Adds a mnemonic verification step in the create wallet flow.
Additionally, it locks the wallet after creation, in order to not run into a session timeout.

## How to test
See the [storybook for `CreateStepVerifyMnemonic` component](http://localhost:6006/?path=/docs/page-create-createstepverifymnemonic--docs), or manually test the create flow in dev mode.

## :camera_flash: 

<img width="250" alt="image" src="https://github.com/user-attachments/assets/75eb9825-cc2d-41db-8665-7e3955bba80e" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/c4266fe7-ad97-4493-8209-a3c3191370ef" />
