### PR TITLE
fix: correct post-increment to pre-increment in recursive wallet balance reload

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -338,7 +338,7 @@ const WalletInfoAutoReload = ({ currentWallet, reloadWalletInfo }: WalletInfoAut
         const info = await reloadWalletInfo({ delay, force: false })
         const newBalance = info.balanceSummary.calculatedTotalBalanceInSats
         if (newBalance > currentBalance) {
-          await reloadWhileBalanceChangesRecursively(newBalance, delay, maxCalls, callCounter++)
+          await reloadWhileBalanceChangesRecursively(newBalance, delay, maxCalls, callCounter + 1)
         }
       }
 


### PR DESCRIPTION
# Fix recursive reload counter not advancing (Bug #1194)

## Summary
This PR fixes a recursion counter bug in the wallet info reload flow after rescan.

In `reloadWhileBalanceChangesRecursively`, the recursive call used `callCounter++` as a function argument. Post-increment returns the current value before incrementing, so each recursive invocation received the same counter value. As a result, the `callCounter >= maxCalls` guard could be bypassed when balance kept increasing.

## What This Fixed
- Ensured the recursion counter advances on each recursive call.
- Restored correct enforcement of `MAX_RECURSIVE_WALLET_INFO_RELOADS`.
- Prevented potentially unbounded recursive reloads during incremental balance discovery after rescan.

## Code Change
- File: `src/components/App.tsx`
- Updated recursive call argument:

```ts
await reloadWhileBalanceChangesRecursively(newBalance, delay, maxCalls, callCounter + 1)
```

## Root Cause
Using post-increment in a call expression (`callCounter++`) passes the old value to the callee. The incremented value is only applied to the local variable after evaluation, which did not help the next recursive call argument.

## Expected Behavior After Fix
If balance continues to increase across reloads, recursive retries now stop after `maxCalls` iterations as intended.

## Validation
Ran targeted tests:

```bash
npm test -- --watchAll=false src/components/App.test.tsx
```

Result:
- 1 test suite passed
- 5 tests passed
- 0 failures

Note:
- Running a duplicated pasted command string (for example appending a second `npm test ...` on the same line) causes Jest to parse an invalid test pattern and may run unrelated suites.
- In that case, failures like missing `localStorage` can appear from unintended full-suite execution and are not caused by this fix.

## Risk
Low. The change is a single-argument correction in one recursive call path and does not alter external APIs or unrelated logic.
