### PR TITLE
feat: add numeric input constraints to fee settings forms

### DIFF
--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -121,7 +121,10 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
             </div>
             <Input
               id="max-cj-fee-abs"
-              type="text"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="any"
               value={maxCjFeeAbs}
               onChange={(event) => setMaxCjFeeAbs(event.target.value)}
               placeholder="0.00 007 517"
@@ -141,7 +144,11 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
             </div>
             <Input
               id="max-cj-fee-rel"
-              type="text"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              max="100"
+              step="any"
               value={maxCjFeeRel}
               onChange={(event) => setMaxCjFeeRel(event.target.value)}
               placeholder="0.03"

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -204,7 +204,11 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
               <span className="text-sm font-medium">%</span>
             </div>
             <Input
-              type="text"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              max="100"
+              step="any"
               value={txFeesFactor}
               onChange={(event) => setTxFeesFactor(event.target.value)}
               placeholder="20"
@@ -227,7 +231,11 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
               <span className="text-sm font-medium">%</span>
             </div>
             <Input
-              type="text"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              max="100"
+              step="any"
               value={maxSweepFeeChange}
               onChange={(event) => setMaxSweepFeeChange(event.target.value)}
               placeholder="80"

--- a/src/components/settings/TxFeeInputField.tsx
+++ b/src/components/settings/TxFeeInputField.tsx
@@ -85,7 +85,10 @@ export const TxFeeInputField = ({
           )}
         </div>
         <Input
-          type="text"
+          type="number"
+          inputMode="decimal"
+          min="0"
+          step="any"
           value={value}
           onChange={(event) => onValueChange(event.target.value)}
           placeholder={unit === txFeeUnit.BLOCKS ? '3' : '1.0'}


### PR DESCRIPTION
## What
Adds numeric input constraints to fee settings inputs.

## Changes
- Added `type="number"` and `inputMode="decimal"`
- Added `min`, `max`, and `step` where appropriate
- Kept existing validation logic unchanged

## Why
Improves user experience by preventing invalid input and enabling better mobile keyboard support.

## Test Plan
- Verified inputs only accept numeric values
- Checked that existing validation still works correctly