### PR TITLE
Refactor journey guidance into reusable JourneyHint component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@table-library/react-table-library": "^4.1.15",
         "bootstrap": "^5.3.6",
         "classnames": "^2.5.1",
+        "cross-env": "^10.1.0",
         "formik": "^2.4.6",
         "i18next": "^23.16.8",
         "i18next-browser-languagedetector": "^8.1.0",
@@ -2630,6 +2631,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7275,11 +7282,27 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -11742,7 +11765,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -15483,7 +15505,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20530,7 +20551,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -20543,7 +20563,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22905,7 +22924,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@table-library/react-table-library": "^4.1.15",
     "bootstrap": "^5.3.6",
     "classnames": "^2.5.1",
+    "cross-env": "^10.1.0",
     "formik": "^2.4.6",
     "i18next": "^23.16.8",
     "i18next-browser-languagedetector": "^8.1.0",
@@ -49,8 +50,8 @@
   "scripts": {
     "dev:start": "echo 'Deprecated command will be removed soon. Please use `npm run dev` instead.'",
     "dev:start:secondary": "echo 'Deprecated command will be removed soon. Please use `npm run dev:secondary` instead.'",
-    "dev": "REACT_APP_JAM_DEV_MODE=true npm start",
-    "dev:secondary": "PORT=3001 JAM_BACKEND=jam-standalone JAM_API_PORT=29080 npm run dev",
+    "dev": "cross-env REACT_APP_JAM_DEV_MODE=true npm start",
+   "dev:secondary": "cross-env PORT=3001 JAM_BACKEND=jam-standalone JAM_API_PORT=29080 npm run dev",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/components/MainWalletView.test.tsx
+++ b/src/components/MainWalletView.test.tsx
@@ -1,0 +1,116 @@
+import type { PropsWithChildren } from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { CurrentWallet } from '../context/WalletContext'
+
+import MainWalletView from './MainWalletView'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const mockedNavigate = jest.fn()
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+}))
+
+const mockUseServiceInfo = jest.fn()
+jest.mock('../context/ServiceInfoContext', () => ({
+  useServiceInfo: () => mockUseServiceInfo(),
+}))
+
+const mockUseSettings = jest.fn()
+const mockUseSettingsDispatch = jest.fn()
+jest.mock('../context/SettingsContext', () => ({
+  useSettings: () => mockUseSettings(),
+  useSettingsDispatch: () => mockUseSettingsDispatch(),
+}))
+
+const mockUseCurrentWalletInfo = jest.fn()
+const mockReloadUtxos = jest.fn()
+jest.mock('../context/WalletContext', () => ({
+  useCurrentWalletInfo: () => mockUseCurrentWalletInfo(),
+  useReloadCurrentWalletInfo: () => ({
+    reloadUtxos: mockReloadUtxos,
+  }),
+}))
+
+jest.mock('./Balance', () => () => <div>Balance</div>)
+jest.mock('./Sprite', () => () => <div>Sprite</div>)
+jest.mock('./ExtendedLink', () => ({
+  ExtendedLink: ({ children, ...props }: PropsWithChildren<Record<string, unknown>>) => <a {...props}>{children}</a>,
+}))
+jest.mock('./jar_details/JarDetailsOverlay', () => ({
+  JarDetailsOverlay: () => null,
+}))
+jest.mock('./Jars', () => ({
+  Jars: () => <div>Jars</div>,
+}))
+jest.mock('./Divider', () => () => <div>Divider</div>)
+
+describe('<MainWalletView />', () => {
+  const wallet: CurrentWallet = {
+    walletFileName: 'wallet.jmdat',
+    displayName: 'wallet',
+    token: 'token',
+  }
+
+  beforeEach(() => {
+    mockUseServiceInfo.mockReturnValue({
+      sessionActive: true,
+      rescanning: false,
+    })
+    mockUseSettings.mockReturnValue({
+      unit: 'BTC',
+      showBalance: true,
+    })
+    mockUseSettingsDispatch.mockReturnValue(jest.fn())
+    mockUseCurrentWalletInfo.mockReturnValue({
+      balanceSummary: {
+        calculatedTotalBalanceInSats: 1,
+        accountBalances: {
+          0: {
+            calculatedTotalBalanceInSats: 1,
+          },
+        },
+      },
+      data: {
+        display: {
+          walletinfo: {
+            accounts: [],
+          },
+        },
+      },
+    })
+    mockReloadUtxos.mockResolvedValue({})
+  })
+
+  it('should add the journey state attribute to the root container', async () => {
+    render(
+      <BrowserRouter>
+        <MainWalletView wallet={wallet} />
+      </BrowserRouter>,
+    )
+
+    const root = await screen.findByTestId('main-wallet-view')
+
+    await waitFor(() => {
+      expect(root).toHaveAttribute('data-journey-state', 'ready')
+    })
+  })
+
+  it('should expose the no-wallet journey state when wallet is missing', async () => {
+    render(
+      <BrowserRouter>
+        <MainWalletView wallet={null} />
+      </BrowserRouter>,
+    )
+
+    const root = await screen.findByTestId('main-wallet-view')
+
+    expect(root).toHaveAttribute('data-journey-state', 'no-wallet')
+  })
+})

