### PR TITLE
feat: forbid sweep with direct send

### DIFF
--- a/src/components/Send/AmountInputField.tsx
+++ b/src/components/Send/AmountInputField.tsx
@@ -35,6 +35,9 @@ export const AmountInputField = ({
   const form = useFormikContext<any>()
   const ref = useRef<HTMLInputElement>(null)
 
+  const isCoinJoin = form.values.isCoinJoin !== false
+  const isSweepDisabledByDirectSend = enableSweep && !isCoinJoin
+
   return (
     <>
       <rb.Form.Group className="mb-4" controlId={name}>
@@ -73,28 +76,42 @@ export const AmountInputField = ({
                 </rb.Button>
               )}
               {enableSweep && field.value?.isSweep !== true && (
-                <rb.Button
-                  variant="outline-dark"
-                  className={styles.button}
-                  onClick={() => {
-                    if (!sourceJarBalance) return
-                    form.setFieldValue(
-                      field.name,
-                      {
-                        value: 0,
-                        isSweep: true,
-                        displayValue: formatBtcDisplayValue(sourceJarBalance.calculatedAvailableBalanceInSats),
-                      },
-                      true,
+                <rb.OverlayTrigger
+                  placement="bottom"
+                  overlay={
+                    isSweepDisabledByDirectSend ? (
+                      <rb.Tooltip>{t('send.button_sweep_disabled_direct_send')}</rb.Tooltip>
+                    ) : (
+                      <span />
                     )
-                  }}
-                  disabled={disabled || !sourceJarBalance}
+                  }
                 >
-                  <div className="d-flex justify-content-center align-items-center">
-                    <Sprite symbol="sweep" width="24px" height="24px" className="me-1" />
-                    {t('send.button_sweep')}
-                  </div>
-                </rb.Button>
+                  <span className="d-inline-block">
+                    <rb.Button
+                      variant="outline-dark"
+                      className={styles.button}
+                      onClick={() => {
+                        if (!sourceJarBalance) return
+                        form.setFieldValue(
+                          field.name,
+                          {
+                            value: 0,
+                            isSweep: true,
+                            displayValue: formatBtcDisplayValue(sourceJarBalance.calculatedAvailableBalanceInSats),
+                          },
+                          true,
+                        )
+                      }}
+                      disabled={disabled || !sourceJarBalance || isSweepDisabledByDirectSend}
+                      style={isSweepDisabledByDirectSend ? { pointerEvents: 'none' } : undefined}
+                    >
+                      <div className="d-flex justify-content-center align-items-center">
+                        <Sprite symbol="sweep" width="24px" height="24px" className="me-1" />
+                        {t('send.button_sweep')}
+                      </div>
+                    </rb.Button>
+                  </span>
+                </rb.OverlayTrigger>
               )}
             </BitcoinAmountInput>
           </div>

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -339,13 +339,26 @@ const InnerSendForm = ({
           disabled={disabled}
         >
           <rb.Form.Group controlId="isCoinjoin" className="mb-3">
-            <ToggleSwitch
-              label={t('send.toggle_coinjoin')}
-              subtitle={t('send.toggle_coinjoin_subtitle')}
-              toggledOn={props.values.isCoinJoin}
-              onToggle={(isToggled) => props.setFieldValue('isCoinJoin', isToggled, true)}
-              disabled={disabled || isLoading}
-            />
+            <rb.OverlayTrigger
+              placement="right"
+              overlay={
+                props.values.amount?.isSweep ? (
+                  <rb.Tooltip>{t('send.toggle_coinjoin_disabled_sweep')}</rb.Tooltip>
+                ) : (
+                  <span />
+                )
+              }
+            >
+              <div>
+                <ToggleSwitch
+                  label={t('send.toggle_coinjoin')}
+                  subtitle={t('send.toggle_coinjoin_subtitle')}
+                  toggledOn={props.values.isCoinJoin}
+                  onToggle={(isToggled) => props.setFieldValue('isCoinJoin', isToggled, true)}
+                  disabled={disabled || isLoading || props.values.amount?.isSweep === true}
+                />
+              </div>
+            </rb.OverlayTrigger>
           </rb.Form.Group>
 
           <div className={!props.values.isCoinJoin ? 'mb-4 d-block' : 'd-none'}>
@@ -432,6 +445,9 @@ export const SendForm = ({
     /** amount */
     if (!isValidAmount(values.amount?.value ?? null, values.amount?.isSweep || false)) {
       errors.amount = t('send.feedback_invalid_amount')
+    }
+    if (values.amount?.isSweep === true && values.isCoinJoin === false) {
+      errors.amount = t('send.button_sweep_disabled_direct_send')
     }
     /** amount - end */
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -322,6 +322,8 @@
     "text_sending": "Sending",
     "button_sweep": "Sweep",
     "button_clear_sweep": "Clear",
+    "button_sweep_disabled_direct_send": "Sweep is not available because direct send is activated.",
+    "toggle_coinjoin_disabled_sweep": "This option cannot be changed because sweep is activated.",
     "button_sweep_amount_breakdown": "How is this calculated?",
     "sweep_amount_breakdown_total_balance": "Total balance",
     "sweep_amount_breakdown_frozen_balance": "Frozen or locked balance",


### PR DESCRIPTION
Fixes #810 

Disables the sweep button when direct send is active, and disables the CoinJoin toggle when sweep is active. Tooltip hints explain why each control is disabled. A form validation check also blocks the invalid combo at submit time.