### PR TITLE
test: add send coverage baseline tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run lint
       # Test
       - name: Test
-        run: npm test
+        run: npm test -- --coverage --watchAll=false --runInBand
       # Build
       - name: Build
         run: npm run build

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,72 @@
+# Testing in Jam
+
+Jam uses Jest and React Testing Library for both unit and component coverage.
+The existing test harness already sets up the core providers and websocket mock,
+so most tests can focus on the feature behavior instead of the plumbing.
+
+## Shared test wrapper
+
+Use the shared renderer from `src/testUtils.tsx` when a component needs the repo's
+standard providers:
+
+```ts
+import { render, screen } from '../testUtils'
+
+render(<MyComponent />)
+expect(screen.getByText('...')).toBeInTheDocument()
+```
+
+That wrapper already includes:
+
+- `I18nextProvider`
+- `SettingsProvider`
+- `WalletProvider`
+- `ServiceConfigProvider`
+- `WebsocketProvider`
+- `ServiceInfoProvider`
+
+## API mocking
+
+The repo usually mocks the API layer directly with `jest.mock(...)` and then
+fills in return values per test.
+
+Example:
+
+```ts
+import * as apiMock from '../libs/JmWalletApi'
+
+jest.mock('../libs/JmWalletApi', () => ({
+  ...jest.requireActual('../libs/JmWalletApi'),
+  getSession: jest.fn(),
+  getGetinfo: jest.fn(),
+}))
+
+;(apiMock.getSession as jest.Mock).mockReturnValue(Promise.resolve({ ok: true }))
+```
+
+This keeps the component tests deterministic while still exercising the real UI
+and state transitions.
+
+## WebSocket mocking
+
+`src/setupTests.ts` creates a reusable websocket server mock:
+
+```ts
+await global.__DEV__.JM_WEBSOCKET_SERVER_MOCK.connected
+global.__DEV__.JM_WEBSOCKET_SERVER_MOCK.close()
+```
+
+That is useful for tests that need to verify connected/disconnected UI states
+without talking to a real backend.
+
+## Provider and async patterns
+
+- Wrap components in `act(...)` when they trigger asynchronous state updates.
+- Prefer `waitFor(...)` or `findBy...` queries when the UI updates after a promise.
+- Reuse the repo's translation and provider setup instead of creating ad-hoc wrappers.
+
+## Coverage contract
+
+CI runs Jest with coverage enabled, and `package.json` enforces a baseline threshold.
+When adding larger features, extend the relevant tests first, then raise the threshold
+only when the suite is ready for it.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,14 @@
       "localStorage"
     ],
     "clearMocks": true,
+    "coverageThreshold": {
+      "global": {
+        "statements": 29,
+        "branches": 17,
+        "functions": 23,
+        "lines": 29
+      }
+    },
     "transformIgnorePatterns": [
       "node_modules/(?!@table-library)"
     ]

--- a/src/components/Send/helpers.test.ts
+++ b/src/components/Send/helpers.test.ts
@@ -1,0 +1,48 @@
+import { MAX_NUM_COLLABORATORS, isValidAddress, isValidAmount, isValidNumCollaborators } from './helpers'
+
+describe('Send helpers', () => {
+  describe('isValidAddress', () => {
+    it('accepts a non-empty address string', () => {
+      expect(isValidAddress('bc1qexampleaddress')).toBe(true)
+    })
+
+    it('rejects null and empty strings', () => {
+      expect(isValidAddress(null)).toBe(false)
+      expect(isValidAddress('')).toBe(false)
+    })
+  })
+
+  describe('isValidAmount', () => {
+    it('accepts positive amounts in normal mode', () => {
+      expect(isValidAmount(1, false)).toBe(true)
+      expect(isValidAmount(100_000, false)).toBe(true)
+    })
+
+    it('accepts only zero in sweep mode', () => {
+      expect(isValidAmount(0, true)).toBe(true)
+      expect(isValidAmount(1, true)).toBe(false)
+      expect(isValidAmount(-1, true)).toBe(false)
+    })
+
+    it('rejects null, NaN, and non-positive values', () => {
+      expect(isValidAmount(null, false)).toBe(false)
+      expect(isValidAmount(NaN, false)).toBe(false)
+      expect(isValidAmount(0, false)).toBe(false)
+      expect(isValidAmount(-1, false)).toBe(false)
+    })
+  })
+
+  describe('isValidNumCollaborators', () => {
+    it('accepts values within the configured boundaries', () => {
+      expect(isValidNumCollaborators(2, 2)).toBe(true)
+      expect(isValidNumCollaborators(MAX_NUM_COLLABORATORS, 2)).toBe(true)
+    })
+
+    it('rejects values below the minimum, above the maximum, null, and NaN', () => {
+      expect(isValidNumCollaborators(1, 2)).toBe(false)
+      expect(isValidNumCollaborators(MAX_NUM_COLLABORATORS + 1, 2)).toBe(false)
+      expect(isValidNumCollaborators(null, 2)).toBe(false)
+      expect(isValidNumCollaborators(NaN, 2)).toBe(false)
+    })
+  })
+})