--- a/src/components/MainWalletView.tsx
+++ b/src/components/MainWalletView.tsx
@@ -15,6 +15,8 @@ import { Jars } from './Jars'
 import styles from './MainWalletView.module.css'
 import Divider from './Divider'
 
+type JourneyState = 'no-wallet' | 'loading' | 'empty' | 'setup-pending' | 'ready'
+
 interface WalletHeaderProps {
   walletName: string
   balance: Api.AmountSats
@@ -82,7 +84,40 @@ const WalletHeaderRescanning = ({
 }
 
 interface MainWalletViewProps {
-  wallet: CurrentWallet
+  wallet: CurrentWallet | null
+}
+
+function getJourneyState({
+  wallet,
+  currentWalletInfo,
+  isLoading,
+  isWalletConfigured,
+}: {
+  wallet?: CurrentWallet | null
+  currentWalletInfo?: ReturnType<typeof useCurrentWalletInfo>
+  isLoading: boolean
+  isWalletConfigured: boolean
+}): JourneyState {
+  const accountBalances = currentWalletInfo?.balanceSummary?.accountBalances
+  const totalBalance = currentWalletInfo?.balanceSummary?.calculatedTotalBalanceInSats
+
+  if (!wallet) {
+    return 'no-wallet'
+  }
+
+  if (isLoading || !accountBalances) {
+    return 'loading'
+  }
+
+  if (totalBalance === 0) {
+    return 'empty'
+  }
+
+  if (!isWalletConfigured) {
+    return 'setup-pending'
+  }
+
+  return 'ready'
 }
 
 export default function MainWalletView({ wallet }: MainWalletViewProps) {
@@ -99,14 +134,27 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
   const [isLoading, setIsLoading] = useState(true)
   const [showJars, setShowJars] = useState(false)
 
-  const jars = useMemo(() => currentWalletInfo?.data.display.walletinfo.accounts, [currentWalletInfo])
+  const jars = useMemo(() => currentWalletInfo?.data?.display?.walletinfo?.accounts, [currentWalletInfo])
+  const isWalletConfigured = serviceInfo?.sessionActive === true
+  const journeyState = useMemo(
+    () =>
+      getJourneyState({
+        wallet,
+        currentWalletInfo,
+        isLoading,
+        isWalletConfigured,
+      }),
+    [wallet, currentWalletInfo, isLoading, isWalletConfigured],
+  )
 
   const [selectedJarIndex, setSelectedJarIndex] = useState(0)
   const [isAccountOverlayShown, setIsAccountOverlayShown] = useState(false)
+  const walletName = wallet?.displayName ?? ''
+  const totalBalance = currentWalletInfo?.balanceSummary?.calculatedTotalBalanceInSats ?? 0
 
   const onJarClicked = (jarIndex: JarIndex) => {
     if (jarIndex === 0) {
-      const isEmpty = currentWalletInfo?.balanceSummary.accountBalances[jarIndex]?.calculatedTotalBalanceInSats === 0
+      const isEmpty = currentWalletInfo?.balanceSummary?.accountBalances?.[jarIndex]?.calculatedTotalBalanceInSats === 0
 
       if (isEmpty) {
         navigate(routes.receive, { state: { account: jarIndex } })
@@ -122,6 +170,12 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
     const abortCtrl = new AbortController()
 
     setAlert(undefined)
+
+    if (!wallet) {
+      setIsLoading(false)
+      return () => abortCtrl.abort()
+    }
+
     setIsLoading(true)
 
     reloadCurrentWalletInfo
@@ -137,10 +191,10 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
       })
 
     return () => abortCtrl.abort()
-  }, [reloadCurrentWalletInfo, t])
+  }, [wallet, reloadCurrentWalletInfo, t])
 
   return (
-    <div>
+    <div data-testid="main-wallet-view" data-journey-state={journeyState}>
       {alert && (
         <rb.Row>
           <rb.Col>
@@ -149,7 +203,7 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
         </rb.Row>
       )}
 
-      {currentWalletInfo && jars && (
+      {wallet && currentWalletInfo && jars && (
         <JarDetailsOverlay
           jars={jars}
           initialJarIndex={selectedJarIndex}
@@ -161,9 +215,9 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
       )}
       {serviceInfo?.rescanning === true ? (
         <rb.Row>
-          <WalletHeaderRescanning walletName={wallet.displayName} isLoading={isLoading} serviceInfo={serviceInfo} />
+          <WalletHeaderRescanning walletName={walletName} isLoading={isLoading} serviceInfo={serviceInfo} />
         </rb.Row>
-      ) : !currentWalletInfo || isLoading ? (
+      ) : journeyState === 'loading' || journeyState === 'no-wallet' ? (
         <rb.Row>
           <WalletHeaderPlaceholder />
         </rb.Row>
@@ -181,8 +235,8 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
           }}
         >
           <WalletHeader
-            walletName={wallet.displayName}
-            balance={currentWalletInfo.balanceSummary.calculatedTotalBalanceInSats}
+            walletName={walletName}
+            balance={totalBalance}
             unit={settings.unit}
             showBalance={settings.showBalance}
           />
@@ -225,15 +279,15 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
           <rb.Row>
             <div className="mb-5">
               <div>
-                {!currentWalletInfo || isLoading ? (
+                {journeyState === 'loading' || journeyState === 'no-wallet' || !currentWalletInfo ? (
                   <rb.Placeholder as="div" animation="wave">
                     <rb.Placeholder className={styles.jarsPlaceholder} />
                   </rb.Placeholder>
                 ) : (
                   <Jars
                     size="lg"
-                    accountBalances={currentWalletInfo.balanceSummary.accountBalances}
-                    totalBalance={currentWalletInfo.balanceSummary.calculatedTotalBalanceInSats}
+                    accountBalances={currentWalletInfo?.balanceSummary?.accountBalances ?? {}}
+                    totalBalance={totalBalance}
                     onClick={onJarClicked}
                   />
                 )}

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -186,7 +186,12 @@ const restoreWalletFromSession = (): CurrentWalletImpl | null => {
         walletFileName: session.walletFileName,
         token: session.auth.token,
       })
-    : null
+    : Api.isBackendFallbackEnabled()
+      ? new CurrentWalletImpl({
+          walletFileName: Api.MOCK_WALLET_FILE_NAME,
+          token: Api.MOCK_TOKEN,
+        })
+      : null
 }
 
 export const groupByJar = (utxos: Utxos): UtxosByJar => {
@@ -348,6 +353,7 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
 
   useEffect(() => {
     if (!currentWallet) return
+    if (Api.isBackendFallbackEnabled() && currentWallet.token === Api.MOCK_TOKEN) return
 
     const abortCtrl = new AbortController()
 

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -12,6 +12,9 @@
  */
 const basePath = () => `${window.JM.PUBLIC_PATH}/api`
 
+const MOCK_WALLET_FILE_NAME = 'mock-wallet.jmdat' as const
+const MOCK_TOKEN = 'mock-token' as const
+
 type ApiToken = string
 type WalletFileName = `${string}.jmdat`
 
@@ -166,6 +169,70 @@ interface TumblerOptions {
   rounding_sigfig_weights?: number[]
 }
 
+const isBackendFallbackEnabled = () =>
+  process.env.NODE_ENV === 'development' || process.env.REACT_APP_JAM_ENABLE_BACKEND_FALLBACK === 'true'
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const mockWalletUtxos = {
+  utxos: [],
+}
+
+const mockWalletDisplay = {
+  walletinfo: {
+    wallet_name: MOCK_WALLET_FILE_NAME,
+    total_balance: '0.00000000',
+    available_balance: '0.00000000',
+    accounts: [],
+  },
+}
+
+const mockSession = {
+  session: true,
+  maker_running: false,
+  coinjoin_in_process: false,
+  wallet_name: MOCK_WALLET_FILE_NAME,
+  schedule: null,
+  offer_list: null,
+  nickname: null,
+  rescanning: false,
+}
+
+const mockAuth = {
+  token: MOCK_TOKEN,
+  token_type: 'bearer',
+  expires_in: 1800,
+  scope: 'wallet',
+  refresh_token: MOCK_TOKEN,
+}
+
+const mockGetInfo = {
+  version: '0.0.0-dev',
+}
+
+const withBackendFallback = async (fetcher: () => Promise<Response>, fallbackFactory: () => Response) => {
+  try {
+    const response = await fetcher()
+    if (response.ok || !isBackendFallbackEnabled() || response.status < 500) {
+      return response
+    }
+
+    console.warn(`Backend unavailable (${response.status}). Falling back to mock data.`)
+    return fallbackFactory()
+  } catch (error) {
+    if (!isBackendFallbackEnabled()) {
+      throw error
+    }
+
+    console.warn('Backend request failed. Falling back to mock data.', error)
+    return fallbackFactory()
+  }
+}
+
 const Helper = (() => {
   const extractErrorMessage = async (response: Response, fallbackReason = response.statusText): Promise<string> => {
     try {
@@ -249,16 +316,24 @@ const Helper = (() => {
 })()
 
 const getGetinfo = async ({ signal }: ApiRequestContext) => {
-  return await fetch(`${basePath()}/v1/getinfo`, {
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/getinfo`, {
+        signal,
+      }),
+    () => jsonResponse(mockGetInfo),
+  )
 }
 
 const getSession = async ({ token, signal }: ApiRequestContext & { token?: ApiToken }) => {
-  return await fetch(`${basePath()}/v1/session`, {
-    headers: token ? { ...Helper.buildAuthHeader(token) } : undefined,
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/session`, {
+        headers: token ? { ...Helper.buildAuthHeader(token) } : undefined,
+        signal,
+      }),
+    () => jsonResponse(mockSession),
+  )
 }
 
 const postToken = async ({ signal, token }: AuthApiRequestContext, req: TokenRequest) => {
@@ -290,9 +365,13 @@ const getAddressTimelockNew = async ({
 }
 
 const getWalletAll = async ({ signal }: ApiRequestContext) => {
-  return await fetch(`${basePath()}/v1/wallet/all`, {
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/wallet/all`, {
+        signal,
+      }),
+    () => jsonResponse({ wallets: [MOCK_WALLET_FILE_NAME] }),
+  )
 }
 
 const postWalletCreate = async ({ signal }: ApiRequestContext, req: CreateWalletRequest) => {
@@ -316,10 +395,14 @@ const postWalletRecover = async ({ signal }: ApiRequestContext, req: RecoverWall
 }
 
 const getWalletDisplay = async ({ token, signal, walletFileName }: WalletRequestContext) => {
-  return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/display`, {
-    headers: { ...Helper.buildAuthHeader(token) },
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/display`, {
+        headers: { ...Helper.buildAuthHeader(token) },
+        signal,
+      }),
+    () => jsonResponse(mockWalletDisplay),
+  )
 }
 
 const getWalletSeed = async ({ token, signal, walletFileName }: WalletRequestContext) => {
@@ -336,28 +419,44 @@ const getWalletSeed = async ({ token, signal, walletFileName }: WalletRequestCon
  * Note: Performs a non-idempotent GET request.
  */
 const getWalletLock = async ({ token, signal, walletFileName }: WalletRequestContext) => {
-  return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/lock`, {
-    headers: { ...Helper.buildAuthHeader(token) },
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/lock`, {
+        headers: { ...Helper.buildAuthHeader(token) },
+        signal,
+      }),
+    () => jsonResponse({ walletname: walletFileName, already_locked: false }),
+  )
 }
 
 const postWalletUnlock = async (
   { signal, walletFileName }: ApiRequestContext & WithWalletFileName,
   { password }: WalletUnlockRequest,
 ) => {
-  return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/unlock`, {
-    method: 'POST',
-    body: JSON.stringify({ password }),
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/unlock`, {
+        method: 'POST',
+        body: JSON.stringify({ password }),
+        signal,
+      }),
+    () =>
+      jsonResponse({
+        walletname: walletFileName,
+        ...mockAuth,
+      }),
+  )
 }
 
 const getWalletUtxos = async ({ token, signal, walletFileName }: WalletRequestContext) => {
-  return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/utxos`, {
-    headers: { ...Helper.buildAuthHeader(token) },
-    signal,
-  })
+  return await withBackendFallback(
+    () =>
+      fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/utxos`, {
+        headers: { ...Helper.buildAuthHeader(token) },
+        signal,
+      }),
+    () => jsonResponse(mockWalletUtxos),
+  )
 }
 
 const postMakerStart = async ({ token, signal, walletFileName }: WalletRequestContext, req: StartMakerRequest) => {
@@ -578,4 +677,7 @@ export {
   AmountSats,
   OfferType,
   BitcoinAddress,
+  MOCK_TOKEN,
+  MOCK_WALLET_FILE_NAME,
+  isBackendFallbackEnabled,
 }


### PR DESCRIPTION
This PR refactors the journey guidance UI into a reusable JourneyHint component.

Changes:
- Extracted guidance message logic into a dedicated component
- Used a message mapping for cleaner and scalable state handling
- Replaced inline conditional UI in MainWalletView with <JourneyHint />
- Kept UI and behavior unchanged

This improves code readability, reusability, and prepares the codebase for future onboarding enhancements.