### PR TITLE
fix(receive): ignore share cancellation to prevent false error toast

### DIFF
--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -100,7 +100,13 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
           title: 'Bitcoin Address',
           text: bitcoinAddress,
         })
-        .catch(() => {
+        .catch((error: unknown) => {
+          if (
+            error instanceof DOMException
+            && (error.name === 'AbortError' || error.name === 'NotAllowedError')
+          ) {
+            return
+          }
           toast.error(t('receive.error_share_address_failed'))
         })
     } else {


### PR DESCRIPTION
# Fix: ignore share cancellation in receive flow

# Problem

Cancelling the native share dialog was incorrectly treated as an error, triggering an unnecessary error toast.

# Solution

* Detect cancellation using `AbortError` / `NotAllowedError`
* Ignore these cases as expected user behavior
* Preserve error handling for genuine failures

#Impact

* Improves UX by preventing false error messages
* Aligns behavior with native share expectations

# Scope

* Minimal change limited to `ReceivePage.tsx`
* No impact on other flows

# Notes

This change avoids conflicts with ongoing PRs by targeting an isolated part of the receive module.
