### PR TITLE
fix: avoid crash when direct-send output lookup misses

### DIFF
--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -262,11 +262,12 @@ export default function Send({ wallet }: SendProps) {
           txinfo: { outputs, inputs, txid },
         } = await res.json()
         const output = outputs.find((o: any) => o.address === destination)
+        const successfulOutput = output ?? { value_sats: amountSats, address: destination }
         setPaymentSuccessfulInfoAlert({
           variant: 'success',
           message: t('send.alert_payment_successful', {
-            amount: output.value_sats,
-            address: output.address,
+            amount: successfulOutput.value_sats,
+            address: successfulOutput.address,
             txid,
           }),
         })


### PR DESCRIPTION
Fixes #1188

The success path assumed outputs.find(...) always returns a match and dereferenced it immediately. When no exact match is found, that raised a TypeError after the transaction succeeded.

This keeps the success flow alive by falling back to the known destination and amount for the alert message, then continues with the UTXO wait tracking as before.

Greetings, saschabuehrle