### PR TITLE
feat(send): utxo selection in send with address-grouped freeze/unfreeze

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -26,6 +26,7 @@ import type { Utxo } from '@/hooks/useQueryUtxos'
 import type { FeeConfigValues } from '@/hooks/useFeeConfigValidation'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { parseBip21Uri, type Bip21ParseResult } from '@/lib/bip21'
+import * as fb from '@/lib/fidelityBondUtils'
 import { utxoTags } from '@/lib/tags'
 import {
   cn,
@@ -385,7 +386,7 @@ export function SendForm({
 
   const defaultUtxoRowSelection = useMemo<RowSelectionState>(() => {
     return (sourceJar?.utxos || []).reduce((acc, utxo) => {
-      if (utxo.frozen === false && utxo.locktime === undefined) {
+      if (utxo.frozen === false && !fb.utxo.isFidelityBond(utxo)) {
         acc[utxo.utxo] = true
       }
       return acc
@@ -450,7 +451,7 @@ export function SendForm({
     // Keep same-address UTXOs together to avoid accidental privacy leaks.
     const selectedUtxoIds = new Set(selectedSourceJarUtxos.map((it) => it.utxo))
     const selectedAddresses = new Set(selectedSourceJarUtxos.map((it) => it.address))
-    const mutableUtxos = sourceJar.utxos.filter((it) => it.locktime === undefined)
+    const mutableUtxos = sourceJar.utxos.filter((it) => !fb.utxo.isFidelityBond(it))
     const groupedSelectedUtxos = mutableUtxos.filter((it) => selectedAddresses.has(it.address))
     const groupedDeselectedUtxos = mutableUtxos.filter((it) => !selectedAddresses.has(it.address))
     const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
@@ -623,7 +624,7 @@ export function SendForm({
               pinnedEntries={[]}
               initialRowSelection={defaultUtxoRowSelection}
               onRowSelectionChange={setUtxoRowSelection}
-              enableRowSelection={(row) => row.original.utxo.locktime === undefined}
+              enableRowSelection={(row) => !fb.utxo.isFidelityBond(row.original.utxo)}
             />
           </div>
 

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -4,7 +4,7 @@ import { getaddress, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-
 import { getAddressInfo, validate as isValidBitcoinAddress, Network } from 'bitcoin-address-validation'
 import type { AddressInfo } from 'bitcoin-address-validation'
 import type { TFunction } from 'i18next'
-import { BrushCleaningIcon, ListFilterIcon, MilkIcon, ScanQrCodeIcon, XIcon } from 'lucide-react'
+import { BrushCleaningIcon, MilkIcon, ScanQrCodeIcon, XIcon } from 'lucide-react'
 import { useForm, useWatch } from 'react-hook-form'
 import type { Resolver, SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -13,11 +13,7 @@ import * as yup from 'yup'
 import QrScannerDialog from '@/components/ui/QrScannerDialog'
 import { isDevMode } from '@/constants/debugFeatures'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '@/constants/jm'
-import {
-  useDetectNetwork,
-  type AddressSummary,
-  type Jar,
-} from '@/context/JamWalletInfoContext'
+import { useDetectNetwork, type AddressSummary, type Jar } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { FeeConfigValues } from '@/hooks/useFeeConfigValidation'
 import type { BalanceSummary } from '@/lib/balanceSummary'
@@ -281,8 +277,7 @@ interface SendFormProps {
   className?: string
   onSubmit: SubmitHandler<SendFormValues>
   onSourceJarChange?: (jarIndex: JarIndex | undefined) => void
-  onOpenUtxoSelector?: () => void
-  utxoSelectorDisabled?: boolean
+  sourceJarLabelButton?: React.ReactElement
   minNumberOfCollaborators?: number
   feeConfigValues?: FeeConfigValues
   forceCoinJoinEnabled?: boolean
@@ -298,8 +293,7 @@ export function SendForm({
   className,
   onSubmit,
   onSourceJarChange,
-  onOpenUtxoSelector,
-  utxoSelectorDisabled = false,
+  sourceJarLabelButton,
   disabled,
   feeConfigValues,
   forceCoinJoinEnabled = false,
@@ -461,16 +455,7 @@ export function SendForm({
           <Field className="space-y-4" data-invalid={errors.source !== undefined}>
             <div className="flex items-center justify-between gap-2">
               <FieldLabel>{t('send.label_source_jar')}</FieldLabel>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={disabled || utxoSelectorDisabled}
-                onClick={() => onOpenUtxoSelector?.()}
-              >
-                <ListFilterIcon />
-                {t('show_utxos.text_select_utxos_tooltip')}
-              </Button>
+              {sourceJarLabelButton && <>{sourceJarLabelButton}</>}
             </div>
             <div className="grid grid-cols-5 gap-4">
               {jars.map((jar, index) => (
@@ -498,10 +483,7 @@ export function SendForm({
                       void trigger('destination.address')
                     }
                   }}
-                  disabled={
-                    disabled ||
-                    jar.balanceSummary.calculatedAvailableBalanceInSats <= 0
-                  }
+                  disabled={disabled || jar.balanceSummary.calculatedAvailableBalanceInSats <= 0}
                 />
               ))}
             </div>

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -121,6 +121,7 @@ const initialNumberOfCollaborators = (minValue: number): number => {
 const DEV_INITIAL_NUM_COLLABORATORS_INPUT = 1
 
 const MAX_NUM_COLLABORATORS = 99
+const SEND_AUTO_SELECTION_TOAST_ID = 'send.utxo.selection_changed_automatically'
 
 // TODO: this value should be dynamic via jm backend settings
 const MIN_NUM_COLLABORATORS = isDevMode() ? DEV_INITIAL_NUM_COLLABORATORS_INPUT : JM_MINIMUM_MAKERS_DEFAULT
@@ -439,6 +440,7 @@ export function SendForm({
 
   const openUtxoSelectorDialog = useCallback(() => {
     if (!sourceJar) return
+    toast.dismiss(SEND_AUTO_SELECTION_TOAST_ID)
     setUtxoFilter('')
     setUtxoRowSelection(defaultUtxoRowSelection)
     setShowUtxoSelectorDialog(true)
@@ -458,12 +460,14 @@ export function SendForm({
     if (groupedSelectedUtxos.length > selectedSourceJarUtxos.length) {
       toast.warning(`Security measure: Selection changed`, {
         description: `Automatically selected ${groupedSelectedUtxos.length - selectedSourceJarUtxos.length} additional UTXOs with matching addresses.`,
+        id: SEND_AUTO_SELECTION_TOAST_ID,
       })
     }
 
     if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
       toast.warning(`Security measure: Selection changed`, {
         description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
+        id: SEND_AUTO_SELECTION_TOAST_ID,
       })
     }
 

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -1,9 +1,6 @@
-import { useCallback, useMemo, useState, type ComponentProps } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ComponentProps } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { freezeMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { getaddress, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
-import { useMutation } from '@tanstack/react-query'
-import type { RowSelectionState } from '@tanstack/react-table'
 import { getAddressInfo, validate as isValidBitcoinAddress, Network } from 'bitcoin-address-validation'
 import type { AddressInfo } from 'bitcoin-address-validation'
 import type { TFunction } from 'i18next'
@@ -22,12 +19,9 @@ import {
   type Jar,
 } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
-import type { Utxo } from '@/hooks/useQueryUtxos'
 import type { FeeConfigValues } from '@/hooks/useFeeConfigValidation'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { parseBip21Uri, type Bip21ParseResult } from '@/lib/bip21'
-import * as fb from '@/lib/fidelityBondUtils'
-import { utxoTags } from '@/lib/tags'
 import {
   cn,
   delayedPromise,
@@ -54,10 +48,8 @@ import { SelectableJar } from '../ui/jam/SelectableJar'
 import { Label } from '../ui/label'
 import { Spinner } from '../ui/spinner'
 import { Switch } from '../ui/switch'
-import type { UtxoTableEntry } from '../wallet/JarUtxosTable'
 import JarSelectorDialog from './JarSelectorDialog'
 import { SendCoinjoinPreconditionAlert } from './SendCoinjoinPreconditionAlert'
-import { UtxoSelectionDialog } from './UtxoSelectionDialog'
 import { estimateMaxCollaboratorFee } from './feeEstimate'
 import type { SendFormValues } from './types'
 
@@ -102,13 +94,6 @@ const AddressFromJarSelectorDialog = ({
   )
 }
 
-const utxoToTableEntry = (utxo: Utxo, addressSummary: AddressSummary, t: TFunction): UtxoTableEntry => {
-  return {
-    utxo,
-    tags: utxoTags(utxo, addressSummary, t),
-  }
-}
-
 const initialNumberOfCollaborators = (minValue: number): number => {
   if (minValue > 8) {
     return minValue + pseudoRandomInteger(0, 2)
@@ -121,7 +106,6 @@ const initialNumberOfCollaborators = (minValue: number): number => {
 const DEV_INITIAL_NUM_COLLABORATORS_INPUT = 1
 
 const MAX_NUM_COLLABORATORS = 99
-const SEND_AUTO_SELECTION_TOAST_ID = 'send.utxo.selection_changed_automatically'
 
 // TODO: this value should be dynamic via jm backend settings
 const MIN_NUM_COLLABORATORS = isDevMode() ? DEV_INITIAL_NUM_COLLABORATORS_INPUT : JM_MINIMUM_MAKERS_DEFAULT
@@ -296,6 +280,9 @@ const FieldPrefixSatSymbol = (
 interface SendFormProps {
   className?: string
   onSubmit: SubmitHandler<SendFormValues>
+  onSourceJarChange?: (jarIndex: JarIndex | undefined) => void
+  onOpenUtxoSelector?: () => void
+  utxoSelectorDisabled?: boolean
   minNumberOfCollaborators?: number
   feeConfigValues?: FeeConfigValues
   forceCoinJoinEnabled?: boolean
@@ -310,6 +297,9 @@ interface SendFormProps {
 export function SendForm({
   className,
   onSubmit,
+  onSourceJarChange,
+  onOpenUtxoSelector,
+  utxoSelectorDisabled = false,
   disabled,
   feeConfigValues,
   forceCoinJoinEnabled = false,
@@ -321,13 +311,9 @@ export function SendForm({
   debug,
 }: SendFormProps) {
   const { t } = useTranslation()
-  const client = useApiClient()
 
   const [showAddressFromJarSelectorDialog, setShowAddressFromJarSelectorDialog] = useState(false)
   const [showQrScannerDialog, setShowQrScannerDialog] = useState(false)
-  const [showUtxoSelectorDialog, setShowUtxoSelectorDialog] = useState(false)
-  const [utxoFilter, setUtxoFilter] = useState('')
-  const [utxoRowSelection, setUtxoRowSelection] = useState<RowSelectionState>({})
   const [bip21Message, setBip21Message] = useState<string>()
 
   const { network } = useDetectNetwork()
@@ -380,136 +366,9 @@ export function SendForm({
     return jars.find((it) => it.jarIndex === sourceJarIndex)
   }, [jars, sourceJarIndex])
 
-  const sourceJarTableEntries = useMemo(() => {
-    return (sourceJar?.utxos || []).map((it) => utxoToTableEntry(it, addressSummary, t))
-  }, [addressSummary, sourceJar?.utxos, t])
-
-  const defaultUtxoRowSelection = useMemo<RowSelectionState>(() => {
-    return (sourceJar?.utxos || []).reduce((acc, utxo) => {
-      if (utxo.frozen === false && !fb.utxo.isFidelityBond(utxo)) {
-        acc[utxo.utxo] = true
-      }
-      return acc
-    }, {} as RowSelectionState)
-  }, [sourceJar?.utxos])
-
-  const selectedSourceJarUtxos = useMemo(() => {
-    return (sourceJar?.utxos || []).filter((utxo) => utxoRowSelection[utxo.utxo] === true)
-  }, [sourceJar?.utxos, utxoRowSelection])
-
-  const { mutateAsync: freezeOrUnfreezeUtxoMutateAsync } = useMutation({
-    ...freezeMutation({ client }),
-    retry: false,
-  })
-
-  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isApplyingUtxoSelection } = useMutation({
-    mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
-      const [freezeResult, unfreezeResult] = await Promise.all([
-        Promise.allSettled(
-          utxosToFreeze.map((utxo) =>
-            freezeOrUnfreezeUtxoMutateAsync({
-              path: {
-                walletname: encodeURIComponent(walletFileName),
-              },
-              body: {
-                'utxo-string': utxo.utxo,
-                freeze: true,
-              },
-            }),
-          ),
-        ),
-        Promise.allSettled(
-          utxosToUnfreeze.map((utxo) =>
-            freezeOrUnfreezeUtxoMutateAsync({
-              path: {
-                walletname: encodeURIComponent(walletFileName),
-              },
-              body: {
-                'utxo-string': utxo.utxo,
-                freeze: false,
-              },
-            }),
-          ),
-        ),
-      ])
-
-      return { freezeResult, unfreezeResult }
-    },
-  })
-
-  const openUtxoSelectorDialog = useCallback(() => {
-    if (!sourceJar) return
-    toast.dismiss(SEND_AUTO_SELECTION_TOAST_ID)
-    setUtxoFilter('')
-    setUtxoRowSelection(defaultUtxoRowSelection)
-    setShowUtxoSelectorDialog(true)
-  }, [defaultUtxoRowSelection, sourceJar])
-
-  const onApplyUtxoSelection = useCallback(async () => {
-    if (!sourceJar) return
-
-    // Keep same-address UTXOs together to avoid accidental privacy leaks.
-    const selectedUtxoIds = new Set(selectedSourceJarUtxos.map((it) => it.utxo))
-    const selectedAddresses = new Set(selectedSourceJarUtxos.map((it) => it.address))
-    const mutableUtxos = sourceJar.utxos.filter((it) => !fb.utxo.isFidelityBond(it))
-    const groupedSelectedUtxos = mutableUtxos.filter((it) => selectedAddresses.has(it.address))
-    const groupedDeselectedUtxos = mutableUtxos.filter((it) => !selectedAddresses.has(it.address))
-    const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
-
-    if (groupedSelectedUtxos.length > selectedSourceJarUtxos.length) {
-      toast.warning(`Security measure: Selection changed`, {
-        description: `Automatically selected ${groupedSelectedUtxos.length - selectedSourceJarUtxos.length} additional UTXOs with matching addresses.`,
-        id: SEND_AUTO_SELECTION_TOAST_ID,
-      })
-    }
-
-    if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
-      toast.warning(`Security measure: Selection changed`, {
-        description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
-        id: SEND_AUTO_SELECTION_TOAST_ID,
-      })
-    }
-
-    // The selected set should remain spendable; everything else becomes frozen.
-    const utxosToFreeze = mutableUtxos.filter((it) => !selectedAddresses.has(it.address) && it.frozen === false)
-    const utxosToUnfreeze = mutableUtxos.filter((it) => selectedAddresses.has(it.address) && it.frozen === true)
-
-    if (utxosToFreeze.length === 0 && utxosToUnfreeze.length === 0) {
-      setShowUtxoSelectorDialog(false)
-      return
-    }
-
-    try {
-      const result = await applyUtxoSelectionMutateAsync({ utxosToFreeze, utxosToUnfreeze })
-
-      if (utxosToFreeze.length > 0) {
-        const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
-        if (rejected.length === 0) {
-          toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: utxosToFreeze.length }))
-        } else {
-          toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length }))
-        }
-      }
-
-      if (utxosToUnfreeze.length > 0) {
-        const rejected = result.unfreezeResult.filter((it) => it.status === 'rejected')
-        if (rejected.length === 0) {
-          toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: utxosToUnfreeze.length }))
-        } else {
-          toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length }))
-        }
-      }
-
-      setShowUtxoSelectorDialog(false)
-    } catch (_ignoredOnPurpose) {
-      if (utxosToFreeze.length > 0) {
-        toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: utxosToFreeze.length }))
-      }
-      if (utxosToUnfreeze.length > 0) {
-        toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
-      }
-    }
-  }, [applyUtxoSelectionMutateAsync, selectedSourceJarUtxos, sourceJar, t])
+  useEffect(() => {
+    onSourceJarChange?.(sourceJarIndex)
+  }, [onSourceJarChange, sourceJarIndex])
 
   const destinationJar = useMemo(() => {
     if (destinationJarIndex === undefined) return
@@ -597,22 +456,6 @@ export function SendForm({
         }}
       />
       <QrScannerDialog open={showQrScannerDialog} onOpenChange={setShowQrScannerDialog} onScan={applyBip21Result} />
-      <UtxoSelectionDialog
-        open={showUtxoSelectorDialog}
-        isApplying={isApplyingUtxoSelection}
-        selectedCount={selectedSourceJarUtxos.length}
-        filter={utxoFilter}
-        tableEntries={sourceJarTableEntries}
-        initialRowSelection={defaultUtxoRowSelection}
-        enableRowSelection={(row) => !fb.utxo.isFidelityBond(row.original.utxo)}
-        onOpenChange={(open) => {
-          if (isApplyingUtxoSelection) return
-          setShowUtxoSelectorDialog(open)
-        }}
-        onFilterChange={setUtxoFilter}
-        onRowSelectionChange={setUtxoRowSelection}
-        onApply={() => void onApplyUtxoSelection()}
-      />
       <form onSubmit={(event) => void doOnSubmit(event)} className={cn('flex flex-col gap-4', className)} noValidate>
         <div className="space-y-2">
           <Field className="space-y-4" data-invalid={errors.source !== undefined}>
@@ -622,13 +465,8 @@ export function SendForm({
                 type="button"
                 size="sm"
                 variant="outline"
-                disabled={
-                  disabled ||
-                  sourceJar === undefined ||
-                  sourceJar.utxos.length === 0 ||
-                  isApplyingUtxoSelection
-                }
-                onClick={openUtxoSelectorDialog}
+                disabled={disabled || utxoSelectorDisabled}
+                onClick={() => onOpenUtxoSelector?.()}
               >
                 <ListFilterIcon />
                 {t('show_utxos.text_select_utxos_tooltip')}
@@ -662,7 +500,6 @@ export function SendForm({
                   }}
                   disabled={
                     disabled ||
-                    isApplyingUtxoSelection ||
                     jar.balanceSummary.calculatedAvailableBalanceInSats <= 0
                   }
                 />

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -44,7 +44,6 @@ import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { ButtonGroup } from '../ui/button-group'
 import { Card, CardContent, CardHeader } from '../ui/card'
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Field, FieldLabel } from '../ui/field'
 import { Input } from '../ui/input'
 import { inputVariants } from '../ui/input-variants'
@@ -55,9 +54,10 @@ import { SelectableJar } from '../ui/jam/SelectableJar'
 import { Label } from '../ui/label'
 import { Spinner } from '../ui/spinner'
 import { Switch } from '../ui/switch'
-import { JarUtxosTable, type UtxoTableEntry } from '../wallet/JarUtxosTable'
+import type { UtxoTableEntry } from '../wallet/JarUtxosTable'
 import JarSelectorDialog from './JarSelectorDialog'
 import { SendCoinjoinPreconditionAlert } from './SendCoinjoinPreconditionAlert'
+import { UtxoSelectionDialog } from './UtxoSelectionDialog'
 import { estimateMaxCollaboratorFee } from './feeEstimate'
 import type { SendFormValues } from './types'
 
@@ -597,57 +597,22 @@ export function SendForm({
         }}
       />
       <QrScannerDialog open={showQrScannerDialog} onOpenChange={setShowQrScannerDialog} onScan={applyBip21Result} />
-      <Dialog
+      <UtxoSelectionDialog
         open={showUtxoSelectorDialog}
+        isApplying={isApplyingUtxoSelection}
+        selectedCount={selectedSourceJarUtxos.length}
+        filter={utxoFilter}
+        tableEntries={sourceJarTableEntries}
+        initialRowSelection={defaultUtxoRowSelection}
+        enableRowSelection={(row) => !fb.utxo.isFidelityBond(row.original.utxo)}
         onOpenChange={(open) => {
           if (isApplyingUtxoSelection) return
           setShowUtxoSelectorDialog(open)
         }}
-      >
-        <DialogContent className="max-w-6xl">
-          <DialogHeader>
-            <DialogTitle>{t('show_utxos.title')}</DialogTitle>
-            <DialogDescription>
-              {t('show_utxos.subtitle', { count: selectedSourceJarUtxos.length })} {t('show_utxos.text_subtitle_addon')}
-            </DialogDescription>
-          </DialogHeader>
-
-          <Input
-            value={utxoFilter}
-            onChange={(event) => setUtxoFilter(event.target.value)}
-            placeholder={t('jar_details.utxo_list.placeholder_search')}
-          />
-          <div className="max-h-[55vh] overflow-hidden">
-            <JarUtxosTable
-              globalFilter={utxoFilter}
-              tableEntries={sourceJarTableEntries}
-              pinnedEntries={[]}
-              initialRowSelection={defaultUtxoRowSelection}
-              onRowSelectionChange={setUtxoRowSelection}
-              enableRowSelection={(row) => !fb.utxo.isFidelityBond(row.original.utxo)}
-            />
-          </div>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setShowUtxoSelectorDialog(false)}
-              disabled={isApplyingUtxoSelection}
-            >
-              {t('modal.confirm_button_reject')}
-            </Button>
-            <Button
-              type="button"
-              onClick={() => void onApplyUtxoSelection()}
-              disabled={isApplyingUtxoSelection}
-            >
-              {isApplyingUtxoSelection ? <Spinner /> : undefined}
-              {t('modal.confirm_button_accept')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onFilterChange={setUtxoFilter}
+        onRowSelectionChange={setUtxoRowSelection}
+        onApply={() => void onApplyUtxoSelection()}
+      />
       <form onSubmit={(event) => void doOnSubmit(event)} className={cn('flex flex-col gap-4', className)} noValidate>
         <div className="space-y-2">
           <Field className="space-y-4" data-invalid={errors.source !== undefined}>

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -18,7 +18,6 @@ import { isDevMode } from '@/constants/debugFeatures'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '@/constants/jm'
 import {
   useDetectNetwork,
-  useJamWalletInfoContext,
   type AddressSummary,
   type Jar,
 } from '@/context/JamWalletInfoContext'
@@ -322,7 +321,6 @@ export function SendForm({
 }: SendFormProps) {
   const { t } = useTranslation()
   const client = useApiClient()
-  const { refetch: refetchWalletInfo } = useJamWalletInfoContext()
 
   const [showAddressFromJarSelectorDialog, setShowAddressFromJarSelectorDialog] = useState(false)
   const [showQrScannerDialog, setShowQrScannerDialog] = useState(false)
@@ -482,7 +480,6 @@ export function SendForm({
 
     try {
       const result = await applyUtxoSelectionMutateAsync({ utxosToFreeze, utxosToUnfreeze })
-      await refetchWalletInfo()
 
       if (utxosToFreeze.length > 0) {
         const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
@@ -511,7 +508,7 @@ export function SendForm({
         toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
       }
     }
-  }, [applyUtxoSelectionMutateAsync, refetchWalletInfo, selectedSourceJarUtxos, sourceJar, t])
+  }, [applyUtxoSelectionMutateAsync, selectedSourceJarUtxos, sourceJar, t])
 
   const destinationJar = useMemo(() => {
     if (destinationJarIndex === undefined) return

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -322,7 +322,7 @@ export function SendForm({
 }: SendFormProps) {
   const { t } = useTranslation()
   const client = useApiClient()
-  const walletInfo = useJamWalletInfoContext()
+  const { refetch: refetchWalletInfo } = useJamWalletInfoContext()
 
   const [showAddressFromJarSelectorDialog, setShowAddressFromJarSelectorDialog] = useState(false)
   const [showQrScannerDialog, setShowQrScannerDialog] = useState(false)
@@ -398,17 +398,17 @@ export function SendForm({
     return (sourceJar?.utxos || []).filter((utxo) => utxoRowSelection[utxo.utxo] === true)
   }, [sourceJar?.utxos, utxoRowSelection])
 
-  const freezeOrUnfreezeUtxo = useMutation({
+  const { mutateAsync: freezeOrUnfreezeUtxoMutateAsync } = useMutation({
     ...freezeMutation({ client }),
     retry: false,
   })
 
-  const applyUtxoSelectionMutation = useMutation({
+  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isApplyingUtxoSelection } = useMutation({
     mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
       const [freezeResult, unfreezeResult] = await Promise.all([
         Promise.allSettled(
           utxosToFreeze.map((utxo) =>
-            freezeOrUnfreezeUtxo.mutateAsync({
+            freezeOrUnfreezeUtxoMutateAsync({
               path: {
                 walletname: encodeURIComponent(walletFileName),
               },
@@ -421,7 +421,7 @@ export function SendForm({
         ),
         Promise.allSettled(
           utxosToUnfreeze.map((utxo) =>
-            freezeOrUnfreezeUtxo.mutateAsync({
+            freezeOrUnfreezeUtxoMutateAsync({
               path: {
                 walletname: encodeURIComponent(walletFileName),
               },
@@ -481,8 +481,8 @@ export function SendForm({
     }
 
     try {
-      const result = await applyUtxoSelectionMutation.mutateAsync({ utxosToFreeze, utxosToUnfreeze })
-      await walletInfo.refetch()
+      const result = await applyUtxoSelectionMutateAsync({ utxosToFreeze, utxosToUnfreeze })
+      await refetchWalletInfo()
 
       if (utxosToFreeze.length > 0) {
         const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
@@ -511,7 +511,7 @@ export function SendForm({
         toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
       }
     }
-  }, [applyUtxoSelectionMutation, selectedSourceJarUtxos, sourceJar, t, walletFileName, walletInfo])
+  }, [applyUtxoSelectionMutateAsync, refetchWalletInfo, selectedSourceJarUtxos, sourceJar, t])
 
   const destinationJar = useMemo(() => {
     if (destinationJarIndex === undefined) return
@@ -602,7 +602,7 @@ export function SendForm({
       <Dialog
         open={showUtxoSelectorDialog}
         onOpenChange={(open) => {
-          if (applyUtxoSelectionMutation.isPending) return
+          if (isApplyingUtxoSelection) return
           setShowUtxoSelectorDialog(open)
         }}
       >
@@ -635,16 +635,16 @@ export function SendForm({
               type="button"
               variant="outline"
               onClick={() => setShowUtxoSelectorDialog(false)}
-              disabled={applyUtxoSelectionMutation.isPending}
+              disabled={isApplyingUtxoSelection}
             >
               {t('modal.confirm_button_reject')}
             </Button>
             <Button
               type="button"
               onClick={() => void onApplyUtxoSelection()}
-              disabled={applyUtxoSelectionMutation.isPending}
+              disabled={isApplyingUtxoSelection}
             >
-              {applyUtxoSelectionMutation.isPending ? <Spinner /> : undefined}
+              {isApplyingUtxoSelection ? <Spinner /> : undefined}
               {t('modal.confirm_button_accept')}
             </Button>
           </DialogFooter>
@@ -663,7 +663,7 @@ export function SendForm({
                   disabled ||
                   sourceJar === undefined ||
                   sourceJar.utxos.length === 0 ||
-                  applyUtxoSelectionMutation.isPending
+                  isApplyingUtxoSelection
                 }
                 onClick={openUtxoSelectorDialog}
               >
@@ -699,7 +699,7 @@ export function SendForm({
                   }}
                   disabled={
                     disabled ||
-                    applyUtxoSelectionMutation.isPending ||
+                    isApplyingUtxoSelection ||
                     jar.balanceSummary.calculatedAvailableBalanceInSats <= 0
                   }
                 />

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -471,6 +471,7 @@ export function SendForm({
       })
     }
 
+    // The selected set should remain spendable; everything else becomes frozen.
     const utxosToFreeze = mutableUtxos.filter((it) => !selectedAddresses.has(it.address) && it.frozen === false)
     const utxosToUnfreeze = mutableUtxos.filter((it) => selectedAddresses.has(it.address) && it.frozen === true)
 
@@ -696,7 +697,11 @@ export function SendForm({
                       void trigger('destination.address')
                     }
                   }}
-                  disabled={disabled || jar.balanceSummary.calculatedAvailableBalanceInSats <= 0}
+                  disabled={
+                    disabled ||
+                    applyUtxoSelectionMutation.isPending ||
+                    jar.balanceSummary.calculatedAvailableBalanceInSats <= 0
+                  }
                 />
               ))}
             </div>

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useMemo, useState, type ComponentProps } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { freezeMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { getaddress, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
+import { useMutation } from '@tanstack/react-query'
+import type { RowSelectionState } from '@tanstack/react-table'
 import { getAddressInfo, validate as isValidBitcoinAddress, Network } from 'bitcoin-address-validation'
 import type { AddressInfo } from 'bitcoin-address-validation'
 import type { TFunction } from 'i18next'
-import { BrushCleaningIcon, MilkIcon, ScanQrCodeIcon, XIcon } from 'lucide-react'
+import { BrushCleaningIcon, ListFilterIcon, MilkIcon, ScanQrCodeIcon, XIcon } from 'lucide-react'
 import { useForm, useWatch } from 'react-hook-form'
 import type { Resolver, SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -13,11 +16,18 @@ import * as yup from 'yup'
 import QrScannerDialog from '@/components/ui/QrScannerDialog'
 import { isDevMode } from '@/constants/debugFeatures'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '@/constants/jm'
-import { useDetectNetwork, type AddressSummary, type Jar } from '@/context/JamWalletInfoContext'
+import {
+  useDetectNetwork,
+  useJamWalletInfoContext,
+  type AddressSummary,
+  type Jar,
+} from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
+import type { Utxo } from '@/hooks/useQueryUtxos'
 import type { FeeConfigValues } from '@/hooks/useFeeConfigValidation'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { parseBip21Uri, type Bip21ParseResult } from '@/lib/bip21'
+import { utxoTags } from '@/lib/tags'
 import {
   cn,
   delayedPromise,
@@ -34,6 +44,7 @@ import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { ButtonGroup } from '../ui/button-group'
 import { Card, CardContent, CardHeader } from '../ui/card'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Field, FieldLabel } from '../ui/field'
 import { Input } from '../ui/input'
 import { inputVariants } from '../ui/input-variants'
@@ -44,6 +55,7 @@ import { SelectableJar } from '../ui/jam/SelectableJar'
 import { Label } from '../ui/label'
 import { Spinner } from '../ui/spinner'
 import { Switch } from '../ui/switch'
+import { JarUtxosTable, type UtxoTableEntry } from '../wallet/JarUtxosTable'
 import JarSelectorDialog from './JarSelectorDialog'
 import { SendCoinjoinPreconditionAlert } from './SendCoinjoinPreconditionAlert'
 import { estimateMaxCollaboratorFee } from './feeEstimate'
@@ -88,6 +100,13 @@ const AddressFromJarSelectorDialog = ({
       }}
     />
   )
+}
+
+const utxoToTableEntry = (utxo: Utxo, addressSummary: AddressSummary, t: TFunction): UtxoTableEntry => {
+  return {
+    utxo,
+    tags: utxoTags(utxo, addressSummary, t),
+  }
 }
 
 const initialNumberOfCollaborators = (minValue: number): number => {
@@ -301,9 +320,14 @@ export function SendForm({
   debug,
 }: SendFormProps) {
   const { t } = useTranslation()
+  const client = useApiClient()
+  const walletInfo = useJamWalletInfoContext()
 
   const [showAddressFromJarSelectorDialog, setShowAddressFromJarSelectorDialog] = useState(false)
   const [showQrScannerDialog, setShowQrScannerDialog] = useState(false)
+  const [showUtxoSelectorDialog, setShowUtxoSelectorDialog] = useState(false)
+  const [utxoFilter, setUtxoFilter] = useState('')
+  const [utxoRowSelection, setUtxoRowSelection] = useState<RowSelectionState>({})
   const [bip21Message, setBip21Message] = useState<string>()
 
   const { network } = useDetectNetwork()
@@ -355,6 +379,134 @@ export function SendForm({
     if (sourceJarIndex === undefined) return
     return jars.find((it) => it.jarIndex === sourceJarIndex)
   }, [jars, sourceJarIndex])
+
+  const sourceJarTableEntries = useMemo(() => {
+    return (sourceJar?.utxos || []).map((it) => utxoToTableEntry(it, addressSummary, t))
+  }, [addressSummary, sourceJar?.utxos, t])
+
+  const defaultUtxoRowSelection = useMemo<RowSelectionState>(() => {
+    return (sourceJar?.utxos || []).reduce((acc, utxo) => {
+      if (utxo.frozen === false && utxo.locktime === undefined) {
+        acc[utxo.utxo] = true
+      }
+      return acc
+    }, {} as RowSelectionState)
+  }, [sourceJar?.utxos])
+
+  const selectedSourceJarUtxos = useMemo(() => {
+    return (sourceJar?.utxos || []).filter((utxo) => utxoRowSelection[utxo.utxo] === true)
+  }, [sourceJar?.utxos, utxoRowSelection])
+
+  const freezeOrUnfreezeUtxo = useMutation({
+    ...freezeMutation({ client }),
+    retry: false,
+  })
+
+  const applyUtxoSelectionMutation = useMutation({
+    mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
+      const [freezeResult, unfreezeResult] = await Promise.all([
+        Promise.allSettled(
+          utxosToFreeze.map((utxo) =>
+            freezeOrUnfreezeUtxo.mutateAsync({
+              path: {
+                walletname: encodeURIComponent(walletFileName),
+              },
+              body: {
+                'utxo-string': utxo.utxo,
+                freeze: true,
+              },
+            }),
+          ),
+        ),
+        Promise.allSettled(
+          utxosToUnfreeze.map((utxo) =>
+            freezeOrUnfreezeUtxo.mutateAsync({
+              path: {
+                walletname: encodeURIComponent(walletFileName),
+              },
+              body: {
+                'utxo-string': utxo.utxo,
+                freeze: false,
+              },
+            }),
+          ),
+        ),
+      ])
+
+      return { freezeResult, unfreezeResult }
+    },
+  })
+
+  const openUtxoSelectorDialog = useCallback(() => {
+    if (!sourceJar) return
+    setUtxoFilter('')
+    setUtxoRowSelection(defaultUtxoRowSelection)
+    setShowUtxoSelectorDialog(true)
+  }, [defaultUtxoRowSelection, sourceJar])
+
+  const onApplyUtxoSelection = useCallback(async () => {
+    if (!sourceJar) return
+
+    // Keep same-address UTXOs together to avoid accidental privacy leaks.
+    const selectedUtxoIds = new Set(selectedSourceJarUtxos.map((it) => it.utxo))
+    const selectedAddresses = new Set(selectedSourceJarUtxos.map((it) => it.address))
+    const mutableUtxos = sourceJar.utxos.filter((it) => it.locktime === undefined)
+    const groupedSelectedUtxos = mutableUtxos.filter((it) => selectedAddresses.has(it.address))
+    const groupedDeselectedUtxos = mutableUtxos.filter((it) => !selectedAddresses.has(it.address))
+    const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
+
+    if (groupedSelectedUtxos.length > selectedSourceJarUtxos.length) {
+      toast.warning(`Security measure: Selection changed`, {
+        description: `Automatically selected ${groupedSelectedUtxos.length - selectedSourceJarUtxos.length} additional UTXOs with matching addresses.`,
+      })
+    }
+
+    if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
+      toast.warning(`Security measure: Selection changed`, {
+        description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
+      })
+    }
+
+    const utxosToFreeze = mutableUtxos.filter((it) => !selectedAddresses.has(it.address) && it.frozen === false)
+    const utxosToUnfreeze = mutableUtxos.filter((it) => selectedAddresses.has(it.address) && it.frozen === true)
+
+    if (utxosToFreeze.length === 0 && utxosToUnfreeze.length === 0) {
+      setShowUtxoSelectorDialog(false)
+      return
+    }
+
+    try {
+      const result = await applyUtxoSelectionMutation.mutateAsync({ utxosToFreeze, utxosToUnfreeze })
+      await walletInfo.refetch()
+
+      if (utxosToFreeze.length > 0) {
+        const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
+        if (rejected.length === 0) {
+          toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: utxosToFreeze.length }))
+        } else {
+          toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length }))
+        }
+      }
+
+      if (utxosToUnfreeze.length > 0) {
+        const rejected = result.unfreezeResult.filter((it) => it.status === 'rejected')
+        if (rejected.length === 0) {
+          toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: utxosToUnfreeze.length }))
+        } else {
+          toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length }))
+        }
+      }
+
+      setShowUtxoSelectorDialog(false)
+    } catch (_ignoredOnPurpose) {
+      if (utxosToFreeze.length > 0) {
+        toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: utxosToFreeze.length }))
+      }
+      if (utxosToUnfreeze.length > 0) {
+        toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
+      }
+    }
+  }, [applyUtxoSelectionMutation, selectedSourceJarUtxos, sourceJar, t, walletFileName, walletInfo])
 
   const destinationJar = useMemo(() => {
     if (destinationJarIndex === undefined) return
@@ -442,10 +594,78 @@ export function SendForm({
         }}
       />
       <QrScannerDialog open={showQrScannerDialog} onOpenChange={setShowQrScannerDialog} onScan={applyBip21Result} />
+      <Dialog
+        open={showUtxoSelectorDialog}
+        onOpenChange={(open) => {
+          if (applyUtxoSelectionMutation.isPending) return
+          setShowUtxoSelectorDialog(open)
+        }}
+      >
+        <DialogContent className="max-w-6xl">
+          <DialogHeader>
+            <DialogTitle>{t('show_utxos.title')}</DialogTitle>
+            <DialogDescription>
+              {t('show_utxos.subtitle', { count: selectedSourceJarUtxos.length })} {t('show_utxos.text_subtitle_addon')}
+            </DialogDescription>
+          </DialogHeader>
+
+          <Input
+            value={utxoFilter}
+            onChange={(event) => setUtxoFilter(event.target.value)}
+            placeholder={t('jar_details.utxo_list.placeholder_search')}
+          />
+          <div className="max-h-[55vh] overflow-hidden">
+            <JarUtxosTable
+              globalFilter={utxoFilter}
+              tableEntries={sourceJarTableEntries}
+              pinnedEntries={[]}
+              initialRowSelection={defaultUtxoRowSelection}
+              onRowSelectionChange={setUtxoRowSelection}
+              enableRowSelection={(row) => row.original.utxo.locktime === undefined}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowUtxoSelectorDialog(false)}
+              disabled={applyUtxoSelectionMutation.isPending}
+            >
+              {t('modal.confirm_button_reject')}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void onApplyUtxoSelection()}
+              disabled={applyUtxoSelectionMutation.isPending}
+            >
+              {applyUtxoSelectionMutation.isPending ? <Spinner /> : undefined}
+              {t('modal.confirm_button_accept')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <form onSubmit={(event) => void doOnSubmit(event)} className={cn('flex flex-col gap-4', className)} noValidate>
         <div className="space-y-2">
           <Field className="space-y-4" data-invalid={errors.source !== undefined}>
-            <FieldLabel>{t('send.label_source_jar')}</FieldLabel>
+            <div className="flex items-center justify-between gap-2">
+              <FieldLabel>{t('send.label_source_jar')}</FieldLabel>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={
+                  disabled ||
+                  sourceJar === undefined ||
+                  sourceJar.utxos.length === 0 ||
+                  applyUtxoSelectionMutation.isPending
+                }
+                onClick={openUtxoSelectorDialog}
+              >
+                <ListFilterIcon />
+                {t('show_utxos.text_select_utxos_tooltip')}
+              </Button>
+            </div>
             <div className="grid grid-cols-5 gap-4">
               {jars.map((jar, index) => (
                 <SelectableJar

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -2,12 +2,10 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   directsendMutation,
   docoinjoinMutation,
-  freezeMutation,
   stopcoinjoinOptions,
 } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { DirectSendRequest, DirectSendResponse, ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import type { RowSelectionState } from '@tanstack/react-table'
 import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
 import { AlertTriangleIcon, HourglassIcon } from 'lucide-react'
 import type { SubmitHandler } from 'react-hook-form'
@@ -28,17 +26,15 @@ import {
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { useJmConfig } from '@/hooks/useJmConfig'
-import type { Utxo, UtxoId } from '@/hooks/useQueryUtxos'
+import { useUtxoSelectionDialog } from '@/hooks/useUtxoSelectionDialog'
+import type { UtxoId } from '@/hooks/useQueryUtxos'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
 import { useWaitForUtxosToBeSpent } from '@/hooks/useWaitForUtxosToBeSpent'
 import { getErrorReason } from '@/lib/errorReason'
-import * as fb from '@/lib/fidelityBondUtils'
-import { utxoTags } from '@/lib/tags'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
 import { jmTxStore, type JmTxInfo } from '@/store/jmTxStore'
-import type { JarIndex } from '@/types/global'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
@@ -60,8 +56,6 @@ type DirectSendResult = {
   response: DirectSendResponse
 }
 
-const SEND_AUTO_SELECTION_TOAST_ID = 'send.utxo.selection_changed_automatically'
-
 interface SendPageProps {
   walletFileName: WalletFileName
 }
@@ -76,10 +70,6 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
   const [showPaymentConfirmDialog, setShowPaymentConfirmDialog] = useState(false)
   const [showAbortCoinjoinDialog, setShowAbortCoinjoinDialog] = useState(false)
-  const [showUtxoSelectorDialog, setShowUtxoSelectorDialog] = useState(false)
-  const [utxoFilter, setUtxoFilter] = useState('')
-  const [utxoRowSelection, setUtxoRowSelection] = useState<RowSelectionState>({})
-  const [sourceJarIndexForUtxoSelector, setSourceJarIndexForUtxoSelector] = useState<JarIndex>()
   const [sendFromValuesAwaitingConfirmation, setSendFromValuesAwaitingConfirmation] = useState<SendFormValues>()
   const [paymentSuccessfulInfoAlert, setPaymentSuccessfulInfoAlert] = useState<SimpleAlert>()
   const [minimumCollaborators, setMinimumCollaborators] = useState<number>()
@@ -111,30 +101,11 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     refetchWalletInfoRef.current = refetchWalletInfo
   }, [refetchWalletInfo])
 
-  const sourceJarForUtxoSelector = useMemo(() => {
-    if (sourceJarIndexForUtxoSelector === undefined) return
-    return jars.find((it) => it.jarIndex === sourceJarIndexForUtxoSelector)
-  }, [jars, sourceJarIndexForUtxoSelector])
-
-  const sourceJarTableEntries = useMemo(() => {
-    return (sourceJarForUtxoSelector?.utxos || []).map((utxo) => ({
-      utxo,
-      tags: utxoTags(utxo, addressSummary, t),
-    }))
-  }, [addressSummary, sourceJarForUtxoSelector?.utxos, t])
-
-  const defaultUtxoRowSelection = useMemo<RowSelectionState>(() => {
-    return (sourceJarForUtxoSelector?.utxos || []).reduce((acc, utxo) => {
-      if (utxo.frozen === false && !fb.utxo.isFidelityBond(utxo)) {
-        acc[utxo.utxo] = true
-      }
-      return acc
-    }, {} as RowSelectionState)
-  }, [sourceJarForUtxoSelector?.utxos])
-
-  const selectedSourceJarUtxos = useMemo(() => {
-    return (sourceJarForUtxoSelector?.utxos || []).filter((utxo) => utxoRowSelection[utxo.utxo] === true)
-  }, [sourceJarForUtxoSelector?.utxos, utxoRowSelection])
+  const utxoSelectionDialog = useUtxoSelectionDialog({
+    walletFileName,
+    jars,
+    addressSummary,
+  })
 
   const sourceJar = useMemo(() => {
     const sourceJarIndex = sendFromValuesAwaitingConfirmation?.source?.fromJar
@@ -157,46 +128,6 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     maxFeesConfigMissing,
     isLoading: isLoadingFeeConfig,
   } = useFeeConfigValidation({ walletFileName })
-
-  const { mutateAsync: freezeOrUnfreezeUtxoMutateAsync } = useMutation({
-    ...freezeMutation({ client }),
-    retry: false,
-  })
-
-  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isApplyingUtxoSelection } = useMutation({
-    mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
-      const [freezeResult, unfreezeResult] = await Promise.all([
-        Promise.allSettled(
-          utxosToFreeze.map((utxo) =>
-            freezeOrUnfreezeUtxoMutateAsync({
-              path: {
-                walletname: encodeURIComponent(walletFileName),
-              },
-              body: {
-                'utxo-string': utxo.utxo,
-                freeze: true,
-              },
-            }),
-          ),
-        ),
-        Promise.allSettled(
-          utxosToUnfreeze.map((utxo) =>
-            freezeOrUnfreezeUtxoMutateAsync({
-              path: {
-                walletname: encodeURIComponent(walletFileName),
-              },
-              body: {
-                'utxo-string': utxo.utxo,
-                freeze: false,
-              },
-            }),
-          ),
-        ),
-      ])
-
-      return { freezeResult, unfreezeResult }
-    },
-  })
 
   const directSendMutation = useMutation({
     ...directsendMutation({ client }),
@@ -509,80 +440,6 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     setShowPaymentConfirmDialog(true)
   }
 
-  const onOpenUtxoSelector = () => {
-    if (!sourceJarForUtxoSelector) return
-    toast.dismiss(SEND_AUTO_SELECTION_TOAST_ID)
-    setUtxoFilter('')
-    setUtxoRowSelection(defaultUtxoRowSelection)
-    setShowUtxoSelectorDialog(true)
-  }
-
-  const onApplyUtxoSelection = async () => {
-    if (!sourceJarForUtxoSelector) return
-
-    // Keep same-address UTXOs together to avoid accidental privacy leaks.
-    const selectedUtxoIds = new Set(selectedSourceJarUtxos.map((it) => it.utxo))
-    const selectedAddresses = new Set(selectedSourceJarUtxos.map((it) => it.address))
-    const mutableUtxos = sourceJarForUtxoSelector.utxos.filter((it) => !fb.utxo.isFidelityBond(it))
-    const groupedSelectedUtxos = mutableUtxos.filter((it) => selectedAddresses.has(it.address))
-    const groupedDeselectedUtxos = mutableUtxos.filter((it) => !selectedAddresses.has(it.address))
-    const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
-
-    if (groupedSelectedUtxos.length > selectedSourceJarUtxos.length) {
-      toast.warning(`Security measure: Selection changed`, {
-        description: `Automatically selected ${groupedSelectedUtxos.length - selectedSourceJarUtxos.length} additional UTXOs with matching addresses.`,
-        id: SEND_AUTO_SELECTION_TOAST_ID,
-      })
-    }
-
-    if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
-      toast.warning(`Security measure: Selection changed`, {
-        description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
-        id: SEND_AUTO_SELECTION_TOAST_ID,
-      })
-    }
-
-    // The selected set should remain spendable; everything else becomes frozen.
-    const utxosToFreeze = mutableUtxos.filter((it) => !selectedAddresses.has(it.address) && it.frozen === false)
-    const utxosToUnfreeze = mutableUtxos.filter((it) => selectedAddresses.has(it.address) && it.frozen === true)
-
-    if (utxosToFreeze.length === 0 && utxosToUnfreeze.length === 0) {
-      setShowUtxoSelectorDialog(false)
-      return
-    }
-
-    try {
-      const result = await applyUtxoSelectionMutateAsync({ utxosToFreeze, utxosToUnfreeze })
-
-      if (utxosToFreeze.length > 0) {
-        const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
-        if (rejected.length === 0) {
-          toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: utxosToFreeze.length }))
-        } else {
-          toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length }))
-        }
-      }
-
-      if (utxosToUnfreeze.length > 0) {
-        const rejected = result.unfreezeResult.filter((it) => it.status === 'rejected')
-        if (rejected.length === 0) {
-          toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: utxosToUnfreeze.length }))
-        } else {
-          toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length }))
-        }
-      }
-
-      setShowUtxoSelectorDialog(false)
-    } catch (_ignoredOnPurpose) {
-      if (utxosToFreeze.length > 0) {
-        toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: utxosToFreeze.length }))
-      }
-      if (utxosToUnfreeze.length > 0) {
-        toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
-      }
-    }
-  }
-
   const onAbortCoinjoin = async () => {
     collaborativeLifecycleRef.current.awaitingCompletion = false
     collaborativeLifecycleRef.current.wasRunning = false
@@ -631,22 +488,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <UtxoSelectionDialog
-        open={showUtxoSelectorDialog}
-        isApplying={isApplyingUtxoSelection}
-        selectedCount={selectedSourceJarUtxos.length}
-        filter={utxoFilter}
-        tableEntries={sourceJarTableEntries}
-        initialRowSelection={defaultUtxoRowSelection}
-        enableRowSelection={(row) => !fb.utxo.isFidelityBond(row.original.utxo)}
-        onOpenChange={(open) => {
-          if (isApplyingUtxoSelection) return
-          setShowUtxoSelectorDialog(open)
-        }}
-        onFilterChange={setUtxoFilter}
-        onRowSelectionChange={setUtxoRowSelection}
-        onApply={() => void onApplyUtxoSelection()}
-      />
+      <UtxoSelectionDialog {...utxoSelectionDialog.dialogProps} />
       {sourceJar && sendFromValuesAwaitingConfirmation && (
         <PaymentConfirmDialog
           open={showPaymentConfirmDialog}
@@ -764,13 +606,9 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
           <CardContent>
             <SendForm
               onSubmit={onSubmit}
-              onSourceJarChange={setSourceJarIndexForUtxoSelector}
-              onOpenUtxoSelector={onOpenUtxoSelector}
-              utxoSelectorDisabled={
-                isApplyingUtxoSelection ||
-                sourceJarForUtxoSelector === undefined ||
-                sourceJarForUtxoSelector.utxos.length === 0
-              }
+              onSourceJarChange={utxoSelectionDialog.setSourceJarIndex}
+              onOpenUtxoSelector={utxoSelectionDialog.onOpenUtxoSelector}
+              utxoSelectorDisabled={utxoSelectionDialog.utxoSelectorDisabled}
               walletFileName={walletFileName}
               minNumberOfCollaborators={minimumCollaborators}
               feeConfigValues={feeConfigValues}
@@ -782,7 +620,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
                 jmSession?.maker_running ||
                 collaborativeFlowActive ||
                 jmSession?.rescanning ||
-                isApplyingUtxoSelection ||
+                utxoSelectionDialog.isApplying ||
                 waitForUtxosToBeSpent.length > 0
               }
               debug={isDeveloperMode}

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   directsendMutation,
   docoinjoinMutation,
+  freezeMutation,
   stopcoinjoinOptions,
 } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { DirectSendRequest, DirectSendResponse, ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
+import type { RowSelectionState } from '@tanstack/react-table'
 import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
 import { AlertTriangleIcon, HourglassIcon } from 'lucide-react'
 import type { SubmitHandler } from 'react-hook-form'
@@ -26,20 +28,24 @@ import {
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { useJmConfig } from '@/hooks/useJmConfig'
-import type { UtxoId } from '@/hooks/useQueryUtxos'
+import type { Utxo, UtxoId } from '@/hooks/useQueryUtxos'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
 import { useWaitForUtxosToBeSpent } from '@/hooks/useWaitForUtxosToBeSpent'
 import { getErrorReason } from '@/lib/errorReason'
+import * as fb from '@/lib/fidelityBondUtils'
+import { utxoTags } from '@/lib/tags'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
 import { jmTxStore, type JmTxInfo } from '@/store/jmTxStore'
+import type { JarIndex } from '@/types/global'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Spinner } from '../ui/spinner'
 import PaymentConfirmDialog from './PaymentConfirmDialog'
 import { SendForm } from './SendForm'
+import { UtxoSelectionDialog } from './UtxoSelectionDialog'
 import { buildCollaborativeSendRequest } from './collaborativeSend'
 import type { SendFormValues } from './types'
 
@@ -53,6 +59,8 @@ type DirectSendResult = {
   request: DirectSendRequest
   response: DirectSendResponse
 }
+
+const SEND_AUTO_SELECTION_TOAST_ID = 'send.utxo.selection_changed_automatically'
 
 interface SendPageProps {
   walletFileName: WalletFileName
@@ -68,6 +76,10 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
   const [showPaymentConfirmDialog, setShowPaymentConfirmDialog] = useState(false)
   const [showAbortCoinjoinDialog, setShowAbortCoinjoinDialog] = useState(false)
+  const [showUtxoSelectorDialog, setShowUtxoSelectorDialog] = useState(false)
+  const [utxoFilter, setUtxoFilter] = useState('')
+  const [utxoRowSelection, setUtxoRowSelection] = useState<RowSelectionState>({})
+  const [sourceJarIndexForUtxoSelector, setSourceJarIndexForUtxoSelector] = useState<JarIndex>()
   const [sendFromValuesAwaitingConfirmation, setSendFromValuesAwaitingConfirmation] = useState<SendFormValues>()
   const [paymentSuccessfulInfoAlert, setPaymentSuccessfulInfoAlert] = useState<SimpleAlert>()
   const [minimumCollaborators, setMinimumCollaborators] = useState<number>()
@@ -99,6 +111,31 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     refetchWalletInfoRef.current = refetchWalletInfo
   }, [refetchWalletInfo])
 
+  const sourceJarForUtxoSelector = useMemo(() => {
+    if (sourceJarIndexForUtxoSelector === undefined) return
+    return jars.find((it) => it.jarIndex === sourceJarIndexForUtxoSelector)
+  }, [jars, sourceJarIndexForUtxoSelector])
+
+  const sourceJarTableEntries = useMemo(() => {
+    return (sourceJarForUtxoSelector?.utxos || []).map((utxo) => ({
+      utxo,
+      tags: utxoTags(utxo, addressSummary, t),
+    }))
+  }, [addressSummary, sourceJarForUtxoSelector?.utxos, t])
+
+  const defaultUtxoRowSelection = useMemo<RowSelectionState>(() => {
+    return (sourceJarForUtxoSelector?.utxos || []).reduce((acc, utxo) => {
+      if (utxo.frozen === false && !fb.utxo.isFidelityBond(utxo)) {
+        acc[utxo.utxo] = true
+      }
+      return acc
+    }, {} as RowSelectionState)
+  }, [sourceJarForUtxoSelector?.utxos])
+
+  const selectedSourceJarUtxos = useMemo(() => {
+    return (sourceJarForUtxoSelector?.utxos || []).filter((utxo) => utxoRowSelection[utxo.utxo] === true)
+  }, [sourceJarForUtxoSelector?.utxos, utxoRowSelection])
+
   const sourceJar = useMemo(() => {
     const sourceJarIndex = sendFromValuesAwaitingConfirmation?.source?.fromJar
     if (sourceJarIndex === undefined) return
@@ -120,6 +157,46 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     maxFeesConfigMissing,
     isLoading: isLoadingFeeConfig,
   } = useFeeConfigValidation({ walletFileName })
+
+  const { mutateAsync: freezeOrUnfreezeUtxoMutateAsync } = useMutation({
+    ...freezeMutation({ client }),
+    retry: false,
+  })
+
+  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isApplyingUtxoSelection } = useMutation({
+    mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
+      const [freezeResult, unfreezeResult] = await Promise.all([
+        Promise.allSettled(
+          utxosToFreeze.map((utxo) =>
+            freezeOrUnfreezeUtxoMutateAsync({
+              path: {
+                walletname: encodeURIComponent(walletFileName),
+              },
+              body: {
+                'utxo-string': utxo.utxo,
+                freeze: true,
+              },
+            }),
+          ),
+        ),
+        Promise.allSettled(
+          utxosToUnfreeze.map((utxo) =>
+            freezeOrUnfreezeUtxoMutateAsync({
+              path: {
+                walletname: encodeURIComponent(walletFileName),
+              },
+              body: {
+                'utxo-string': utxo.utxo,
+                freeze: false,
+              },
+            }),
+          ),
+        ),
+      ])
+
+      return { freezeResult, unfreezeResult }
+    },
+  })
 
   const directSendMutation = useMutation({
     ...directsendMutation({ client }),
@@ -432,6 +509,80 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     setShowPaymentConfirmDialog(true)
   }
 
+  const onOpenUtxoSelector = () => {
+    if (!sourceJarForUtxoSelector) return
+    toast.dismiss(SEND_AUTO_SELECTION_TOAST_ID)
+    setUtxoFilter('')
+    setUtxoRowSelection(defaultUtxoRowSelection)
+    setShowUtxoSelectorDialog(true)
+  }
+
+  const onApplyUtxoSelection = async () => {
+    if (!sourceJarForUtxoSelector) return
+
+    // Keep same-address UTXOs together to avoid accidental privacy leaks.
+    const selectedUtxoIds = new Set(selectedSourceJarUtxos.map((it) => it.utxo))
+    const selectedAddresses = new Set(selectedSourceJarUtxos.map((it) => it.address))
+    const mutableUtxos = sourceJarForUtxoSelector.utxos.filter((it) => !fb.utxo.isFidelityBond(it))
+    const groupedSelectedUtxos = mutableUtxos.filter((it) => selectedAddresses.has(it.address))
+    const groupedDeselectedUtxos = mutableUtxos.filter((it) => !selectedAddresses.has(it.address))
+    const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
+
+    if (groupedSelectedUtxos.length > selectedSourceJarUtxos.length) {
+      toast.warning(`Security measure: Selection changed`, {
+        description: `Automatically selected ${groupedSelectedUtxos.length - selectedSourceJarUtxos.length} additional UTXOs with matching addresses.`,
+        id: SEND_AUTO_SELECTION_TOAST_ID,
+      })
+    }
+
+    if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
+      toast.warning(`Security measure: Selection changed`, {
+        description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
+        id: SEND_AUTO_SELECTION_TOAST_ID,
+      })
+    }
+
+    // The selected set should remain spendable; everything else becomes frozen.
+    const utxosToFreeze = mutableUtxos.filter((it) => !selectedAddresses.has(it.address) && it.frozen === false)
+    const utxosToUnfreeze = mutableUtxos.filter((it) => selectedAddresses.has(it.address) && it.frozen === true)
+
+    if (utxosToFreeze.length === 0 && utxosToUnfreeze.length === 0) {
+      setShowUtxoSelectorDialog(false)
+      return
+    }
+
+    try {
+      const result = await applyUtxoSelectionMutateAsync({ utxosToFreeze, utxosToUnfreeze })
+
+      if (utxosToFreeze.length > 0) {
+        const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
+        if (rejected.length === 0) {
+          toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: utxosToFreeze.length }))
+        } else {
+          toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length }))
+        }
+      }
+
+      if (utxosToUnfreeze.length > 0) {
+        const rejected = result.unfreezeResult.filter((it) => it.status === 'rejected')
+        if (rejected.length === 0) {
+          toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: utxosToUnfreeze.length }))
+        } else {
+          toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length }))
+        }
+      }
+
+      setShowUtxoSelectorDialog(false)
+    } catch (_ignoredOnPurpose) {
+      if (utxosToFreeze.length > 0) {
+        toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: utxosToFreeze.length }))
+      }
+      if (utxosToUnfreeze.length > 0) {
+        toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
+      }
+    }
+  }
+
   const onAbortCoinjoin = async () => {
     collaborativeLifecycleRef.current.awaitingCompletion = false
     collaborativeLifecycleRef.current.wasRunning = false
@@ -480,6 +631,22 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <UtxoSelectionDialog
+        open={showUtxoSelectorDialog}
+        isApplying={isApplyingUtxoSelection}
+        selectedCount={selectedSourceJarUtxos.length}
+        filter={utxoFilter}
+        tableEntries={sourceJarTableEntries}
+        initialRowSelection={defaultUtxoRowSelection}
+        enableRowSelection={(row) => !fb.utxo.isFidelityBond(row.original.utxo)}
+        onOpenChange={(open) => {
+          if (isApplyingUtxoSelection) return
+          setShowUtxoSelectorDialog(open)
+        }}
+        onFilterChange={setUtxoFilter}
+        onRowSelectionChange={setUtxoRowSelection}
+        onApply={() => void onApplyUtxoSelection()}
+      />
       {sourceJar && sendFromValuesAwaitingConfirmation && (
         <PaymentConfirmDialog
           open={showPaymentConfirmDialog}
@@ -597,6 +764,13 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
           <CardContent>
             <SendForm
               onSubmit={onSubmit}
+              onSourceJarChange={setSourceJarIndexForUtxoSelector}
+              onOpenUtxoSelector={onOpenUtxoSelector}
+              utxoSelectorDisabled={
+                isApplyingUtxoSelection ||
+                sourceJarForUtxoSelector === undefined ||
+                sourceJarForUtxoSelector.utxos.length === 0
+              }
               walletFileName={walletFileName}
               minNumberOfCollaborators={minimumCollaborators}
               feeConfigValues={feeConfigValues}
@@ -608,6 +782,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
                 jmSession?.maker_running ||
                 collaborativeFlowActive ||
                 jmSession?.rescanning ||
+                isApplyingUtxoSelection ||
                 waitForUtxosToBeSpent.length > 0
               }
               debug={isDeveloperMode}

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -7,7 +7,7 @@ import {
 import type { DirectSendRequest, DirectSendResponse, ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
-import { AlertTriangleIcon, HourglassIcon } from 'lucide-react'
+import { AlertTriangleIcon, HourglassIcon, ListFilterIcon } from 'lucide-react'
 import type { SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -26,9 +26,9 @@ import {
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { useJmConfig } from '@/hooks/useJmConfig'
-import { useUtxoSelectionDialog } from '@/hooks/useUtxoSelectionDialog'
 import type { UtxoId } from '@/hooks/useQueryUtxos'
 import { useRefreshSession } from '@/hooks/useRefreshSession'
+import { useUtxoSelectionDialog } from '@/hooks/useUtxoSelectionDialog'
 import { useWaitForUtxosToBeSpent } from '@/hooks/useWaitForUtxosToBeSpent'
 import { getErrorReason } from '@/lib/errorReason'
 import type { WalletFileName } from '@/lib/utils'
@@ -606,9 +606,6 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
           <CardContent>
             <SendForm
               onSubmit={onSubmit}
-              onSourceJarChange={utxoSelectionDialog.setSourceJarIndex}
-              onOpenUtxoSelector={utxoSelectionDialog.onOpenUtxoSelector}
-              utxoSelectorDisabled={utxoSelectionDialog.utxoSelectorDisabled}
               walletFileName={walletFileName}
               minNumberOfCollaborators={minimumCollaborators}
               feeConfigValues={feeConfigValues}
@@ -624,6 +621,19 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
                 waitForUtxosToBeSpent.length > 0
               }
               debug={isDeveloperMode}
+              onSourceJarChange={utxoSelectionDialog.setSourceJarIndex}
+              sourceJarLabelButton={
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={utxoSelectionDialog.utxoSelectorDisabled}
+                  onClick={utxoSelectionDialog.onOpenUtxoSelector}
+                >
+                  <ListFilterIcon />
+                  {t('show_utxos.text_select_utxos_tooltip')}
+                </Button>
+              }
             />
           </CardContent>
         </Card>

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -1,0 +1,76 @@
+import type { OnChangeFn, Row, RowSelectionState } from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
+import { Button } from '../ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Spinner } from '../ui/spinner'
+import { JarUtxosTable, type UtxoTableEntry } from '../wallet/JarUtxosTable'
+
+interface UtxoSelectionDialogProps {
+  open: boolean
+  isApplying: boolean
+  selectedCount: number
+  filter: string
+  tableEntries: UtxoTableEntry[]
+  initialRowSelection: RowSelectionState
+  enableRowSelection: boolean | ((row: Row<UtxoTableEntry>) => boolean)
+  onOpenChange: (open: boolean) => void
+  onFilterChange: (value: string) => void
+  onRowSelectionChange: OnChangeFn<RowSelectionState>
+  onApply: () => void
+}
+
+export const UtxoSelectionDialog = ({
+  open,
+  isApplying,
+  selectedCount,
+  filter,
+  tableEntries,
+  initialRowSelection,
+  enableRowSelection,
+  onOpenChange,
+  onFilterChange,
+  onRowSelectionChange,
+  onApply,
+}: UtxoSelectionDialogProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-6xl">
+        <DialogHeader>
+          <DialogTitle>{t('show_utxos.title')}</DialogTitle>
+          <DialogDescription>
+            {t('show_utxos.subtitle', { count: selectedCount })} {t('show_utxos.text_subtitle_addon')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          value={filter}
+          onChange={(event) => onFilterChange(event.target.value)}
+          placeholder={t('jar_details.utxo_list.placeholder_search')}
+        />
+        <div className="max-h-[55vh] overflow-hidden">
+          <JarUtxosTable
+            globalFilter={filter}
+            tableEntries={tableEntries}
+            pinnedEntries={[]}
+            initialRowSelection={initialRowSelection}
+            onRowSelectionChange={onRowSelectionChange}
+            enableRowSelection={enableRowSelection}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isApplying}>
+            {t('modal.confirm_button_reject')}
+          </Button>
+          <Button type="button" onClick={onApply} disabled={isApplying}>
+            {isApplying ? <Spinner /> : undefined}
+            {t('modal.confirm_button_accept')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -6,7 +6,7 @@ import { Input } from '../ui/input'
 import { Spinner } from '../ui/spinner'
 import { JarUtxosTable, type UtxoTableEntry } from '../wallet/JarUtxosTable'
 
-interface UtxoSelectionDialogProps {
+export interface UtxoSelectionDialogProps {
   open: boolean
   isApplying: boolean
   selectedCount: number

--- a/src/components/ui/jam/Jar.tsx
+++ b/src/components/ui/jam/Jar.tsx
@@ -12,6 +12,7 @@ interface JarProps {
   availableBalance: AmountSats
   frozenOrLockedBalance: AmountSats
   totalWalletBalance: AmountSats
+  isSelected?: boolean
   disabled?: boolean
 }
 
@@ -23,13 +24,20 @@ export function Jar({
   availableBalance,
   frozenOrLockedBalance,
   totalWalletBalance,
+  isSelected = false,
   disabled = false,
 }: JarProps) {
   return (
     <div
       className={cn('group/jar flex flex-row items-center gap-2 transition-all duration-300 sm:flex-col', className)}
     >
-      <JarIcon color={color} totalBalance={totalBalance} totalWalletBalance={totalWalletBalance} disabled={disabled} />
+      <JarIcon
+        color={color}
+        totalBalance={totalBalance}
+        totalWalletBalance={totalWalletBalance}
+        isSelected={isSelected}
+        disabled={disabled}
+      />
       <div className="flex flex-col items-center text-sm">
         <p
           className={cn(

--- a/src/components/ui/jam/SelectableJar.tsx
+++ b/src/components/ui/jam/SelectableJar.tsx
@@ -13,6 +13,8 @@ export const SelectableJar = ({
   name,
   color,
   totalBalance,
+  availableBalance,
+  frozenOrLockedBalance,
   totalWalletBalance,
   isSelected,
   disabled = false,
@@ -42,8 +44,15 @@ export const SelectableJar = ({
           disabled={disabled}
         />
         <span className="text-xs">{name}</span>
-        <div className="flex items-center text-sm">
-          <Balance valueString={String(totalBalance)} />
+        <div className="flex min-w-[110px] items-center justify-center text-sm">
+          <Balance valueString={String(availableBalance)} />
+        </div>
+        <div
+          className={cn('light:text-blue-500/80 flex min-w-[110px] items-center justify-center gap-1 text-xs', {
+            hidden: frozenOrLockedBalance <= 0,
+          })}
+        >
+          <Balance valueString={String(frozenOrLockedBalance)} frozen={true} />
         </div>
       </div>
       <div className="flex items-center">

--- a/src/components/ui/jam/SelectableJar.tsx
+++ b/src/components/ui/jam/SelectableJar.tsx
@@ -1,8 +1,6 @@
 import { useRef, type ComponentProps } from 'react'
 import { cn } from '@/lib/utils'
-import { Balance } from './Balance'
-import type { Jar } from './Jar'
-import { JarIcon } from './JarIcon'
+import { Jar } from './Jar'
 
 interface SelectableJarProps extends ComponentProps<typeof Jar> {
   isSelected: NonNullable<React.ComponentProps<'input'>['checked']>
@@ -35,26 +33,17 @@ export const SelectableJar = ({
       }}
       tabIndex={-1}
     >
-      <div className="flex flex-col items-center">
-        <JarIcon
-          color={color}
-          totalBalance={totalBalance}
-          isSelected={isSelected}
-          totalWalletBalance={totalWalletBalance}
-          disabled={disabled}
-        />
-        <span className="text-xs">{name}</span>
-        <div className="flex min-w-[110px] items-center justify-center text-sm">
-          <Balance valueString={String(availableBalance)} />
-        </div>
-        <div
-          className={cn('light:text-blue-500/80 flex min-w-[110px] items-center justify-center gap-1 text-xs', {
-            hidden: frozenOrLockedBalance <= 0,
-          })}
-        >
-          <Balance valueString={String(frozenOrLockedBalance)} frozen={true} />
-        </div>
-      </div>
+      <Jar
+        className="flex-col gap-0"
+        name={name}
+        color={color}
+        totalBalance={totalBalance}
+        availableBalance={availableBalance}
+        frozenOrLockedBalance={frozenOrLockedBalance}
+        totalWalletBalance={totalWalletBalance}
+        isSelected={isSelected}
+        disabled={disabled}
+      />
       <div className="flex items-center">
         <input
           ref={radioRef}

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -262,6 +262,8 @@ interface JarUtxosTableProps {
   globalFilter?: string
   tableEntries: UtxoTableEntry[]
   pinnedEntries: UtxoTableEntry[]
+  initialRowSelection?: RowSelectionState
+  enableRowSelection?: boolean | ((row: Row<UtxoTableEntry>) => boolean)
   onChange?: (table: TableType<UtxoTableEntry>) => void
   onRowSelectionChange?: OnChangeFn<RowSelectionState>
 }
@@ -270,6 +272,8 @@ export const JarUtxosTable = ({
   globalFilter,
   tableEntries,
   pinnedEntries,
+  initialRowSelection,
+  enableRowSelection,
   onChange,
   onRowSelectionChange,
 }: JarUtxosTableProps) => {
@@ -289,7 +293,7 @@ export const JarUtxosTable = ({
     bottom: [],
   })
 
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>(initialRowSelection ?? {})
 
   const table = useReactTable<UtxoTableEntry>({
     data: tableEntries,
@@ -310,7 +314,7 @@ export const JarUtxosTable = ({
     },
     globalFilterFn: 'fuzzy' as FilterFnOption<UtxoTableEntry>,
     keepPinnedRows: true,
-    enableRowSelection: true,
+    enableRowSelection: enableRowSelection ?? true,
     enableMultiRowSelection: true,
     getRowId: (row) => row.utxo.utxo,
     onSortingChange: setSorting,
@@ -343,6 +347,12 @@ export const JarUtxosTable = ({
       row.pin(pinnedEntries.includes(row.original) ? 'top' : false)
     })
   }, [table, pinnedEntries])
+
+  useEffect(() => {
+    if (!initialRowSelection) return
+    setRowSelection(initialRowSelection)
+    onRowSelectionChange?.(initialRowSelection)
+  }, [initialRowSelection, onRowSelectionChange])
 
   useEffect(() => {
     if (currentPage > totalPages) {

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -62,7 +62,7 @@ interface UtxosContentProps {
 
 export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: UtxosContentProps) => {
   const { t } = useTranslation()
-  const walletInfo = useJamWalletInfoContext()
+  const { refetch: walletInfoRefetch, isFetching: walletInfoIsFetching } = useJamWalletInfoContext()
 
   const client = useApiClient()
 
@@ -92,11 +92,11 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
   })
   const freezeUtxos = useMutation({
     mutationFn: (values: Utxo[]) =>
-      freezeOrUnfreezeUtxos.mutateAsync({ values, freeze: true }).then((it) => walletInfo.refetch().then(() => it)),
+      freezeOrUnfreezeUtxos.mutateAsync({ values, freeze: true }).then((it) => walletInfoRefetch().then(() => it)),
   })
   const unfreezeUtxos = useMutation({
     mutationFn: (values: Utxo[]) =>
-      freezeOrUnfreezeUtxos.mutateAsync({ values, freeze: false }).then((it) => walletInfo.refetch().then(() => it)),
+      freezeOrUnfreezeUtxos.mutateAsync({ values, freeze: false }).then((it) => walletInfoRefetch().then(() => it)),
   })
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
@@ -133,7 +133,7 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
   }, [tableEntries])
 
   // TODO: makerRunning, takerRunner, rescanRunning, etc.
-  const operationsEnabled = enabled && !(walletInfo.isFetching || freezeUtxos.isPending || unfreezeUtxos.isPending)
+  const operationsEnabled = enabled && !(walletInfoIsFetching || freezeUtxos.isPending || unfreezeUtxos.isPending)
 
   const onFreezeClick = async () => {
     const selectedAddresses = new Set(selectedUtxos.map((it) => it.address))
@@ -207,10 +207,10 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
         <div className="flex items-center gap-2">
           <Button
             size="sm"
-            disabled={!operationsEnabled || walletInfo.isFetching}
-            onClick={() => void walletInfo.refetch()}
+            disabled={!operationsEnabled || walletInfoIsFetching}
+            onClick={() => void walletInfoRefetch()}
           >
-            <RefreshCwIcon className={cn({ 'motion-safe:animate-spin': walletInfo.isFetching })} />
+            <RefreshCwIcon className={cn({ 'motion-safe:animate-spin': walletInfoIsFetching })} />
             {t('global.refresh')}
           </Button>
           <ButtonGroup>

--- a/src/hooks/useUtxoSelectionDialog.ts
+++ b/src/hooks/useUtxoSelectionDialog.ts
@@ -1,0 +1,200 @@
+import { useMemo, useState } from 'react'
+import { freezeMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
+import type { RowSelectionState } from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import type { UtxoSelectionDialogProps } from '@/components/send/UtxoSelectionDialog'
+import type { AddressSummary, Jar } from '@/context/JamWalletInfoContext'
+import { useApiClient } from '@/hooks/useApiClient'
+import type { Utxo } from '@/hooks/useQueryUtxos'
+import * as fb from '@/lib/fidelityBondUtils'
+import { utxoTags } from '@/lib/tags'
+import type { WalletFileName } from '@/lib/utils'
+import type { JarIndex } from '@/types/global'
+
+const SEND_AUTO_SELECTION_TOAST_ID = 'send.utxo.selection_changed_automatically'
+
+interface UseUtxoSelectionDialogProps {
+  walletFileName: WalletFileName
+  jars: Jar[]
+  addressSummary: AddressSummary
+}
+
+export const useUtxoSelectionDialog = ({
+  walletFileName,
+  jars,
+  addressSummary,
+}: UseUtxoSelectionDialogProps) => {
+  const { t } = useTranslation()
+  const client = useApiClient()
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
+  const [sourceJarIndex, setSourceJarIndex] = useState<JarIndex>()
+
+  const sourceJar = useMemo(() => {
+    if (sourceJarIndex === undefined) return
+    return jars.find((it) => it.jarIndex === sourceJarIndex)
+  }, [jars, sourceJarIndex])
+
+  const tableEntries = useMemo(() => {
+    return (sourceJar?.utxos || []).map((utxo) => ({
+      utxo,
+      tags: utxoTags(utxo, addressSummary, t),
+    }))
+  }, [addressSummary, sourceJar?.utxos, t])
+
+  const initialRowSelection = useMemo<RowSelectionState>(() => {
+    return (sourceJar?.utxos || []).reduce((acc, utxo) => {
+      if (utxo.frozen === false && !fb.utxo.isFidelityBond(utxo)) {
+        acc[utxo.utxo] = true
+      }
+      return acc
+    }, {} as RowSelectionState)
+  }, [sourceJar?.utxos])
+
+  const selectedUtxos = useMemo(() => {
+    return (sourceJar?.utxos || []).filter((utxo) => rowSelection[utxo.utxo] === true)
+  }, [sourceJar?.utxos, rowSelection])
+
+  const { mutateAsync: freezeOrUnfreezeUtxoMutateAsync } = useMutation({
+    ...freezeMutation({ client }),
+    retry: false,
+  })
+
+  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isApplying } = useMutation({
+    mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
+      const [freezeResult, unfreezeResult] = await Promise.all([
+        Promise.allSettled(
+          utxosToFreeze.map((utxo) =>
+            freezeOrUnfreezeUtxoMutateAsync({
+              path: {
+                walletname: encodeURIComponent(walletFileName),
+              },
+              body: {
+                'utxo-string': utxo.utxo,
+                freeze: true,
+              },
+            }),
+          ),
+        ),
+        Promise.allSettled(
+          utxosToUnfreeze.map((utxo) =>
+            freezeOrUnfreezeUtxoMutateAsync({
+              path: {
+                walletname: encodeURIComponent(walletFileName),
+              },
+              body: {
+                'utxo-string': utxo.utxo,
+                freeze: false,
+              },
+            }),
+          ),
+        ),
+      ])
+
+      return { freezeResult, unfreezeResult }
+    },
+  })
+
+  const onOpenUtxoSelector = () => {
+    if (!sourceJar) return
+    toast.dismiss(SEND_AUTO_SELECTION_TOAST_ID)
+    setFilter('')
+    setRowSelection(initialRowSelection)
+    setOpen(true)
+  }
+
+  const onApplyUtxoSelection = async () => {
+    if (!sourceJar) return
+
+    // Keep same-address UTXOs together to avoid accidental privacy leaks.
+    const selectedUtxoIds = new Set(selectedUtxos.map((it) => it.utxo))
+    const selectedAddresses = new Set(selectedUtxos.map((it) => it.address))
+    const mutableUtxos = sourceJar.utxos.filter((it) => !fb.utxo.isFidelityBond(it))
+    const groupedSelectedUtxos = mutableUtxos.filter((it) => selectedAddresses.has(it.address))
+    const groupedDeselectedUtxos = mutableUtxos.filter((it) => !selectedAddresses.has(it.address))
+    const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
+
+    if (groupedSelectedUtxos.length > selectedUtxos.length) {
+      toast.warning(`Security measure: Selection changed`, {
+        description: `Automatically selected ${groupedSelectedUtxos.length - selectedUtxos.length} additional UTXOs with matching addresses.`,
+        id: SEND_AUTO_SELECTION_TOAST_ID,
+      })
+    }
+
+    if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
+      toast.warning(`Security measure: Selection changed`, {
+        description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
+        id: SEND_AUTO_SELECTION_TOAST_ID,
+      })
+    }
+
+    // The selected set should remain spendable; everything else becomes frozen.
+    const utxosToFreeze = mutableUtxos.filter((it) => !selectedAddresses.has(it.address) && it.frozen === false)
+    const utxosToUnfreeze = mutableUtxos.filter((it) => selectedAddresses.has(it.address) && it.frozen === true)
+
+    if (utxosToFreeze.length === 0 && utxosToUnfreeze.length === 0) {
+      setOpen(false)
+      return
+    }
+
+    try {
+      const result = await applyUtxoSelectionMutateAsync({ utxosToFreeze, utxosToUnfreeze })
+
+      if (utxosToFreeze.length > 0) {
+        const rejected = result.freezeResult.filter((it) => it.status === 'rejected')
+        if (rejected.length === 0) {
+          toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: utxosToFreeze.length }))
+        } else {
+          toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length }))
+        }
+      }
+
+      if (utxosToUnfreeze.length > 0) {
+        const rejected = result.unfreezeResult.filter((it) => it.status === 'rejected')
+        if (rejected.length === 0) {
+          toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: utxosToUnfreeze.length }))
+        } else {
+          toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length }))
+        }
+      }
+
+      setOpen(false)
+    } catch (_ignoredOnPurpose) {
+      if (utxosToFreeze.length > 0) {
+        toast.warning(t('jar_details.utxo_list.toast_freeze_error', { count: utxosToFreeze.length }))
+      }
+      if (utxosToUnfreeze.length > 0) {
+        toast.warning(t('jar_details.utxo_list.toast_unfreeze_error', { count: utxosToUnfreeze.length }))
+      }
+    }
+  }
+
+  const dialogProps: UtxoSelectionDialogProps = {
+    open,
+    isApplying,
+    selectedCount: selectedUtxos.length,
+    filter,
+    tableEntries,
+    initialRowSelection,
+    enableRowSelection: (row) => !fb.utxo.isFidelityBond(row.original.utxo),
+    onOpenChange: (nextOpen: boolean) => {
+      if (isApplying) return
+      setOpen(nextOpen)
+    },
+    onFilterChange: setFilter,
+    onRowSelectionChange: setRowSelection,
+    onApply: () => void onApplyUtxoSelection(),
+  }
+
+  return {
+    isApplying,
+    sourceJarIndex,
+    setSourceJarIndex,
+    onOpenUtxoSelector,
+    utxoSelectorDisabled: isApplying || sourceJar === undefined || sourceJar.utxos.length === 0,
+    dialogProps,
+  }
+}

--- a/src/hooks/useUtxoSelectionDialog.ts
+++ b/src/hooks/useUtxoSelectionDialog.ts
@@ -5,7 +5,7 @@ import type { RowSelectionState } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import type { UtxoSelectionDialogProps } from '@/components/send/UtxoSelectionDialog'
-import type { AddressSummary, Jar } from '@/context/JamWalletInfoContext'
+import { useJamWalletInfoContext, type AddressSummary, type Jar } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { Utxo } from '@/hooks/useQueryUtxos'
 import * as fb from '@/lib/fidelityBondUtils'
@@ -21,13 +21,11 @@ interface UseUtxoSelectionDialogProps {
   addressSummary: AddressSummary
 }
 
-export const useUtxoSelectionDialog = ({
-  walletFileName,
-  jars,
-  addressSummary,
-}: UseUtxoSelectionDialogProps) => {
+export const useUtxoSelectionDialog = ({ walletFileName, jars, addressSummary }: UseUtxoSelectionDialogProps) => {
   const { t } = useTranslation()
   const client = useApiClient()
+
+  const { refetch: walletInfoRefetch } = useJamWalletInfoContext()
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
@@ -58,6 +56,8 @@ export const useUtxoSelectionDialog = ({
     return (sourceJar?.utxos || []).filter((utxo) => rowSelection[utxo.utxo] === true)
   }, [sourceJar?.utxos, rowSelection])
 
+  // TODO: Should this be moved to `WalletInfoContext`?
+  // Similar/Duplicate code in `WalletJarDetailsContent`
   const { mutateAsync: freezeOrUnfreezeUtxoMutateAsync } = useMutation({
     ...freezeMutation({ client }),
     retry: false,
@@ -92,7 +92,7 @@ export const useUtxoSelectionDialog = ({
             }),
           ),
         ),
-      ])
+      ]).then((it) => walletInfoRefetch().then(() => it))
 
       return { freezeResult, unfreezeResult }
     },
@@ -109,7 +109,6 @@ export const useUtxoSelectionDialog = ({
   const onApplyUtxoSelection = async () => {
     if (!sourceJar) return
 
-    // Keep same-address UTXOs together to avoid accidental privacy leaks.
     const selectedUtxoIds = new Set(selectedUtxos.map((it) => it.utxo))
     const selectedAddresses = new Set(selectedUtxos.map((it) => it.address))
     const mutableUtxos = sourceJar.utxos.filter((it) => !fb.utxo.isFidelityBond(it))
@@ -118,6 +117,7 @@ export const useUtxoSelectionDialog = ({
     const userDeselectedUtxos = mutableUtxos.filter((it) => !selectedUtxoIds.has(it.utxo))
 
     if (groupedSelectedUtxos.length > selectedUtxos.length) {
+      // TODO: i18n
       toast.warning(`Security measure: Selection changed`, {
         description: `Automatically selected ${groupedSelectedUtxos.length - selectedUtxos.length} additional UTXOs with matching addresses.`,
         id: SEND_AUTO_SELECTION_TOAST_ID,
@@ -125,6 +125,7 @@ export const useUtxoSelectionDialog = ({
     }
 
     if (groupedDeselectedUtxos.length > userDeselectedUtxos.length) {
+      // TODO: i18n
       toast.warning(`Security measure: Selection changed`, {
         description: `Automatically deselected ${groupedDeselectedUtxos.length - userDeselectedUtxos.length} additional UTXOs with matching addresses.`,
         id: SEND_AUTO_SELECTION_TOAST_ID,


### PR DESCRIPTION
this PR adds coin-control style utxo selection to the send flow, so you can choose which utxos are eligible before sending. selected utxos remain spendable, unselected ones are frozen, and utxos on the same address are automatically grouped to preserve privacy. it also shows a toast when selection is auto-adjusted and includes a small reusable update to the utxo table to support default selection and selection rules.

ping @theborakompanioni 