--- a/src/components/utxo/utils.test.ts
+++ b/src/components/utxo/utils.test.ts
@@ -1,0 +1,68 @@
+import type { TFunction } from 'i18next'
+import { Utxo } from '../../context/WalletContext'
+import * as fb from '../fb/utils'
+import { utxoTags } from './utils'
+
+jest.mock('../fb/utils', () => ({
+  ...jest.requireActual('../fb/utils'),
+  utxo: {
+    ...jest.requireActual('../fb/utils').utxo,
+    isFidelityBond: jest.fn(),
+  },
+}))
+
+const makeUtxo = (overrides: Partial<Utxo> = {}) =>
+  ({
+    address: 'bc1qexampleaddress',
+    path: 'm/0/0',
+    label: '',
+    value: 0,
+    tries: 0,
+    tries_remaining: 0,
+    external: false,
+    mixdepth: 0,
+    confirmations: 0,
+    frozen: false,
+    utxo: 'deadbeef:0',
+    ...overrides,
+  }) as Utxo
+
+const makeWalletInfo = (status?: string, address = 'bc1qexampleaddress') =>
+  ({
+    addressSummary: status ? { [address]: { address, status } } : {},
+  }) as any
+
+describe('utxoTags', () => {
+  const t = ((key: string) => key) as unknown as TFunction
+
+  beforeEach(() => {
+    ;(fb.utxo.isFidelityBond as jest.Mock).mockReturnValue(false)
+  })
+
+  it('parses the leading status and keeps the label tag', () => {
+    const tags = utxoTags(makeUtxo({ label: 'saved for fees' }), makeWalletInfo('reused [FROZEN]'), t)
+
+    expect(tags).toEqual([
+      { value: 'reused', displayValue: 'reused', color: 'danger' },
+      { value: 'saved for fees', displayValue: 'saved for fees', color: 'normal' },
+    ])
+  })
+
+  it('ignores address status when the utxo is timelocked', () => {
+    const tags = utxoTags(makeUtxo({ locktime: '2099-12-01', label: 'locked output' }), makeWalletInfo('cj-out'), t)
+
+    expect(tags).toEqual([{ value: 'locked output', displayValue: 'locked output', color: 'normal' }])
+  })
+
+  it('adds the fidelity bond tag first when applicable', () => {
+    ;(fb.utxo.isFidelityBond as jest.Mock).mockReturnValue(true)
+
+    const tags = utxoTags(makeUtxo({ label: 'fb output' }), makeWalletInfo('cj-out'), t)
+
+    expect(tags).toEqual([
+      { value: 'bond', displayValue: 'jar_details.utxo_list.utxo_tag_fb', color: 'dark' },
+      { value: 'cj-out', displayValue: 'cj-out', color: 'success' },
+      { value: 'fb output', displayValue: 'fb output', color: 'normal' },
+    ])
+  })
+})

--- a/src/constants/features.test.ts
+++ b/src/constants/features.test.ts
@@ -1,0 +1,25 @@
+import { isFeatureEnabled } from './features'
+
+describe('isFeatureEnabled', () => {
+  it('respects the txFeeOnSend version boundary', () => {
+    expect(
+      isFeatureEnabled('txFeeOnSend', {
+        server: {
+          version: { major: 0, minor: 9, patch: 10 },
+        },
+      } as any),
+    ).toBe(false)
+
+    expect(
+      isFeatureEnabled('txFeeOnSend', {
+        server: {
+          version: { major: 0, minor: 9, patch: 11 },
+        },
+      } as any),
+    ).toBe(true)
+  })
+
+  it('returns false when the service has no server info', () => {
+    expect(isFeatureEnabled('importWallet', {} as any)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds the first coverage-focused patch for the Send/Earn testing project.

It starts with a small, reviewable slice:
- adds direct unit tests for `src/components/Send/helpers.ts`
- adds a version-boundary test for `src/constants/features.ts`
- adds helper coverage for `src/components/utxo/utils.ts`
- documents the current testing patterns in `TESTING.md`
- enables coverage-aware CI execution and adds an initial Jest coverage threshold

## Why

Jam’s most important flows are `Send` and `Earn`, but the current repo has only light direct coverage around the supporting logic and no enforced CI coverage contract.

This patch is meant to establish:
- a concrete testing direction for the send-related helpers
- a small public contribution mentors can review easily
- a baseline coverage gate that prevents silent regression

## What changed

### Tests
- added `src/components/Send/helpers.test.ts`
- added `src/constants/features.test.ts`
- added `src/components/utxo/utils.test.ts`

### Documentation
- added `TESTING.md` covering:
  - provider wrapping via `src/testUtils.tsx`
  - API mocking patterns
  - WebSocket mocking via `src/setupTests.ts`
  - async testing conventions

### CI / Coverage
- updated GitHub Actions test step to run Jest with coverage
- added global `coverageThreshold` in `package.json`

## Validation

Ran:

```bash
npm test -- --coverage --watchAll=false --runInBand
