### PR TITLE
fix: correct destructive styling typo and standardize error styles

### DIFF
--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -128,7 +128,7 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.maxCjFeeAbs && <div className="text-desctructive mt-1 text-xs">{errors.maxCjFeeAbs}</div>}
+          {errors.maxCjFeeAbs && <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeAbs}</div>}
         </div>
 
         {/* Relative limit field */}
@@ -148,7 +148,7 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.maxCjFeeRel && <div className="text-desctructive mt-1 text-xs">{errors.maxCjFeeRel}</div>}
+          {errors.maxCjFeeRel && <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeRel}</div>}
         </div>
       </div>
     )

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -205,7 +205,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
               <AccordionItem value="collaborator-fees">
                 <AccordionTrigger
                   className={cx({
-                    'text-desctructive border-red-300':
+                    'text-destructive border-red-300':
                       collaboratorFormRef.current && !collaboratorFormRef.current.getFormData(),
                   })}
                 >
@@ -247,7 +247,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
               <AccordionItem value="mining-fees">
                 <AccordionTrigger
                   className={cx({
-                    'text-desctructive border-red-300': miningFormRef.current && !miningFormRef.current.getFormData(),
+                    'text-destructive border-red-300': miningFormRef.current && !miningFormRef.current.getFormData(),
                   })}
                 >
                   {t('settings.fees.title_general_fee_settings')}
@@ -281,7 +281,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
         </div>
 
         {saveErrorMessage && (
-          <div className="text-desctructive mb-4 w-full rounded-lg border border-red-200 p-2 text-sm">
+          <div className="text-destructive mb-4 w-full rounded-lg border border-red-200 p-2 text-sm">
             {saveErrorMessage}
           </div>
         )}

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -211,7 +211,7 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.txFeesFactor && <div className="mt-1 text-xs text-red-500">{errors.txFeesFactor}</div>}
+          {errors.txFeesFactor && <div className="text-destructive mt-1 text-xs">{errors.txFeesFactor}</div>}
         </div>
 
         <div className="space-y-2">
@@ -234,7 +234,7 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.maxSweepFeeChange && <div className="mt-1 text-xs text-red-500">{errors.maxSweepFeeChange}</div>}
+          {errors.maxSweepFeeChange && <div className="text-destructive mt-1 text-xs">{errors.maxSweepFeeChange}</div>}
         </div>
       </div>
     )

--- a/src/components/settings/TxFeeInputField.tsx
+++ b/src/components/settings/TxFeeInputField.tsx
@@ -93,7 +93,7 @@ export const TxFeeInputField = ({
           disabled={disabled}
         />
       </div>
-      {error && <div className="mt-1 text-xs text-red-500">{error}</div>}
+      {error && <div className="text-destructive mt-1 text-xs">{error}</div>}
     </div>
   )
 }


### PR DESCRIPTION
## What
Fixes incorrect Tailwind class `text-desctructive` used in fee settings and standardizes error text styling.

## Changes
- Replaced all instances of `text-desctructive` with `text-destructive`
- Replaced `text-red-500` with `text-destructive` for consistent design system usage

## Why
Ensures correct and consistent error styling across settings UI components.

## Test Plan
- Trigger validation errors in fee settings
- Verified correct styling is applied