### PR TITLE
refactor(settings): use react-hook-form for fee settings forms

### DIFF
--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -601,6 +601,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
               addressSummary={addressSummary}
               walletBalanceSummary={walletBalanceSummary}
               disabled={
+                maxFeesConfigMissing ||
                 jmSession?.maker_running ||
                 collaborativeFlowActive ||
                 jmSession?.rescanning ||

--- a/src/components/send/feeEstimate.ts
+++ b/src/components/send/feeEstimate.ts
@@ -15,7 +15,7 @@ export const estimateMaxCollaboratorFee = (
     throw new Error('Invalid state: Missing fee config values.')
   }
   const maxAbsoluteFee = Number.parseInt(feeConfigValues.max_cj_fee_abs || '', 10)
-  if (!Number.isFinite(maxAbsoluteFee)) {
+  if (!Number.isSafeInteger(maxAbsoluteFee)) {
     throw new TypeError('Invalid state: Missing "max_cj_fee_abs" fee config value.')
   }
   const maxRelativeFee = Number.parseFloat(feeConfigValues.max_cj_fee_rel || '')

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import * as yup from 'yup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { CJ_FEE_ABS_MIN, CJ_FEE_ABS_MAX, CJ_FEE_REL_MIN, CJ_FEE_REL_MAX } from '@/constants/jam'
-import { isValidNumber, factorToPercentage, percentageToFactor, formatSats } from '@/lib/utils'
+import { factorToPercentage, percentageToFactor, formatSats } from '@/lib/utils'
 import { Field, FieldDescription, FieldLabel } from '../ui/field'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
 import { SatSymbol } from '../ui/jam/CurrencySymbol'
@@ -69,29 +69,17 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
       return yup
         .object({
           maxCjFeeAbs: yup
-            .string()
-            .test('max-cj-fee-abs', maxCjFeeAbsMessage, (value) => {
-              const absoluteFeeValue = Number(value)
-              return (
-                !!value &&
-                isValidNumber(absoluteFeeValue) &&
-                absoluteFeeValue >= CJ_FEE_ABS_MIN &&
-                absoluteFeeValue <= CJ_FEE_ABS_MAX
-              )
-            })
+            .number()
+            .integer(maxCjFeeAbsMessage)
+            .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+            .min(CJ_FEE_ABS_MIN, maxCjFeeAbsMessage)
+            .max(CJ_FEE_ABS_MAX, maxCjFeeAbsMessage)
             .required(maxCjFeeAbsMessage),
           maxCjFeeRel: yup
-            .string()
-            .test('max-cj-fee-rel', maxCjFeeRelMessage, (value) => {
-              const relativeFeeValue = Number(value)
-              const relFactorVal = percentageToFactor(relativeFeeValue)
-              return (
-                !!value &&
-                isValidNumber(relativeFeeValue) &&
-                relFactorVal >= CJ_FEE_REL_MIN &&
-                relFactorVal <= CJ_FEE_REL_MAX
-              )
-            })
+            .number()
+            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+            .min(factorToPercentage(CJ_FEE_REL_MIN), maxCjFeeRelMessage)
+            .max(factorToPercentage(CJ_FEE_REL_MAX), maxCjFeeRelMessage)
             .required(maxCjFeeRelMessage),
         })
         .required()

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -1,14 +1,25 @@
 import { useEffect, forwardRef, useImperativeHandle, useMemo } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { InfoIcon } from 'lucide-react'
+import { InfoIcon, PercentIcon } from 'lucide-react'
 import { useForm, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import * as yup from 'yup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { CJ_FEE_ABS_MIN, CJ_FEE_ABS_MAX, CJ_FEE_REL_MIN, CJ_FEE_REL_MAX } from '@/constants/jam'
-import { isValidNumber, factorToPercentage, percentageToFactor } from '@/lib/utils'
+import { isValidNumber, factorToPercentage, percentageToFactor, formatSats } from '@/lib/utils'
+import { Field, FieldDescription, FieldLabel } from '../ui/field'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
+import { SatSymbol } from '../ui/jam/CurrencySymbol'
+
+const FieldPrefixSatSymbol = (
+  <SatSymbol
+    width={'18px'}
+    height={'18px'}
+    style={{
+      margin: '5px -1px',
+    }}
+  />
+)
 
 interface CollaboratorFeesFormProps {
   initialValues: {
@@ -47,8 +58,8 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
       }
 
       const maxCjFeeAbsMessage = t('settings.fees.feedback_invalid_max_cj_fee_abs', {
-        min: CJ_FEE_ABS_MIN,
-        max: CJ_FEE_ABS_MAX,
+        min: formatSats(CJ_FEE_ABS_MIN),
+        max: formatSats(CJ_FEE_ABS_MAX),
       })
       const maxCjFeeRelMessage = t('settings.fees.feedback_invalid_max_cj_fee_rel', {
         min: factorToPercentage(CJ_FEE_REL_MIN),
@@ -139,61 +150,60 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
     )
 
     return (
-      <div>
-        <p className="text-muted-foreground mb-6 text-sm">{t('settings.fees.description_max_cj_fee_settings')}</p>
+      <div className="space-y-6">
+        <p className="text-muted-foreground text-sm">{t('settings.fees.description_max_cj_fee_settings')}</p>
 
-        <Alert variant="default" className="mb-6">
+        <Alert variant="default">
           <InfoIcon className="text-muted-foreground size-4 shrink-0" />
           <AlertDescription>{t('settings.fees.subtitle_max_cj_fee')}</AlertDescription>
         </Alert>
 
         {/* Absolute limit field */}
-        <div className="mb-6 space-y-2">
-          <Label htmlFor="max-cj-fee-abs">{t('settings.fees.label_max_cj_fee_abs')}</Label>
-          <p className="text-muted-foreground text-xs">{t('settings.fees.description_max_cj_fee_abs')}</p>
-          <div className="flex h-12 items-center">
-            <div className="bg-muted flex h-full items-center rounded-l-md border border-r-0 px-3 py-2">
-              <span className="text-sm font-medium">₿</span>
-            </div>
-            <Input
-              id="max-cj-fee-abs"
-              {...register('maxCjFeeAbs')}
-              type="number"
-              inputMode="decimal"
-              min="0"
-              step="any"
-              placeholder="0.00 007 517"
-              className="h-full rounded-l-none"
-            />
-          </div>
-          {errors.maxCjFeeAbs?.message && (
-            <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeAbs.message}</div>
-          )}
+
+        <div className="space-y-2">
+          <Field data-invalid={errors.maxCjFeeAbs !== undefined}>
+            <FieldLabel htmlFor="collaborator-fees-max-cj-fee-abs">
+              {t('settings.fees.label_max_cj_fee_abs')}
+            </FieldLabel>
+            <FieldDescription className="text-xs">{t('settings.fees.description_max_cj_fee_abs')}</FieldDescription>
+            <InputGroup>
+              <InputGroupInput
+                id="collaborator-fees-max-cj-fee-abs"
+                {...register('maxCjFeeAbs')}
+                type="number"
+                inputMode="numeric"
+                min="0"
+                step="any"
+              />
+              <InputGroupAddon align="inline-start">{FieldPrefixSatSymbol}</InputGroupAddon>
+            </InputGroup>
+          </Field>
+          {errors.maxCjFeeAbs?.message && <div className="text-destructive text-xs">{errors.maxCjFeeAbs.message}</div>}
         </div>
 
         {/* Relative limit field */}
         <div className="space-y-2">
-          <Label htmlFor="max-cj-fee-rel">{t('settings.fees.label_max_cj_fee_rel')}</Label>
-          <p className="text-muted-foreground text-xs">{t('settings.fees.description_max_cj_fee_rel')}</p>
-          <div className="flex h-12 items-center">
-            <div className="bg-muted flex h-full items-center rounded-l-md border border-r-0 px-3 py-2">
-              <span className="text-sm font-medium">%</span>
-            </div>
-            <Input
-              id="max-cj-fee-rel"
-              {...register('maxCjFeeRel')}
-              type="number"
-              inputMode="decimal"
-              min="0"
-              max="100"
-              step="any"
-              placeholder="0.03"
-              className="h-full rounded-l-none"
-            />
-          </div>
-          {errors.maxCjFeeRel?.message && (
-            <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeRel.message}</div>
-          )}
+          <Field data-invalid={errors.maxCjFeeRel !== undefined}>
+            <FieldLabel htmlFor="collaborator-fees-max-cj-fee-rel">
+              {t('settings.fees.label_max_cj_fee_rel')}
+            </FieldLabel>
+            <FieldDescription className="text-xs">{t('settings.fees.description_max_cj_fee_rel')}</FieldDescription>
+            <InputGroup>
+              <InputGroupInput
+                id="collaborator-fees-max-cj-fee-rel"
+                {...register('maxCjFeeRel')}
+                type="number"
+                inputMode="decimal"
+                min="0"
+                max="100"
+                step="any"
+              />
+              <InputGroupAddon align="inline-start">
+                <PercentIcon />
+              </InputGroupAddon>
+            </InputGroup>
+          </Field>
+          {errors.maxCjFeeRel?.message && <div className="text-destructive text-xs">{errors.maxCjFeeRel.message}</div>}
         </div>
       </div>
     )

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect, forwardRef, useImperativeHandle, useCallback } from 'react'
+import { useEffect, forwardRef, useImperativeHandle, useMemo } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
 import { InfoIcon } from 'lucide-react'
+import { useForm, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import * as yup from 'yup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -15,6 +18,11 @@ interface CollaboratorFeesFormProps {
   enableValidation?: boolean
 }
 
+type CollaboratorFeesFormValues = {
+  maxCjFeeAbs: string
+  maxCjFeeRel: string
+}
+
 export interface CollaboratorFeesFormRef {
   getFormData: () => {
     maxCjFeeAbs: string
@@ -22,85 +30,113 @@ export interface CollaboratorFeesFormRef {
   } | null
   setFormData: (data: { maxCjFeeAbs: string; maxCjFeeRel: string }) => void
   resetForm: () => void
-  validateForm: () => boolean
+  validateForm: () => Promise<boolean>
 }
 
 export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, CollaboratorFeesFormProps>(
   ({ initialValues, enableValidation = true }, ref) => {
     const { t } = useTranslation()
-    const [maxCjFeeAbs, setMaxCjFeeAbs] = useState(initialValues.maxCjFeeAbs)
-    const [maxCjFeeRel, setMaxCjFeeRel] = useState(initialValues.maxCjFeeRel)
-    const [errors, setErrors] = useState<{ maxCjFeeAbs?: string; maxCjFeeRel?: string }>({})
-
-    const validate = useCallback(() => {
+    const schema = useMemo(() => {
       if (!enableValidation) {
-        setErrors({})
-        return true
-      }
-      const absoluteFeeValue = Number(maxCjFeeAbs)
-      const relativeFeeValue = Number(maxCjFeeRel)
-      const newErrors: { maxCjFeeAbs?: string; maxCjFeeRel?: string } = {}
-
-      if (!maxCjFeeAbs) {
-        newErrors.maxCjFeeAbs = t('settings.fees.feedback_invalid_max_cj_fee_abs', {
-          min: CJ_FEE_ABS_MIN,
-          max: CJ_FEE_ABS_MAX,
-        })
-      } else if (
-        !isValidNumber(absoluteFeeValue) ||
-        absoluteFeeValue < CJ_FEE_ABS_MIN ||
-        absoluteFeeValue > CJ_FEE_ABS_MAX
-      ) {
-        newErrors.maxCjFeeAbs = t('settings.fees.feedback_invalid_max_cj_fee_abs', {
-          min: CJ_FEE_ABS_MIN,
-          max: CJ_FEE_ABS_MAX,
-        })
-      }
-
-      if (!maxCjFeeRel) {
-        newErrors.maxCjFeeRel = t('settings.fees.feedback_invalid_max_cj_fee_rel', {
-          min: factorToPercentage(CJ_FEE_REL_MIN),
-          max: factorToPercentage(CJ_FEE_REL_MAX),
-        })
-      } else {
-        const relFactorVal = percentageToFactor(relativeFeeValue)
-        if (!isValidNumber(relativeFeeValue) || relFactorVal < CJ_FEE_REL_MIN || relFactorVal > CJ_FEE_REL_MAX) {
-          newErrors.maxCjFeeRel = t('settings.fees.feedback_invalid_max_cj_fee_rel', {
-            min: factorToPercentage(CJ_FEE_REL_MIN),
-            max: factorToPercentage(CJ_FEE_REL_MAX),
+        return yup
+          .object({
+            maxCjFeeAbs: yup.string().default(''),
+            maxCjFeeRel: yup.string().default(''),
           })
-        }
+          .required()
       }
-      setErrors(newErrors)
-      return Object.keys(newErrors).length === 0
-    }, [enableValidation, maxCjFeeAbs, maxCjFeeRel, t])
+
+      const maxCjFeeAbsMessage = t('settings.fees.feedback_invalid_max_cj_fee_abs', {
+        min: CJ_FEE_ABS_MIN,
+        max: CJ_FEE_ABS_MAX,
+      })
+      const maxCjFeeRelMessage = t('settings.fees.feedback_invalid_max_cj_fee_rel', {
+        min: factorToPercentage(CJ_FEE_REL_MIN),
+        max: factorToPercentage(CJ_FEE_REL_MAX),
+      })
+
+      return yup
+        .object({
+          maxCjFeeAbs: yup
+            .string()
+            .test('max-cj-fee-abs', maxCjFeeAbsMessage, (value) => {
+              const absoluteFeeValue = Number(value)
+              return (
+                !!value &&
+                isValidNumber(absoluteFeeValue) &&
+                absoluteFeeValue >= CJ_FEE_ABS_MIN &&
+                absoluteFeeValue <= CJ_FEE_ABS_MAX
+              )
+            })
+            .required(maxCjFeeAbsMessage),
+          maxCjFeeRel: yup
+            .string()
+            .test('max-cj-fee-rel', maxCjFeeRelMessage, (value) => {
+              const relativeFeeValue = Number(value)
+              const relFactorVal = percentageToFactor(relativeFeeValue)
+              return (
+                !!value &&
+                isValidNumber(relativeFeeValue) &&
+                relFactorVal >= CJ_FEE_REL_MIN &&
+                relFactorVal <= CJ_FEE_REL_MAX
+              )
+            })
+            .required(maxCjFeeRelMessage),
+        })
+        .required()
+    }, [enableValidation, t])
+
+    const {
+      register,
+      getValues,
+      reset,
+      trigger,
+      formState: { errors },
+    } = useForm<CollaboratorFeesFormValues, unknown, CollaboratorFeesFormValues>({
+      mode: 'onChange',
+      defaultValues: initialValues,
+      resolver: yupResolver(schema as yup.AnyObjectSchema) as Resolver<
+        CollaboratorFeesFormValues,
+        unknown,
+        CollaboratorFeesFormValues
+      >,
+    })
 
     useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      validate()
-    }, [maxCjFeeAbs, maxCjFeeRel, validate, enableValidation])
+      void trigger()
+    }, [trigger, enableValidation])
 
-    useImperativeHandle(ref, () => ({
-      getFormData: () => {
-        if (!validate()) return null
-        return {
-          maxCjFeeAbs,
-          maxCjFeeRel: maxCjFeeRel ? String(percentageToFactor(Number(maxCjFeeRel))) : '',
-        }
-      },
-      setFormData: (data) => {
-        setMaxCjFeeAbs(data.maxCjFeeAbs)
-        const relVal = data.maxCjFeeRel ? factorToPercentage(Number(data.maxCjFeeRel)) : ''
-        setMaxCjFeeRel(String(relVal))
-        setErrors({})
-      },
-      resetForm: () => {
-        setMaxCjFeeAbs('')
-        setMaxCjFeeRel('')
-        setErrors({})
-      },
-      validateForm: () => validate(),
-    }))
+    useImperativeHandle(
+      ref,
+      () => ({
+        getFormData: () => {
+          const values = getValues()
+          if (!schema.isValidSync(values)) {
+            return null
+          }
+          return {
+            maxCjFeeAbs: values.maxCjFeeAbs,
+            maxCjFeeRel: values.maxCjFeeRel ? String(percentageToFactor(Number(values.maxCjFeeRel))) : '',
+          }
+        },
+        setFormData: (data) => {
+          reset({
+            maxCjFeeAbs: data.maxCjFeeAbs,
+            maxCjFeeRel: data.maxCjFeeRel ? String(factorToPercentage(Number(data.maxCjFeeRel))) : '',
+          })
+          void trigger()
+        },
+        resetForm: () => {
+          reset({
+            maxCjFeeAbs: '',
+            maxCjFeeRel: '',
+          })
+          void trigger()
+        },
+        validateForm: () => trigger(),
+      }),
+      [getValues, reset, schema, trigger],
+    )
 
     return (
       <div>
@@ -121,17 +157,18 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
             </div>
             <Input
               id="max-cj-fee-abs"
+              {...register('maxCjFeeAbs')}
               type="number"
               inputMode="decimal"
               min="0"
               step="any"
-              value={maxCjFeeAbs}
-              onChange={(event) => setMaxCjFeeAbs(event.target.value)}
               placeholder="0.00 007 517"
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.maxCjFeeAbs && <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeAbs}</div>}
+          {errors.maxCjFeeAbs?.message && (
+            <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeAbs.message}</div>
+          )}
         </div>
 
         {/* Relative limit field */}
@@ -144,18 +181,19 @@ export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, Collabor
             </div>
             <Input
               id="max-cj-fee-rel"
+              {...register('maxCjFeeRel')}
               type="number"
               inputMode="decimal"
               min="0"
               max="100"
               step="any"
-              value={maxCjFeeRel}
-              onChange={(event) => setMaxCjFeeRel(event.target.value)}
               placeholder="0.03"
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.maxCjFeeRel && <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeRel}</div>}
+          {errors.maxCjFeeRel?.message && (
+            <div className="text-destructive mt-1 text-xs">{errors.maxCjFeeRel.message}</div>
+          )}
         </div>
       </div>
     )

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -27,7 +27,7 @@ export const CollaboratorFeesForm = ({
   className,
   form: {
     register,
-    formState: { errors },
+    formState: { errors, disabled },
   },
 }: CollaboratorFeesFormProps) => {
   const { t } = useTranslation()
@@ -49,6 +49,7 @@ export const CollaboratorFeesForm = ({
             <InputGroupInput
               id="collaborator-fees-max-cj-fee-abs"
               {...register('maxCjFeeAbs', {
+                disabled,
                 valueAsNumber: true,
               })}
               type="number"
@@ -70,6 +71,7 @@ export const CollaboratorFeesForm = ({
             <InputGroupInput
               id="collaborator-fees-max-cj-fee-rel"
               {...register('maxCjFeeRelInPercent', {
+                disabled,
                 valueAsNumber: true,
               })}
               type="number"

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -41,8 +41,6 @@ export const CollaboratorFeesForm = ({
         <AlertDescription>{t('settings.fees.subtitle_max_cj_fee')}</AlertDescription>
       </Alert>
 
-      {/* Absolute limit field */}
-
       <div className="space-y-2">
         <Field data-invalid={errors.maxCjFeeAbs !== undefined}>
           <FieldLabel htmlFor="collaborator-fees-max-cj-fee-abs">{t('settings.fees.label_max_cj_fee_abs')}</FieldLabel>
@@ -54,7 +52,7 @@ export const CollaboratorFeesForm = ({
               type="number"
               inputMode="numeric"
               min="0"
-              step="any"
+              step="1"
             />
             <InputGroupAddon align="inline-start">{FieldPrefixSatSymbol}</InputGroupAddon>
           </InputGroup>
@@ -62,7 +60,6 @@ export const CollaboratorFeesForm = ({
         {errors.maxCjFeeAbs?.message && <div className="text-destructive text-xs">{errors.maxCjFeeAbs.message}</div>}
       </div>
 
-      {/* Relative limit field */}
       <div className="space-y-2">
         <Field data-invalid={errors.maxCjFeeRelInPercent !== undefined}>
           <FieldLabel htmlFor="collaborator-fees-max-cj-fee-rel">{t('settings.fees.label_max_cj_fee_rel')}</FieldLabel>
@@ -75,7 +72,7 @@ export const CollaboratorFeesForm = ({
               inputMode="decimal"
               min="0"
               max="100"
-              step="any"
+              step="0.0001"
             />
             <InputGroupAddon align="inline-start">
               <PercentIcon />

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -1,15 +1,12 @@
-import { useEffect, forwardRef, useImperativeHandle, useMemo } from 'react'
-import { yupResolver } from '@hookform/resolvers/yup'
 import { InfoIcon, PercentIcon } from 'lucide-react'
-import { useForm, type Resolver } from 'react-hook-form'
+import { type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import * as yup from 'yup'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { CJ_FEE_ABS_MIN, CJ_FEE_ABS_MAX, CJ_FEE_REL_MIN, CJ_FEE_REL_MAX } from '@/constants/jam'
-import { factorToPercentage, percentageToFactor, formatSats } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 import { Field, FieldDescription, FieldLabel } from '../ui/field'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
 import { SatSymbol } from '../ui/jam/CurrencySymbol'
+import type { CollaboratorFeesFormValues } from './CollaboratorFeesFormSchema'
 
 const FieldPrefixSatSymbol = (
   <SatSymbol
@@ -22,178 +19,73 @@ const FieldPrefixSatSymbol = (
 )
 
 interface CollaboratorFeesFormProps {
-  initialValues: {
-    maxCjFeeAbs: string
-    maxCjFeeRel: string
-  }
-  enableValidation?: boolean
+  className?: string
+  form: UseFormReturn<CollaboratorFeesFormValues, unknown, CollaboratorFeesFormValues>
 }
 
-type CollaboratorFeesFormValues = {
-  maxCjFeeAbs: string
-  maxCjFeeRel: string
-}
-
-export interface CollaboratorFeesFormRef {
-  getFormData: () => {
-    maxCjFeeAbs: string
-    maxCjFeeRel: string
-  } | null
-  setFormData: (data: { maxCjFeeAbs: string; maxCjFeeRel: string }) => void
-  resetForm: () => void
-  validateForm: () => Promise<boolean>
-}
-
-export const CollaboratorFeesForm = forwardRef<CollaboratorFeesFormRef, CollaboratorFeesFormProps>(
-  ({ initialValues, enableValidation = true }, ref) => {
-    const { t } = useTranslation()
-    const schema = useMemo(() => {
-      if (!enableValidation) {
-        return yup
-          .object({
-            maxCjFeeAbs: yup.string().default(''),
-            maxCjFeeRel: yup.string().default(''),
-          })
-          .required()
-      }
-
-      const maxCjFeeAbsMessage = t('settings.fees.feedback_invalid_max_cj_fee_abs', {
-        min: formatSats(CJ_FEE_ABS_MIN),
-        max: formatSats(CJ_FEE_ABS_MAX),
-      })
-      const maxCjFeeRelMessage = t('settings.fees.feedback_invalid_max_cj_fee_rel', {
-        min: factorToPercentage(CJ_FEE_REL_MIN),
-        max: factorToPercentage(CJ_FEE_REL_MAX),
-      })
-
-      return yup
-        .object({
-          maxCjFeeAbs: yup
-            .number()
-            .integer(maxCjFeeAbsMessage)
-            .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
-            .min(CJ_FEE_ABS_MIN, maxCjFeeAbsMessage)
-            .max(CJ_FEE_ABS_MAX, maxCjFeeAbsMessage)
-            .required(maxCjFeeAbsMessage),
-          maxCjFeeRel: yup
-            .number()
-            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
-            .min(factorToPercentage(CJ_FEE_REL_MIN), maxCjFeeRelMessage)
-            .max(factorToPercentage(CJ_FEE_REL_MAX), maxCjFeeRelMessage)
-            .required(maxCjFeeRelMessage),
-        })
-        .required()
-    }, [enableValidation, t])
-
-    const {
-      register,
-      getValues,
-      reset,
-      trigger,
-      formState: { errors },
-    } = useForm<CollaboratorFeesFormValues, unknown, CollaboratorFeesFormValues>({
-      mode: 'onChange',
-      defaultValues: initialValues,
-      resolver: yupResolver(schema as yup.AnyObjectSchema) as Resolver<
-        CollaboratorFeesFormValues,
-        unknown,
-        CollaboratorFeesFormValues
-      >,
-    })
-
-    useEffect(() => {
-      void trigger()
-    }, [trigger, enableValidation])
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        getFormData: () => {
-          const values = getValues()
-          if (!schema.isValidSync(values)) {
-            return null
-          }
-          return {
-            maxCjFeeAbs: values.maxCjFeeAbs,
-            maxCjFeeRel: values.maxCjFeeRel ? String(percentageToFactor(Number(values.maxCjFeeRel))) : '',
-          }
-        },
-        setFormData: (data) => {
-          reset({
-            maxCjFeeAbs: data.maxCjFeeAbs,
-            maxCjFeeRel: data.maxCjFeeRel ? String(factorToPercentage(Number(data.maxCjFeeRel))) : '',
-          })
-          void trigger()
-        },
-        resetForm: () => {
-          reset({
-            maxCjFeeAbs: '',
-            maxCjFeeRel: '',
-          })
-          void trigger()
-        },
-        validateForm: () => trigger(),
-      }),
-      [getValues, reset, schema, trigger],
-    )
-
-    return (
-      <div className="space-y-6">
-        <p className="text-muted-foreground text-sm">{t('settings.fees.description_max_cj_fee_settings')}</p>
-
-        <Alert variant="default">
-          <InfoIcon className="text-muted-foreground size-4 shrink-0" />
-          <AlertDescription>{t('settings.fees.subtitle_max_cj_fee')}</AlertDescription>
-        </Alert>
-
-        {/* Absolute limit field */}
-
-        <div className="space-y-2">
-          <Field data-invalid={errors.maxCjFeeAbs !== undefined}>
-            <FieldLabel htmlFor="collaborator-fees-max-cj-fee-abs">
-              {t('settings.fees.label_max_cj_fee_abs')}
-            </FieldLabel>
-            <FieldDescription className="text-xs">{t('settings.fees.description_max_cj_fee_abs')}</FieldDescription>
-            <InputGroup>
-              <InputGroupInput
-                id="collaborator-fees-max-cj-fee-abs"
-                {...register('maxCjFeeAbs')}
-                type="number"
-                inputMode="numeric"
-                min="0"
-                step="any"
-              />
-              <InputGroupAddon align="inline-start">{FieldPrefixSatSymbol}</InputGroupAddon>
-            </InputGroup>
-          </Field>
-          {errors.maxCjFeeAbs?.message && <div className="text-destructive text-xs">{errors.maxCjFeeAbs.message}</div>}
-        </div>
-
-        {/* Relative limit field */}
-        <div className="space-y-2">
-          <Field data-invalid={errors.maxCjFeeRel !== undefined}>
-            <FieldLabel htmlFor="collaborator-fees-max-cj-fee-rel">
-              {t('settings.fees.label_max_cj_fee_rel')}
-            </FieldLabel>
-            <FieldDescription className="text-xs">{t('settings.fees.description_max_cj_fee_rel')}</FieldDescription>
-            <InputGroup>
-              <InputGroupInput
-                id="collaborator-fees-max-cj-fee-rel"
-                {...register('maxCjFeeRel')}
-                type="number"
-                inputMode="decimal"
-                min="0"
-                max="100"
-                step="any"
-              />
-              <InputGroupAddon align="inline-start">
-                <PercentIcon />
-              </InputGroupAddon>
-            </InputGroup>
-          </Field>
-          {errors.maxCjFeeRel?.message && <div className="text-destructive text-xs">{errors.maxCjFeeRel.message}</div>}
-        </div>
-      </div>
-    )
+export const CollaboratorFeesForm = ({
+  className,
+  form: {
+    register,
+    formState: { errors },
   },
-)
+}: CollaboratorFeesFormProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <p className="text-muted-foreground text-sm">{t('settings.fees.description_max_cj_fee_settings')}</p>
+
+      <Alert variant="default">
+        <InfoIcon className="text-muted-foreground size-4 shrink-0" />
+        <AlertDescription>{t('settings.fees.subtitle_max_cj_fee')}</AlertDescription>
+      </Alert>
+
+      {/* Absolute limit field */}
+
+      <div className="space-y-2">
+        <Field data-invalid={errors.maxCjFeeAbs !== undefined}>
+          <FieldLabel htmlFor="collaborator-fees-max-cj-fee-abs">{t('settings.fees.label_max_cj_fee_abs')}</FieldLabel>
+          <FieldDescription className="text-xs">{t('settings.fees.description_max_cj_fee_abs')}</FieldDescription>
+          <InputGroup>
+            <InputGroupInput
+              id="collaborator-fees-max-cj-fee-abs"
+              {...register('maxCjFeeAbs')}
+              type="number"
+              inputMode="numeric"
+              min="0"
+              step="any"
+            />
+            <InputGroupAddon align="inline-start">{FieldPrefixSatSymbol}</InputGroupAddon>
+          </InputGroup>
+        </Field>
+        {errors.maxCjFeeAbs?.message && <div className="text-destructive text-xs">{errors.maxCjFeeAbs.message}</div>}
+      </div>
+
+      {/* Relative limit field */}
+      <div className="space-y-2">
+        <Field data-invalid={errors.maxCjFeeRelInPercent !== undefined}>
+          <FieldLabel htmlFor="collaborator-fees-max-cj-fee-rel">{t('settings.fees.label_max_cj_fee_rel')}</FieldLabel>
+          <FieldDescription className="text-xs">{t('settings.fees.description_max_cj_fee_rel')}</FieldDescription>
+          <InputGroup>
+            <InputGroupInput
+              id="collaborator-fees-max-cj-fee-rel"
+              {...register('maxCjFeeRelInPercent')}
+              type="number"
+              inputMode="decimal"
+              min="0"
+              max="100"
+              step="any"
+            />
+            <InputGroupAddon align="inline-start">
+              <PercentIcon />
+            </InputGroupAddon>
+          </InputGroup>
+        </Field>
+        {errors.maxCjFeeRelInPercent?.message && (
+          <div className="text-destructive text-xs">{errors.maxCjFeeRelInPercent.message}</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/CollaboratorFeesForm.tsx
+++ b/src/components/settings/CollaboratorFeesForm.tsx
@@ -48,7 +48,9 @@ export const CollaboratorFeesForm = ({
           <InputGroup>
             <InputGroupInput
               id="collaborator-fees-max-cj-fee-abs"
-              {...register('maxCjFeeAbs')}
+              {...register('maxCjFeeAbs', {
+                valueAsNumber: true,
+              })}
               type="number"
               inputMode="numeric"
               min="0"
@@ -67,7 +69,9 @@ export const CollaboratorFeesForm = ({
           <InputGroup>
             <InputGroupInput
               id="collaborator-fees-max-cj-fee-rel"
-              {...register('maxCjFeeRelInPercent')}
+              {...register('maxCjFeeRelInPercent', {
+                valueAsNumber: true,
+              })}
               type="number"
               inputMode="decimal"
               min="0"

--- a/src/components/settings/CollaboratorFeesFormSchema.ts
+++ b/src/components/settings/CollaboratorFeesFormSchema.ts
@@ -1,0 +1,48 @@
+import type { TFunction } from 'i18next'
+import * as yup from 'yup'
+import { CJ_FEE_ABS_MAX, CJ_FEE_ABS_MIN, CJ_FEE_REL_MAX, CJ_FEE_REL_MIN } from '@/constants/jam'
+import { factorToPercentage, formatSats } from '@/lib/utils'
+import type { AmountSats } from '@/types/global'
+
+export type CollaboratorFeesFormValues = {
+  maxCjFeeAbs?: AmountSats
+  maxCjFeeRelInPercent?: number
+}
+
+export function collaboratorFeesFormSchema(enableFormValidation: boolean, t: TFunction<'translation', undefined>) {
+  if (!enableFormValidation) {
+    return yup
+      .object({
+        maxCjFeeAbs: yup.string().default(''),
+        maxCjFeeRelInPercent: yup.string().default(''),
+      })
+      .required()
+  }
+
+  const maxCjFeeAbsoluteMessage = t('settings.fees.feedback_invalid_max_cj_fee_abs', {
+    min: formatSats(CJ_FEE_ABS_MIN),
+    max: formatSats(CJ_FEE_ABS_MAX),
+  })
+  const maxCjFeeRelativeMessage = t('settings.fees.feedback_invalid_max_cj_fee_rel', {
+    min: factorToPercentage(CJ_FEE_REL_MIN),
+    max: factorToPercentage(CJ_FEE_REL_MAX),
+  })
+
+  return yup
+    .object({
+      maxCjFeeAbs: yup
+        .number()
+        .integer(maxCjFeeAbsoluteMessage)
+        .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+        .min(CJ_FEE_ABS_MIN, maxCjFeeAbsoluteMessage)
+        .max(CJ_FEE_ABS_MAX, maxCjFeeAbsoluteMessage)
+        .required(maxCjFeeAbsoluteMessage),
+      maxCjFeeRelInPercent: yup
+        .number()
+        .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+        .min(factorToPercentage(CJ_FEE_REL_MIN), maxCjFeeRelativeMessage)
+        .max(factorToPercentage(CJ_FEE_REL_MAX), maxCjFeeRelativeMessage)
+        .required(maxCjFeeRelativeMessage),
+    })
+    .required()
+}

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -20,7 +20,7 @@ import { Switch } from '@/components/ui/switch'
 import { FEE_CONFIG_KEYS, type FeeConfigName } from '@/constants/jm'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
-import { factorToPercentage } from '@/lib/utils'
+import { cn, factorToPercentage } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import type { WithRequiredProperty } from '@/types/global'
@@ -211,7 +211,9 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
                 >
                   {t('settings.fees.title_max_cj_fee_settings')}
                 </AccordionTrigger>
-                <AccordionContent>
+                <AccordionContent
+                  className={cn('space-y-2', 'mx-1' /* add x-spacing for input component focus state*/)}
+                >
                   {isLoadingConfig ? (
                     <div className="m-2 flex items-center justify-center gap-2">
                       <Spinner className="motion-reduce:hidden" />
@@ -252,7 +254,9 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
                 >
                   {t('settings.fees.title_general_fee_settings')}
                 </AccordionTrigger>
-                <AccordionContent>
+                <AccordionContent
+                  className={cn('space-y-2', 'mx-1' /* add x-spacing for input component focus state*/)}
+                >
                   {isLoadingConfig ? (
                     <div className="m-2 flex items-center justify-center gap-2">
                       <Spinner className="motion-reduce:hidden" />

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -74,8 +74,8 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
   const handleSubmit = async () => {
     // Trigger validation on both forms before submission
-    const collaboratorValid = collaboratorFormRef.current?.validateForm() ?? false
-    const miningValid = miningFormRef.current?.validateForm() ?? false
+    const collaboratorValid = await collaboratorFormRef.current?.validateForm()
+    const miningValid = await miningFormRef.current?.validateForm()
 
     if (!collaboratorValid || !miningValid) {
       toast.error(t('settings.fees.error_message'))
@@ -146,8 +146,8 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
     })
 
     setTimeout(() => {
-      collaboratorFormRef.current?.validateForm()
-      miningFormRef.current?.validateForm()
+      void collaboratorFormRef.current?.validateForm()
+      void miningFormRef.current?.validateForm()
     }, 4)
 
     toast.success('[DEV] Form values have been reset')

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type ComponentProps, useMemo } from 'react'
+import { useState, type ComponentProps, useMemo } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { configsettingMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { useMutation } from '@tanstack/react-query'
@@ -78,6 +78,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
   const miningFeesForm = useForm<MiningFeesFormValues, unknown, MiningFeesFormValues>({
     mode: 'onChange',
+    disabled: isSubmitting || isLoadingConfig,
     values: miningFeeFormInitialValues,
     resolver: yupResolver(miningFeeFormSchema as yup.AnyObjectSchema) as Resolver<
       MiningFeesFormValues,
@@ -101,6 +102,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
   const collaboratorFeesForm = useForm<CollaboratorFeesFormValues, unknown, CollaboratorFeesFormValues>({
     mode: 'onChange',
+    disabled: isSubmitting || isLoadingConfig,
     values: collaboratorFeesFormInitialValues,
     resolver: yupResolver(collaboratorFormSchema as yup.AnyObjectSchema) as Resolver<
       CollaboratorFeesFormValues,
@@ -108,10 +110,6 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
       CollaboratorFeesFormValues
     >,
   })
-
-  useEffect(() => {
-    setAccordionValue([])
-  }, [open])
 
   const setconfigMutation = useMutation(configsettingMutation({ client }))
 
@@ -213,7 +211,6 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
             </Trans>
           </DialogDescription>
         </DialogHeader>
-
         <div className="flex-1 space-y-4">
           {isDeveloperMode && (
             <>
@@ -278,7 +275,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
         </div>
 
         <DialogFooter
-          className={cx('', {
+          className={cx({
             'border-t pt-4': accordionValue.length > 0,
           })}
         >

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, type ComponentProps, useMemo } from 'react'
+import { useState, useEffect, type ComponentProps, useMemo } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { configsettingMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { useMutation } from '@tanstack/react-query'
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { FEE_CONFIG_KEYS, type FeeConfigName } from '@/constants/jm'
+import { FEE_CONFIG_KEYS, txFeeUnit, type FeeConfigName } from '@/constants/jm'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { cn, factorToPercentage, percentageToFactor } from '@/lib/utils'
@@ -30,7 +30,8 @@ import type { WithRequiredProperty } from '@/types/global'
 import { Spinner } from '../ui/spinner'
 import { CollaboratorFeesForm } from './CollaboratorFeesForm'
 import { collaboratorFeesFormSchema, type CollaboratorFeesFormValues } from './CollaboratorFeesFormSchema'
-import { MiningFeesForm, type MiningFeesFormRef } from './MiningFeesForm'
+import { MiningFeesForm } from './MiningFeesForm'
+import { miningFeesFormSchema, type MiningFeesFormValues } from './MiningFeesFormSchema'
 
 type FeeLimitDialogProps = WithRequiredProperty<
   Omit<ComponentProps<typeof Dialog>, 'children'>,
@@ -62,7 +63,36 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
   }, [open])
 
   const client = useApiClient()
-  const miningFormRef = useRef<MiningFeesFormRef>(null)
+
+  const miningFeeFormSchema = useMemo(() => {
+    return miningFeesFormSchema(enableFormValidation, t)
+  }, [enableFormValidation, t])
+
+  const miningFeeFormInitialValues: MiningFeesFormValues = useMemo(() => {
+    const txFeesValue = Number.parseInt(feeConfigValues?.tx_fees || '', 10)
+    const txFeesFactor = Number.parseFloat(feeConfigValues?.tx_fees_factor || '')
+    const maxSweepChangeFactor = Number.parseFloat(feeConfigValues?.max_sweep_fee_change || '')
+    const feeType = txFeesValue >= 1_001 ? txFeeUnit.SATS_PER_KILO_VBYTE : txFeeUnit.BLOCKS
+    return {
+      feeType,
+      txFeesBlocks: feeType === txFeeUnit.BLOCKS ? txFeesValue : undefined,
+      txFeesSatsPerVbyte: feeType === txFeeUnit.SATS_PER_KILO_VBYTE ? txFeesValue / 1_000 : undefined,
+      txFeesFactorInPercent: Number.isFinite(txFeesFactor) ? factorToPercentage(txFeesFactor) : undefined,
+      maxSweepFeeChangeInPercent: Number.isFinite(maxSweepChangeFactor)
+        ? factorToPercentage(maxSweepChangeFactor)
+        : undefined,
+    }
+  }, [feeConfigValues])
+
+  const miningFeesForm = useForm<MiningFeesFormValues, unknown, MiningFeesFormValues>({
+    mode: 'onChange',
+    values: miningFeeFormInitialValues,
+    resolver: yupResolver(miningFeeFormSchema as yup.AnyObjectSchema) as Resolver<
+      MiningFeesFormValues,
+      unknown,
+      MiningFeesFormValues
+    >,
+  })
 
   const collaboratorFormSchema = useMemo(() => {
     return collaboratorFeesFormSchema(enableFormValidation, t)
@@ -77,8 +107,6 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
     }
   }, [feeConfigValues])
 
-  console.log(feeConfigValues)
-  console.log(collaboratorFeesFormInitialValues)
   const collaboratorFeesForm = useForm<CollaboratorFeesFormValues, unknown, CollaboratorFeesFormValues>({
     mode: 'onChange',
     values: collaboratorFeesFormInitialValues,
@@ -100,8 +128,11 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
   const handleSubmit = async () => {
     // Trigger validation on both forms before submission
+    await collaboratorFeesForm.trigger()
+    await miningFeesForm.trigger()
+
     const collaboratorValid = collaboratorFeesForm.formState.isValid
-    const miningValid = await miningFormRef.current?.validateForm()
+    const miningValid = miningFeesForm.formState.isValid
 
     if (!collaboratorValid || !miningValid) {
       toast.error(t('settings.fees.error_message'))
@@ -113,7 +144,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
     try {
       const collaboratorData = collaboratorFeesForm.getValues()
-      const miningData = miningFormRef.current?.getFormData()
+      const miningData = miningFeesForm.getValues()
 
       if (!collaboratorData || !miningData) {
         toast.error(t('settings.fees.error_message'))
@@ -121,21 +152,37 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
         return
       }
 
+      const maxCjFeeAbsoluteValue =
+        collaboratorData.maxCjFeeAbs !== undefined && Number.isSafeInteger(collaboratorData.maxCjFeeAbs)
+          ? String(collaboratorData.maxCjFeeAbs)
+          : ''
+      const maxCjFeeRelativeValue =
+        collaboratorData.maxCjFeeRelInPercent !== undefined && Number.isFinite(collaboratorData.maxCjFeeRelInPercent)
+          ? String(percentageToFactor(collaboratorData.maxCjFeeRelInPercent))
+          : ''
+      const txFeesBlocksValue = Number.isSafeInteger(miningData.txFeesBlocks) ? String(miningData.txFeesBlocks) : ''
+      const txFeesSatsPerKvByteValue =
+        miningData.txFeesSatsPerVbyte !== undefined && Number.isFinite(miningData.txFeesSatsPerVbyte)
+          ? String(Math.round(miningData.txFeesSatsPerVbyte * 1_000))
+          : ''
+      const txFeesFactorValue =
+        miningData.txFeesFactorInPercent !== undefined && Number.isFinite(miningData.txFeesFactorInPercent)
+          ? String(percentageToFactor(miningData.txFeesFactorInPercent))
+          : ''
+      const maxSweepFeeChangeValue =
+        miningData.maxSweepFeeChangeInPercent !== undefined && Number.isFinite(miningData.maxSweepFeeChangeInPercent)
+          ? String(percentageToFactor(miningData.maxSweepFeeChangeInPercent))
+          : ''
+
       const configUpdates: { key: FeeConfigName; value: string }[] = [
+        { key: 'max_cj_fee_abs', value: maxCjFeeAbsoluteValue },
+        { key: 'max_cj_fee_rel', value: maxCjFeeRelativeValue },
         {
-          key: 'max_cj_fee_abs',
-          value: collaboratorData.maxCjFeeAbs !== undefined ? String(collaboratorData.maxCjFeeAbs) : '',
+          key: 'tx_fees',
+          value: miningData.feeType === txFeeUnit.BLOCKS ? txFeesBlocksValue : txFeesSatsPerKvByteValue,
         },
-        {
-          key: 'max_cj_fee_rel',
-          value:
-            collaboratorData.maxCjFeeRelInPercent !== undefined
-              ? String(percentageToFactor(collaboratorData.maxCjFeeRelInPercent))
-              : '',
-        },
-        { key: 'tx_fees', value: miningData.txFees },
-        { key: 'tx_fees_factor', value: miningData.txFeesFactor },
-        { key: 'max_sweep_fee_change', value: miningData.maxSweepFeeChange },
+        { key: 'tx_fees_factor', value: txFeesFactorValue },
+        { key: 'max_sweep_fee_change', value: maxSweepFeeChangeValue },
       ]
 
       for (const { key, value } of configUpdates) {
@@ -171,18 +218,11 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
   const handleResetFormValues = () => {
     collaboratorFeesForm.reset()
-    miningFormRef.current?.setFormData({
-      txFees: '',
-      txFeesFactor: '',
-      maxSweepFeeChange: '',
-    })
+    miningFeesForm.reset()
 
-    setTimeout(() => {
-      void collaboratorFeesForm.trigger()
-      void miningFormRef.current?.validateForm()
-    }, 4)
-
-    toast.success('[DEV] Form values have been reset')
+    if (isDeveloperMode) {
+      toast.success('[DEV] Form values have been reset')
+    }
   }
 
   return (
@@ -270,7 +310,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
               <AccordionItem value="mining-fees">
                 <AccordionTrigger
                   className={cx({
-                    'text-destructive border-red-300': miningFormRef.current && !miningFormRef.current.getFormData(),
+                    'text-destructive border-red-300': !!miningFeesForm.formState.errors.form,
                   })}
                 >
                   {t('settings.fees.title_general_fee_settings')}
@@ -284,20 +324,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
                       {t('global.loading')}
                     </div>
                   ) : (
-                    <MiningFeesForm
-                      key={`mining-${walletFileName}-${open}`}
-                      ref={miningFormRef}
-                      initialValues={{
-                        txFees: feeConfigValues?.tx_fees ?? '',
-                        txFeesFactor: feeConfigValues?.tx_fees_factor
-                          ? String(factorToPercentage(Number(feeConfigValues.tx_fees_factor)))
-                          : '',
-                        maxSweepFeeChange: feeConfigValues?.max_sweep_fee_change
-                          ? String(factorToPercentage(Number(feeConfigValues.max_sweep_fee_change)))
-                          : '',
-                      }}
-                      enableValidation={enableFormValidation}
-                    />
+                    <MiningFeesForm key={`mining-${walletFileName}-${open}`} form={miningFeesForm} />
                   )}
                 </AccordionContent>
               </AccordionItem>
@@ -319,12 +346,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
             {t('settings.fees.text_button_cancel')}
           </Button>
           {isDeveloperMode && (
-            <Button
-              variant="outline"
-              onClick={handleResetFormValues}
-              disabled={isSubmitting || isLoadingConfig}
-              className="border-amber-300 bg-amber-100 hover:bg-amber-200"
-            >
+            <Button variant="outline" onClick={handleResetFormValues} disabled={isSubmitting || isLoadingConfig}>
               Reset form values
               <DevBadge />
             </Button>

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -1,9 +1,12 @@
-import { useState, useRef, useEffect, type ComponentProps } from 'react'
+import { useState, useRef, useEffect, type ComponentProps, useMemo } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
 import { configsettingMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { useMutation } from '@tanstack/react-query'
 import { cx } from 'class-variance-authority'
+import { useForm, type Resolver } from 'react-hook-form'
 import { useTranslation, Trans } from 'react-i18next'
 import { toast } from 'sonner'
+import * as yup from 'yup'
 import { DevBadge } from '@/components/dev/DevBadge'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Button } from '@/components/ui/button'
@@ -20,15 +23,14 @@ import { Switch } from '@/components/ui/switch'
 import { FEE_CONFIG_KEYS, type FeeConfigName } from '@/constants/jm'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
-import { cn, factorToPercentage } from '@/lib/utils'
+import { cn, factorToPercentage, percentageToFactor } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import type { WithRequiredProperty } from '@/types/global'
 import { Spinner } from '../ui/spinner'
-import { CollaboratorFeesForm, type CollaboratorFeesFormRef } from './CollaboratorFeesForm'
+import { CollaboratorFeesForm } from './CollaboratorFeesForm'
+import { collaboratorFeesFormSchema, type CollaboratorFeesFormValues } from './CollaboratorFeesFormSchema'
 import { MiningFeesForm, type MiningFeesFormRef } from './MiningFeesForm'
-
-//TODO: needs testing!
 
 type FeeLimitDialogProps = WithRequiredProperty<
   Omit<ComponentProps<typeof Dialog>, 'children'>,
@@ -60,8 +62,32 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
   }, [open])
 
   const client = useApiClient()
-  const collaboratorFormRef = useRef<CollaboratorFeesFormRef>(null)
   const miningFormRef = useRef<MiningFeesFormRef>(null)
+
+  const collaboratorFormSchema = useMemo(() => {
+    return collaboratorFeesFormSchema(enableFormValidation, t)
+  }, [enableFormValidation, t])
+
+  const collaboratorFeesFormInitialValues: CollaboratorFeesFormValues = useMemo(() => {
+    const maxCjFeeAbsolute = Number.parseInt(feeConfigValues?.max_cj_fee_abs || '', 10)
+    const maxCjFeeRelative = Number.parseFloat(feeConfigValues?.max_cj_fee_rel || '')
+    return {
+      maxCjFeeAbs: Number.isSafeInteger(maxCjFeeAbsolute) ? maxCjFeeAbsolute : undefined,
+      maxCjFeeRelInPercent: Number.isFinite(maxCjFeeRelative) ? factorToPercentage(maxCjFeeRelative) : undefined,
+    }
+  }, [feeConfigValues])
+
+  console.log(feeConfigValues)
+  console.log(collaboratorFeesFormInitialValues)
+  const collaboratorFeesForm = useForm<CollaboratorFeesFormValues, unknown, CollaboratorFeesFormValues>({
+    mode: 'onChange',
+    values: collaboratorFeesFormInitialValues,
+    resolver: yupResolver(collaboratorFormSchema as yup.AnyObjectSchema) as Resolver<
+      CollaboratorFeesFormValues,
+      unknown,
+      CollaboratorFeesFormValues
+    >,
+  })
 
   const setconfigMutation = useMutation(configsettingMutation({ client }))
 
@@ -74,7 +100,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
   const handleSubmit = async () => {
     // Trigger validation on both forms before submission
-    const collaboratorValid = await collaboratorFormRef.current?.validateForm()
+    const collaboratorValid = collaboratorFeesForm.formState.isValid
     const miningValid = await miningFormRef.current?.validateForm()
 
     if (!collaboratorValid || !miningValid) {
@@ -86,7 +112,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
     setSaveErrorMessage(undefined)
 
     try {
-      const collaboratorData = collaboratorFormRef.current?.getFormData()
+      const collaboratorData = collaboratorFeesForm.getValues()
       const miningData = miningFormRef.current?.getFormData()
 
       if (!collaboratorData || !miningData) {
@@ -96,8 +122,17 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
       }
 
       const configUpdates: { key: FeeConfigName; value: string }[] = [
-        { key: 'max_cj_fee_abs', value: collaboratorData.maxCjFeeAbs },
-        { key: 'max_cj_fee_rel', value: collaboratorData.maxCjFeeRel },
+        {
+          key: 'max_cj_fee_abs',
+          value: collaboratorData.maxCjFeeAbs !== undefined ? String(collaboratorData.maxCjFeeAbs) : '',
+        },
+        {
+          key: 'max_cj_fee_rel',
+          value:
+            collaboratorData.maxCjFeeRelInPercent !== undefined
+              ? String(percentageToFactor(collaboratorData.maxCjFeeRelInPercent))
+              : '',
+        },
         { key: 'tx_fees', value: miningData.txFees },
         { key: 'tx_fees_factor', value: miningData.txFeesFactor },
         { key: 'max_sweep_fee_change', value: miningData.maxSweepFeeChange },
@@ -135,10 +170,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
   }
 
   const handleResetFormValues = () => {
-    collaboratorFormRef.current?.setFormData({
-      maxCjFeeAbs: '',
-      maxCjFeeRel: '',
-    })
+    collaboratorFeesForm.reset()
     miningFormRef.current?.setFormData({
       txFees: '',
       txFeesFactor: '',
@@ -146,7 +178,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
     })
 
     setTimeout(() => {
-      void collaboratorFormRef.current?.validateForm()
+      void collaboratorFeesForm.trigger()
       void miningFormRef.current?.validateForm()
     }, 4)
 
@@ -205,8 +237,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
               <AccordionItem value="collaborator-fees">
                 <AccordionTrigger
                   className={cx({
-                    'text-destructive border-red-300':
-                      collaboratorFormRef.current && !collaboratorFormRef.current.getFormData(),
+                    'text-destructive border-red-300': !!collaboratorFeesForm.formState.errors.form,
                   })}
                 >
                   {t('settings.fees.title_max_cj_fee_settings')}
@@ -220,17 +251,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
                       {t('global.loading')}
                     </div>
                   ) : (
-                    <CollaboratorFeesForm
-                      key={`collaborator-${walletFileName}-${open}`}
-                      ref={collaboratorFormRef}
-                      initialValues={{
-                        maxCjFeeAbs: feeConfigValues?.max_cj_fee_abs || '',
-                        maxCjFeeRel: feeConfigValues?.max_cj_fee_rel
-                          ? String(factorToPercentage(Number(feeConfigValues.max_cj_fee_rel)))
-                          : '',
-                      }}
-                      enableValidation={enableFormValidation}
-                    />
+                    <CollaboratorFeesForm key={`collaborator-${walletFileName}-${open}`} form={collaboratorFeesForm} />
                   )}
                 </AccordionContent>
               </AccordionItem>

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -23,6 +23,7 @@ import { Switch } from '@/components/ui/switch'
 import { FEE_CONFIG_KEYS, txFeeUnit, type FeeConfigName } from '@/constants/jm'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import { getErrorReason } from '@/lib/errorReason'
 import { cn, factorToPercentage, percentageToFactor } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
@@ -44,23 +45,14 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
   const { t } = useTranslation()
 
   const { enabled: isDeveloperMode } = useDeveloperMode()
+  const [accordionValue, setAccordionValue] = useState<string[]>([])
   const [enableFormValidation, setEnableFormValidation] = useState(true)
-  const [collaboratorFeesExpanded, setCollaboratorFeesExpanded] = useState(false)
-  const [miningFeesExpanded, setMiningFeesExpanded] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [saveErrorMessage, setSaveErrorMessage] = useState<string>()
   const {
     feeConfigValues,
     refetchAll: refetchFeeConfigValues,
     isLoading: isLoadingConfig,
   } = useFeeConfigValidation({ walletFileName })
-
-  useEffect(() => {
-    if (open) {
-      setCollaboratorFeesExpanded(false)
-      setMiningFeesExpanded(false)
-    }
-  }, [open])
 
   const client = useApiClient()
 
@@ -117,40 +109,26 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
     >,
   })
 
-  const setconfigMutation = useMutation(configsettingMutation({ client }))
-
   useEffect(() => {
-    if (!open) {
-      setSaveErrorMessage(undefined)
-      return
-    }
+    setAccordionValue([])
   }, [open])
 
+  const setconfigMutation = useMutation(configsettingMutation({ client }))
+
   const handleSubmit = async () => {
-    // Trigger validation on both forms before submission
-    await collaboratorFeesForm.trigger()
-    await miningFeesForm.trigger()
-
-    const collaboratorValid = collaboratorFeesForm.formState.isValid
-    const miningValid = miningFeesForm.formState.isValid
-
-    if (!collaboratorValid || !miningValid) {
-      toast.error(t('settings.fees.error_message'))
-      return
-    }
-
     setIsSubmitting(true)
-    setSaveErrorMessage(undefined)
 
     try {
-      const collaboratorData = collaboratorFeesForm.getValues()
-      const miningData = miningFeesForm.getValues()
+      // Trigger validation on both forms before submission
+      const collaboratorValid = await collaboratorFeesForm.trigger()
+      const miningValid = await miningFeesForm.trigger()
 
-      if (!collaboratorData || !miningData) {
-        toast.error(t('settings.fees.error_message'))
-        setIsSubmitting(false)
+      if (!collaboratorValid || !miningValid) {
         return
       }
+
+      const collaboratorData = collaboratorFeesForm.getValues()
+      const miningData = miningFeesForm.getValues()
 
       const maxCjFeeAbsoluteValue =
         collaboratorData.maxCjFeeAbs !== undefined && Number.isSafeInteger(collaboratorData.maxCjFeeAbs)
@@ -165,6 +143,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
         miningData.txFeesSatsPerVbyte !== undefined && Number.isFinite(miningData.txFeesSatsPerVbyte)
           ? String(Math.round(miningData.txFeesSatsPerVbyte * 1_000))
           : ''
+      const txFeesValue = miningData.feeType === txFeeUnit.BLOCKS ? txFeesBlocksValue : txFeesSatsPerKvByteValue
       const txFeesFactorValue =
         miningData.txFeesFactorInPercent !== undefined && Number.isFinite(miningData.txFeesFactorInPercent)
           ? String(percentageToFactor(miningData.txFeesFactorInPercent))
@@ -177,10 +156,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
       const configUpdates: { key: FeeConfigName; value: string }[] = [
         { key: 'max_cj_fee_abs', value: maxCjFeeAbsoluteValue },
         { key: 'max_cj_fee_rel', value: maxCjFeeRelativeValue },
-        {
-          key: 'tx_fees',
-          value: miningData.feeType === txFeeUnit.BLOCKS ? txFeesBlocksValue : txFeesSatsPerKvByteValue,
-        },
+        { key: 'tx_fees', value: txFeesValue },
         { key: 'tx_fees_factor', value: txFeesFactorValue },
         { key: 'max_sweep_fee_change', value: maxSweepFeeChangeValue },
       ]
@@ -201,28 +177,19 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
       onOpenChange(false)
     } catch (error: unknown) {
       console.error('Failed to update fee settings:', error)
-      const errorMessage =
-        typeof error === 'object' && error !== null && 'message' in error
-          ? (error as { message?: string }).message
-          : t('global.errors.reason_unknown')
-      setSaveErrorMessage(
-        t('settings.fees.error_saving_fee_config_failed', {
-          reason: errorMessage,
-        }),
-      )
-      toast.error(t('settings.fees.error_message'))
+      const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+      const errorMessage = t('settings.fees.error_saving_fee_config_failed', { reason })
+      toast.error(errorMessage)
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleResetFormValues = () => {
+  const handleResetFormValues = async () => {
     collaboratorFeesForm.reset()
     miningFeesForm.reset()
-
-    if (isDeveloperMode) {
-      toast.success('[DEV] Form values have been reset')
-    }
+    await collaboratorFeesForm.trigger()
+    await miningFeesForm.trigger()
   }
 
   return (
@@ -268,89 +235,64 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
             </>
           )}
 
-          <div className="space-y-2">
-            <Accordion
-              defaultValue="collaborator-fees"
-              type="single"
-              onValueChange={(val) => setCollaboratorFeesExpanded(!!val)}
-            >
-              <AccordionItem value="collaborator-fees">
-                <AccordionTrigger
-                  className={cx({
-                    'text-destructive border-red-300': !!collaboratorFeesForm.formState.errors.form,
-                  })}
-                >
-                  {t('settings.fees.title_max_cj_fee_settings')}
-                </AccordionTrigger>
-                <AccordionContent
-                  className={cn('space-y-2', 'mx-1' /* add x-spacing for input component focus state*/)}
-                >
-                  {isLoadingConfig ? (
-                    <div className="m-2 flex items-center justify-center gap-2">
-                      <Spinner className="motion-reduce:hidden" />
-                      {t('global.loading')}
-                    </div>
-                  ) : (
-                    <CollaboratorFeesForm key={`collaborator-${walletFileName}-${open}`} form={collaboratorFeesForm} />
-                  )}
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
-          </div>
-
-          {/* Mining fees dropdown */}
-          <div className="space-y-2">
-            <Accordion
-              type="single"
-              defaultValue="mining-fees"
-              onValueChange={(val) => {
-                setMiningFeesExpanded(!!val)
-              }}
-            >
-              <AccordionItem value="mining-fees">
-                <AccordionTrigger
-                  className={cx({
-                    'text-destructive border-red-300': !!miningFeesForm.formState.errors.form,
-                  })}
-                >
-                  {t('settings.fees.title_general_fee_settings')}
-                </AccordionTrigger>
-                <AccordionContent
-                  className={cn('space-y-2', 'mx-1' /* add x-spacing for input component focus state*/)}
-                >
-                  {isLoadingConfig ? (
-                    <div className="m-2 flex items-center justify-center gap-2">
-                      <Spinner className="motion-reduce:hidden" />
-                      {t('global.loading')}
-                    </div>
-                  ) : (
-                    <MiningFeesForm key={`mining-${walletFileName}-${open}`} form={miningFeesForm} />
-                  )}
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
-          </div>
+          <Accordion type="multiple" value={accordionValue} onValueChange={setAccordionValue}>
+            <AccordionItem value="collaborator-fees">
+              <AccordionTrigger
+                className={cx({
+                  'text-destructive border-red-300': !collaboratorFeesForm.formState.isValid,
+                })}
+              >
+                {t('settings.fees.title_max_cj_fee_settings')}
+              </AccordionTrigger>
+              <AccordionContent className={cn('space-y-2', 'mx-1' /* add x-spacing for input component focus state*/)}>
+                {isLoadingConfig ? (
+                  <div className="m-2 flex items-center justify-center gap-2">
+                    <Spinner className="motion-reduce:hidden" />
+                    {t('global.loading')}
+                  </div>
+                ) : (
+                  <CollaboratorFeesForm key={`collaborator-${walletFileName}-${open}`} form={collaboratorFeesForm} />
+                )}
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="mining-fees">
+              <AccordionTrigger
+                className={cx({
+                  'text-destructive border-red-300': !miningFeesForm.formState.isValid,
+                })}
+              >
+                {t('settings.fees.title_general_fee_settings')}
+              </AccordionTrigger>
+              <AccordionContent className={cn('space-y-2', 'mx-1' /* add x-spacing for input component focus state*/)}>
+                {isLoadingConfig ? (
+                  <div className="m-2 flex items-center justify-center gap-2">
+                    <Spinner className="motion-reduce:hidden" />
+                    {t('global.loading')}
+                  </div>
+                ) : (
+                  <MiningFeesForm key={`mining-${walletFileName}-${open}`} form={miningFeesForm} />
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         </div>
 
-        {saveErrorMessage && (
-          <div className="text-destructive mb-4 w-full rounded-lg border border-red-200 p-2 text-sm">
-            {saveErrorMessage}
-          </div>
-        )}
         <DialogFooter
           className={cx('', {
-            'border-t pt-4': collaboratorFeesExpanded || miningFeesExpanded,
+            'border-t pt-4': accordionValue.length > 0,
           })}
         >
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting || isLoadingConfig}>
             {t('settings.fees.text_button_cancel')}
           </Button>
-          {isDeveloperMode && (
-            <Button variant="outline" onClick={handleResetFormValues} disabled={isSubmitting || isLoadingConfig}>
-              Reset form values
-              <DevBadge />
-            </Button>
-          )}
+          <Button
+            variant="outline"
+            onClick={() => void handleResetFormValues()}
+            disabled={isSubmitting || isLoadingConfig}
+          >
+            {/* TODO: i18n */}
+            Reset
+          </Button>
           <Button onClick={() => void handleSubmit()} disabled={isSubmitting || isLoadingConfig}>
             {isSubmitting ? t('settings.fees.text_button_submitting') : t('settings.fees.text_button_submit')}
           </Button>

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -20,7 +20,7 @@ export const MiningFeesForm = ({
     register,
     control,
     setValue,
-    formState: { errors },
+    formState: { errors, disabled },
   },
 }: MiningFeesFormProps) => {
   const { t } = useTranslation()
@@ -74,7 +74,7 @@ export const MiningFeesForm = ({
           onUnitChange={handleTxFeeUnitChange}
           onValueChange={handleTxFeeValueChange}
           error={txFeesError}
-          disabled={false}
+          disabled={disabled}
         />
       </div>
 
@@ -88,6 +88,7 @@ export const MiningFeesForm = ({
             <InputGroupInput
               id="mining-fees-tx-fees-factor"
               {...register('txFeesFactorInPercent', {
+                disabled,
                 valueAsNumber: true,
               })}
               type="number"
@@ -121,6 +122,7 @@ export const MiningFeesForm = ({
             <InputGroupInput
               id="mining-fees-sweep-fee-change"
               {...register('maxSweepFeeChangeInPercent', {
+                disabled,
                 valueAsNumber: true,
               })}
               type="number"

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -1,327 +1,139 @@
-import { useEffect, forwardRef, useImperativeHandle, useMemo } from 'react'
-import { yupResolver } from '@hookform/resolvers/yup'
 import { PercentIcon } from 'lucide-react'
-import { useForm, useWatch, type Resolver } from 'react-hook-form'
+import { useWatch, type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import * as yup from 'yup'
 import { Label } from '@/components/ui/label'
-import {
-  TX_FEES_FACTOR_MIN,
-  TX_FEES_FACTOR_MAX,
-  MAX_SWEEP_FEE_CHANGE_MIN,
-  MAX_SWEEP_FEE_CHANGE_MAX,
-} from '@/constants/jam'
 import { JM_MAX_SWEEP_FEE_CHANGE_DEFAULT, txFeeUnit, type TxFeeUnit } from '@/constants/jm'
-import { factorToPercentage, percentageToFactor } from '@/lib/utils'
+import { cn, factorToPercentage } from '@/lib/utils'
 import { Field, FieldDescription, FieldLabel } from '../ui/field'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
+import type { MiningFeesFormValues } from './MiningFeesFormSchema'
 import { TxFeeInputField } from './TxFeeInputField'
 
 interface MiningFeesFormProps {
-  initialValues: {
-    txFees: string
-    txFeesFactor: string
-    maxSweepFeeChange: string
-  }
-  enableValidation?: boolean
+  className?: string
+  form: UseFormReturn<MiningFeesFormValues, unknown, MiningFeesFormValues>
 }
 
-type MiningFeesFormValues = {
-  feeType: TxFeeUnit
-  txFeesBlocks: string
-  txFeesSatsPerVbyte: string
-  txFeesFactor: string
-  maxSweepFeeChange: string
-}
+export const MiningFeesForm = ({
+  className,
+  form: {
+    register,
+    control,
+    setValue,
+    formState: { errors },
+  },
+}: MiningFeesFormProps) => {
+  const { t } = useTranslation()
 
-export interface MiningFeesFormRef {
-  getFormData: () => {
-    txFees: string
-    txFeesFactor: string
-    maxSweepFeeChange: string
-  } | null
-  setFormData: (data: { txFees: string; txFeesFactor: string; maxSweepFeeChange: string }) => void
-  resetForm: () => void
-  validateForm: () => Promise<boolean>
-}
+  const feeType = useWatch({ control, name: 'feeType' })
+  const txFeesBlocks = useWatch({ control, name: 'txFeesBlocks' })
+  const txFeesSatsPerVbyte = useWatch({ control, name: 'txFeesSatsPerVbyte' })
 
-const getMiningFeesFormValues = (initialValues: MiningFeesFormProps['initialValues']): MiningFeesFormValues => {
-  const txFeesValue = Number(initialValues.txFees)
+  const handleTxFeeUnitChange = (newUnit: TxFeeUnit) => {
+    if (newUnit !== feeType) {
+      const currentValue = feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte
 
-  if (initialValues.txFees && txFeesValue >= 1_001) {
-    return {
-      feeType: txFeeUnit.SATS_PER_KILO_VBYTE,
-      txFeesBlocks: '',
-      txFeesSatsPerVbyte: String(txFeesValue / 1_000),
-      txFeesFactor: initialValues.txFeesFactor,
-      maxSweepFeeChange: initialValues.maxSweepFeeChange,
-    }
-  }
-
-  return {
-    feeType: txFeeUnit.BLOCKS,
-    txFeesBlocks: initialValues.txFees,
-    txFeesSatsPerVbyte: '',
-    txFeesFactor: initialValues.txFeesFactor,
-    maxSweepFeeChange: initialValues.maxSweepFeeChange,
-  }
-}
-
-const DEFAULT_MINING_FEES_FORM_VALUES: MiningFeesFormValues = {
-  feeType: txFeeUnit.BLOCKS,
-  txFeesBlocks: '3',
-  txFeesSatsPerVbyte: '',
-  txFeesFactor: '20',
-  maxSweepFeeChange: '80',
-}
-
-export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>(
-  ({ initialValues, enableValidation = true }, ref) => {
-    const { t } = useTranslation()
-    const schema = useMemo(() => {
-      if (!enableValidation) {
-        return yup
-          .object({
-            feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
-            txFeesBlocks: yup.string().default(''),
-            txFeesSatsPerVbyte: yup.string().default(''),
-            txFeesFactor: yup.string().default(''),
-            maxSweepFeeChange: yup.string().default(''),
-          })
-          .required()
-      }
-
-      const txFeesBlocksMessage = t('settings.fees.feedback_invalid_tx_fees_blocks', {
-        min: Number(1).toLocaleString(),
-        max: Number(1_000).toLocaleString(),
-      })
-      const txFeesSatsMessage = t('settings.fees.feedback_invalid_tx_fees_satspervbyte', {
-        min: Number(1.001).toLocaleString(),
-        max: Number(350).toLocaleString(),
-      })
-      const txFeesFactorMessage = t('settings.fees.feedback_invalid_tx_fees_factor', {
-        min: factorToPercentage(TX_FEES_FACTOR_MIN).toLocaleString(),
-        max: factorToPercentage(TX_FEES_FACTOR_MAX).toLocaleString(),
-      })
-      const maxSweepFeeChangeMessage = t('settings.fees.feedback_invalid_max_sweep_fee_change', {
-        min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN).toLocaleString(),
-        max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX).toLocaleString(),
-      })
-
-      return yup
-        .object({
-          feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
-          txFeesBlocks: yup.number().when('feeType', {
-            is: txFeeUnit.BLOCKS,
-            then: (schema) =>
-              schema
-                .integer(txFeesBlocksMessage)
-                .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
-                .min(1, txFeesBlocksMessage)
-                .max(1_000, txFeesBlocksMessage)
-                .required(txFeesBlocksMessage),
-            otherwise: (schema) => schema.nullable().optional(),
-          }),
-          txFeesSatsPerVbyte: yup.number().when('feeType', {
-            is: txFeeUnit.SATS_PER_KILO_VBYTE,
-            then: (schema) =>
-              schema
-                .transform((value) => (Number.isFinite(value) ? Number(value) : null))
-                .min(1.001, txFeesSatsMessage)
-                .max(350, txFeesSatsMessage)
-                .required(txFeesSatsMessage),
-            otherwise: (schema) => schema.nullable().optional(),
-          }),
-          txFeesFactor: yup
-            .number()
-            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
-            .min(factorToPercentage(TX_FEES_FACTOR_MIN), txFeesFactorMessage)
-            .max(factorToPercentage(TX_FEES_FACTOR_MAX), txFeesFactorMessage)
-            .required(txFeesFactorMessage),
-          maxSweepFeeChange: yup
-            .number()
-            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
-            .min(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN), maxSweepFeeChangeMessage)
-            .max(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX), maxSweepFeeChangeMessage)
-            .required(maxSweepFeeChangeMessage),
-        })
-        .required()
-    }, [enableValidation, t])
-
-    const {
-      control,
-      register,
-      getValues,
-      reset,
-      setValue,
-      trigger,
-      formState: { errors },
-    } = useForm<MiningFeesFormValues, unknown, MiningFeesFormValues>({
-      mode: 'onChange',
-      defaultValues: getMiningFeesFormValues(initialValues),
-      resolver: yupResolver(schema as yup.AnyObjectSchema) as Resolver<
-        MiningFeesFormValues,
-        unknown,
-        MiningFeesFormValues
-      >,
-    })
-
-    const feeType = useWatch({ control, name: 'feeType' })
-    const txFeesBlocks = useWatch({ control, name: 'txFeesBlocks' })
-    const txFeesSatsPerVbyte = useWatch({ control, name: 'txFeesSatsPerVbyte' })
-
-    useEffect(() => {
-      void trigger()
-    }, [trigger, enableValidation])
-
-    const handleTxFeeUnitChange = (newUnit: TxFeeUnit) => {
-      if (newUnit !== feeType) {
-        const currentValue = feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte
-
-        if (currentValue) {
-          const numberValue = Number(currentValue)
-          if (!Number.isNaN(numberValue)) {
-            if (newUnit === txFeeUnit.SATS_PER_KILO_VBYTE && feeType === txFeeUnit.BLOCKS) {
-              setValue('txFeesSatsPerVbyte', String(Math.round(numberValue * 1_000) / 1_000), {
-                shouldDirty: true,
-                shouldValidate: true,
-              })
-            } else if (newUnit === txFeeUnit.BLOCKS && feeType === txFeeUnit.SATS_PER_KILO_VBYTE) {
-              const converted = Math.round(numberValue * 1_000)
-              setValue('txFeesBlocks', String(Math.round(converted / 1_000)), {
-                shouldDirty: true,
-                shouldValidate: true,
-              })
-            }
+      if (currentValue) {
+        const numberValue = Number(currentValue)
+        if (!Number.isNaN(numberValue)) {
+          if (newUnit === txFeeUnit.SATS_PER_KILO_VBYTE && feeType === txFeeUnit.BLOCKS) {
+            setValue('txFeesSatsPerVbyte', Math.round(numberValue * 1_000) / 1_000, {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
+          } else if (newUnit === txFeeUnit.BLOCKS && feeType === txFeeUnit.SATS_PER_KILO_VBYTE) {
+            const converted = Math.round(numberValue * 1_000)
+            setValue('txFeesBlocks', Math.round(converted / 1_000), {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
           }
         }
       }
-
-      setValue('feeType', newUnit, { shouldDirty: true, shouldValidate: true })
     }
 
-    const handleTxFeeValueChange = (value: string) => {
-      const fieldName = feeType === txFeeUnit.BLOCKS ? 'txFeesBlocks' : 'txFeesSatsPerVbyte'
-      setValue(fieldName, value, { shouldDirty: true, shouldValidate: true })
-    }
+    setValue('feeType', newUnit, { shouldDirty: true, shouldValidate: true })
+  }
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        getFormData: () => {
-          const values = getValues()
-          if (!schema.isValidSync(values)) {
-            return null
-          }
-          return {
-            txFees:
-              values.feeType === txFeeUnit.BLOCKS
-                ? values.txFeesBlocks
-                : String(Math.round(Number(values.txFeesSatsPerVbyte) * 1_000)),
-            txFeesFactor: values.txFeesFactor ? String(percentageToFactor(Number(values.txFeesFactor))) : '',
-            maxSweepFeeChange: values.maxSweepFeeChange
-              ? String(percentageToFactor(Number(values.maxSweepFeeChange)))
-              : '',
-          }
-        },
-        setFormData: (data: { txFees: string; txFeesFactor: string; maxSweepFeeChange: string }) => {
-          reset(
-            getMiningFeesFormValues({
-              txFees: data.txFees,
-              txFeesFactor: data.txFeesFactor ? String(factorToPercentage(Number(data.txFeesFactor))) : '',
-              maxSweepFeeChange: data.maxSweepFeeChange
-                ? String(factorToPercentage(Number(data.maxSweepFeeChange)))
-                : '',
-            }),
-          )
-          void trigger()
-        },
-        resetForm: () => {
-          reset(DEFAULT_MINING_FEES_FORM_VALUES)
-          void trigger()
-        },
-        validateForm: () => trigger(),
-      }),
-      [getValues, reset, schema, trigger],
-    )
+  const handleTxFeeValueChange = (value: string) => {
+    const fieldName = feeType === txFeeUnit.BLOCKS ? 'txFeesBlocks' : 'txFeesSatsPerVbyte'
+    setValue(fieldName, Number(value), { shouldDirty: true, shouldValidate: true })
+  }
 
-    const txFeesError = feeType === txFeeUnit.BLOCKS ? errors.txFeesBlocks?.message : errors.txFeesSatsPerVbyte?.message
+  const txFeesError = feeType === txFeeUnit.BLOCKS ? errors.txFeesBlocks?.message : errors.txFeesSatsPerVbyte?.message
 
-    return (
-      <div className="space-y-6">
-        <p className="text-muted-foreground mb-6 text-sm">{t('settings.fees.description_general_fee_settings')}</p>
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      <p className="text-muted-foreground mb-6 text-sm">{t('settings.fees.description_general_fee_settings')}</p>
 
-        <div className="space-y-2">
-          <Label>{t('settings.fees.label_tx_fees')}</Label>
-          <TxFeeInputField
-            value={feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte}
-            unit={feeType}
-            onUnitChange={handleTxFeeUnitChange}
-            onValueChange={handleTxFeeValueChange}
-            error={txFeesError}
-            disabled={false}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Field data-invalid={errors.txFeesFactor !== undefined}>
-            <FieldLabel htmlFor="mining-fees-tx-fees-factor">{t('settings.fees.label_tx_fees_factor')}</FieldLabel>
-            <FieldDescription className="text-xs">
-              {t('settings.fees.description_tx_fees_factor_^0.9.10')}
-            </FieldDescription>
-            <InputGroup>
-              <InputGroupInput
-                id="mining-fees-tx-fees-factor"
-                {...register('txFeesFactor')}
-                type="number"
-                inputMode="decimal"
-                min="0"
-                max="100"
-                step="any"
-                placeholder="20"
-              />
-              <InputGroupAddon align="inline-start">
-                <PercentIcon />
-              </InputGroupAddon>
-            </InputGroup>
-          </Field>
-          {errors.txFeesFactor?.message && (
-            <div className="text-destructive text-xs">{errors.txFeesFactor.message}</div>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <Field data-invalid={errors.maxSweepFeeChange !== undefined}>
-            <FieldLabel htmlFor="mining-fees-sweep-fee-change">
-              {t('settings.fees.label_max_sweep_fee_change')}
-            </FieldLabel>
-            <FieldDescription className="text-xs">
-              {t('settings.fees.description_max_sweep_fee_change', {
-                // TODO: i18n - change variable name.. `defaultValue` is used by the library!
-                defaultValue: `${factorToPercentage(JM_MAX_SWEEP_FEE_CHANGE_DEFAULT)}%`,
-              })}
-            </FieldDescription>
-            <InputGroup>
-              <InputGroupInput
-                id="mining-fees-sweep-fee-change"
-                {...register('maxSweepFeeChange')}
-                type="number"
-                inputMode="decimal"
-                min="0"
-                max="100"
-                step="any"
-                placeholder="80"
-              />
-              <InputGroupAddon align="inline-start">
-                <PercentIcon />
-              </InputGroupAddon>
-            </InputGroup>
-            {errors.maxSweepFeeChange?.message && (
-              <div className="text-destructive text-xs">{errors.maxSweepFeeChange.message}</div>
-            )}
-          </Field>
-        </div>
+      <div className="space-y-2">
+        <Label>{t('settings.fees.label_tx_fees')}</Label>
+        <TxFeeInputField
+          value={String(feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte)}
+          unit={feeType}
+          onUnitChange={handleTxFeeUnitChange}
+          onValueChange={handleTxFeeValueChange}
+          error={txFeesError}
+          disabled={false}
+        />
       </div>
-    )
-  },
-)
+
+      <div className="space-y-2">
+        <Field data-invalid={errors.txFeesFactorInPercent !== undefined}>
+          <FieldLabel htmlFor="mining-fees-tx-fees-factor">{t('settings.fees.label_tx_fees_factor')}</FieldLabel>
+          <FieldDescription className="text-xs">
+            {t('settings.fees.description_tx_fees_factor_^0.9.10')}
+          </FieldDescription>
+          <InputGroup>
+            <InputGroupInput
+              id="mining-fees-tx-fees-factor"
+              {...register('txFeesFactorInPercent')}
+              type="number"
+              inputMode="decimal"
+              min="0"
+              max="100"
+              step="1"
+            />
+            <InputGroupAddon align="inline-start">
+              <PercentIcon />
+            </InputGroupAddon>
+          </InputGroup>
+        </Field>
+        {errors.txFeesFactorInPercent?.message && (
+          <div className="text-destructive text-xs">{errors.txFeesFactorInPercent.message}</div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Field data-invalid={errors.maxSweepFeeChangeInPercent !== undefined}>
+          <FieldLabel htmlFor="mining-fees-sweep-fee-change">
+            {t('settings.fees.label_max_sweep_fee_change')}
+          </FieldLabel>
+          <FieldDescription className="text-xs">
+            {t('settings.fees.description_max_sweep_fee_change', {
+              // TODO: i18n - change variable name.. `defaultValue` is used by the library!
+              defaultValue: `${factorToPercentage(JM_MAX_SWEEP_FEE_CHANGE_DEFAULT)}%`,
+            })}
+          </FieldDescription>
+          <InputGroup>
+            <InputGroupInput
+              id="mining-fees-sweep-fee-change"
+              {...register('maxSweepFeeChangeInPercent')}
+              type="number"
+              inputMode="decimal"
+              min="0"
+              max="100"
+              step="1"
+            />
+            <InputGroupAddon align="inline-start">
+              <PercentIcon />
+            </InputGroupAddon>
+          </InputGroup>
+          {errors.maxSweepFeeChangeInPercent?.message && (
+            <div className="text-destructive text-xs">{errors.maxSweepFeeChangeInPercent.message}</div>
+          )}
+        </Field>
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -12,7 +12,7 @@ import {
   MAX_SWEEP_FEE_CHANGE_MAX,
 } from '@/constants/jam'
 import { JM_MAX_SWEEP_FEE_CHANGE_DEFAULT, txFeeUnit, type TxFeeUnit } from '@/constants/jm'
-import { isValidNumber, factorToPercentage, percentageToFactor } from '@/lib/utils'
+import { factorToPercentage, percentageToFactor } from '@/lib/utils'
 import { Field, FieldDescription, FieldLabel } from '../ui/field'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
 import { TxFeeInputField } from './TxFeeInputField'
@@ -111,51 +111,38 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
       return yup
         .object({
           feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
-          txFeesBlocks: yup.string().when('feeType', {
+          txFeesBlocks: yup.number().when('feeType', {
             is: txFeeUnit.BLOCKS,
             then: (schema) =>
               schema
-                .test('tx-fees-blocks', txFeesBlocksMessage, (value) => {
-                  const val = Number(value)
-                  return !!value && isValidNumber(val) && val >= 1 && val <= 1_000
-                })
+                .integer(txFeesBlocksMessage)
+                .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+                .min(1, txFeesBlocksMessage)
+                .max(1_000, txFeesBlocksMessage)
                 .required(txFeesBlocksMessage),
-            otherwise: (schema) => schema.default(''),
+            otherwise: (schema) => schema.nullable().optional(),
           }),
-          txFeesSatsPerVbyte: yup.string().when('feeType', {
+          txFeesSatsPerVbyte: yup.number().when('feeType', {
             is: txFeeUnit.SATS_PER_KILO_VBYTE,
             then: (schema) =>
               schema
-                .test('tx-fees-sats', txFeesSatsMessage, (value) => {
-                  const val = Number(value)
-                  return !!value && isValidNumber(val) && val >= 1.001 && val <= 350
-                })
+                .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+                .min(1.001, txFeesSatsMessage)
+                .max(350, txFeesSatsMessage)
                 .required(txFeesSatsMessage),
-            otherwise: (schema) => schema.default(''),
+            otherwise: (schema) => schema.nullable().optional(),
           }),
           txFeesFactor: yup
-            .string()
-            .test('tx-fees-factor', txFeesFactorMessage, (value) => {
-              const factorValue = percentageToFactor(Number(value))
-              return (
-                !!value &&
-                isValidNumber(Number(value)) &&
-                factorValue >= TX_FEES_FACTOR_MIN &&
-                factorValue <= TX_FEES_FACTOR_MAX
-              )
-            })
+            .number()
+            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+            .min(factorToPercentage(TX_FEES_FACTOR_MIN), txFeesFactorMessage)
+            .max(factorToPercentage(TX_FEES_FACTOR_MAX), txFeesFactorMessage)
             .required(txFeesFactorMessage),
           maxSweepFeeChange: yup
-            .string()
-            .test('max-sweep-fee-change', maxSweepFeeChangeMessage, (value) => {
-              const sweepValue = percentageToFactor(Number(value))
-              return (
-                !!value &&
-                isValidNumber(Number(value)) &&
-                sweepValue >= MAX_SWEEP_FEE_CHANGE_MIN &&
-                sweepValue <= MAX_SWEEP_FEE_CHANGE_MAX
-              )
-            })
+            .number()
+            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+            .min(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN), maxSweepFeeChangeMessage)
+            .max(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX), maxSweepFeeChangeMessage)
             .required(maxSweepFeeChangeMessage),
         })
         .required()

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -1,5 +1,8 @@
-import { useState, useEffect, forwardRef, useImperativeHandle } from 'react'
+import { useEffect, forwardRef, useImperativeHandle, useMemo } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useForm, useWatch, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import * as yup from 'yup'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -21,6 +24,14 @@ interface MiningFeesFormProps {
   enableValidation?: boolean
 }
 
+type MiningFeesFormValues = {
+  feeType: TxFeeUnit
+  txFeesBlocks: string
+  txFeesSatsPerVbyte: string
+  txFeesFactor: string
+  maxSweepFeeChange: string
+}
+
 export interface MiningFeesFormRef {
   getFormData: () => {
     txFees: string
@@ -29,150 +40,223 @@ export interface MiningFeesFormRef {
   } | null
   setFormData: (data: { txFees: string; txFeesFactor: string; maxSweepFeeChange: string }) => void
   resetForm: () => void
-  validateForm: () => boolean
+  validateForm: () => Promise<boolean>
+}
+
+const getMiningFeesFormValues = (initialValues: MiningFeesFormProps['initialValues']): MiningFeesFormValues => {
+  const txFeesValue = Number(initialValues.txFees)
+
+  if (initialValues.txFees && txFeesValue >= 1_001) {
+    return {
+      feeType: txFeeUnit.SATS_PER_KILO_VBYTE,
+      txFeesBlocks: '',
+      txFeesSatsPerVbyte: String(txFeesValue / 1_000),
+      txFeesFactor: initialValues.txFeesFactor,
+      maxSweepFeeChange: initialValues.maxSweepFeeChange,
+    }
+  }
+
+  return {
+    feeType: txFeeUnit.BLOCKS,
+    txFeesBlocks: initialValues.txFees,
+    txFeesSatsPerVbyte: '',
+    txFeesFactor: initialValues.txFeesFactor,
+    maxSweepFeeChange: initialValues.maxSweepFeeChange,
+  }
+}
+
+const DEFAULT_MINING_FEES_FORM_VALUES: MiningFeesFormValues = {
+  feeType: txFeeUnit.BLOCKS,
+  txFeesBlocks: '3',
+  txFeesSatsPerVbyte: '',
+  txFeesFactor: '20',
+  maxSweepFeeChange: '80',
 }
 
 export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>(
   ({ initialValues, enableValidation = true }, ref) => {
     const { t } = useTranslation()
-    const [feeType, setFeeType] = useState<TxFeeUnit>(txFeeUnit.BLOCKS)
-    const [txFeesBlocks, setTxFeesBlocks] = useState('')
-    const [txFeesSatsPerVbyte, setTxFeesSatsPerVbyte] = useState('')
-    const [txFeesFactor, setTxFeesFactor] = useState(initialValues.txFeesFactor)
-    const [maxSweepFeeChange, setMaxSweepFeeChange] = useState(initialValues.maxSweepFeeChange)
-
-    const [errors, setErrors] = useState<{ txFees?: string; txFeesFactor?: string; maxSweepFeeChange?: string }>({})
-
-    // Initialize txFees with proper unit detection
-    useEffect(() => {
-      if (initialValues.txFees) {
-        const txFeesValue = Number(initialValues.txFees)
-        if (txFeesValue >= 1_001) {
-          // This is sats/kilo-vbyte, display as sats/vbyte
-          setFeeType(txFeeUnit.SATS_PER_KILO_VBYTE)
-          setTxFeesSatsPerVbyte(String(txFeesValue / 1_000))
-          setTxFeesBlocks('')
-        } else {
-          // This is blocks
-          setFeeType(txFeeUnit.BLOCKS)
-          setTxFeesBlocks(initialValues.txFees)
-          setTxFeesSatsPerVbyte('')
-        }
-      }
-    }, [initialValues.txFees])
-
-    const validate = () => {
+    const schema = useMemo(() => {
       if (!enableValidation) {
-        setErrors({})
-        return true
-      }
-      const newErrors: { txFees?: string; txFeesFactor?: string; maxSweepFeeChange?: string } = {}
-
-      if (feeType === txFeeUnit.BLOCKS) {
-        const val = Number(txFeesBlocks)
-        if (!txFeesBlocks || !isValidNumber(val) || val < 1 || val > 1_000) {
-          newErrors.txFees = t('settings.fees.feedback_invalid_tx_fees_blocks', {
-            min: 1,
-            max: 1_000,
+        return yup
+          .object({
+            feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
+            txFeesBlocks: yup.string().default(''),
+            txFeesSatsPerVbyte: yup.string().default(''),
+            txFeesFactor: yup.string().default(''),
+            maxSweepFeeChange: yup.string().default(''),
           })
-        }
-      } else {
-        const val = Number(txFeesSatsPerVbyte)
-        if (!txFeesSatsPerVbyte || !isValidNumber(val) || val < 1.001 || val > 350) {
-          newErrors.txFees = t('settings.fees.feedback_invalid_tx_fees_satspervbyte', {
-            min: 1.001,
-            max: 350,
-          })
-        }
+          .required()
       }
 
-      if (!txFeesFactor) {
-        newErrors.txFeesFactor = t('settings.fees.feedback_invalid_tx_fees_factor', {
-          min: factorToPercentage(TX_FEES_FACTOR_MIN),
-          max: factorToPercentage(TX_FEES_FACTOR_MAX),
+      const txFeesBlocksMessage = t('settings.fees.feedback_invalid_tx_fees_blocks', {
+        min: 1,
+        max: 1_000,
+      })
+      const txFeesSatsMessage = t('settings.fees.feedback_invalid_tx_fees_satspervbyte', {
+        min: 1.001,
+        max: 350,
+      })
+      const txFeesFactorMessage = t('settings.fees.feedback_invalid_tx_fees_factor', {
+        min: factorToPercentage(TX_FEES_FACTOR_MIN),
+        max: factorToPercentage(TX_FEES_FACTOR_MAX),
+      })
+      const maxSweepFeeChangeMessage = t('settings.fees.feedback_invalid_max_sweep_fee_change', {
+        min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN),
+        max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX),
+      })
+
+      return yup
+        .object({
+          feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
+          txFeesBlocks: yup.string().when('feeType', {
+            is: txFeeUnit.BLOCKS,
+            then: (schema) =>
+              schema
+                .test('tx-fees-blocks', txFeesBlocksMessage, (value) => {
+                  const val = Number(value)
+                  return !!value && isValidNumber(val) && val >= 1 && val <= 1_000
+                })
+                .required(txFeesBlocksMessage),
+            otherwise: (schema) => schema.default(''),
+          }),
+          txFeesSatsPerVbyte: yup.string().when('feeType', {
+            is: txFeeUnit.SATS_PER_KILO_VBYTE,
+            then: (schema) =>
+              schema
+                .test('tx-fees-sats', txFeesSatsMessage, (value) => {
+                  const val = Number(value)
+                  return !!value && isValidNumber(val) && val >= 1.001 && val <= 350
+                })
+                .required(txFeesSatsMessage),
+            otherwise: (schema) => schema.default(''),
+          }),
+          txFeesFactor: yup
+            .string()
+            .test('tx-fees-factor', txFeesFactorMessage, (value) => {
+              const factorValue = percentageToFactor(Number(value))
+              return (
+                !!value &&
+                isValidNumber(Number(value)) &&
+                factorValue >= TX_FEES_FACTOR_MIN &&
+                factorValue <= TX_FEES_FACTOR_MAX
+              )
+            })
+            .required(txFeesFactorMessage),
+          maxSweepFeeChange: yup
+            .string()
+            .test('max-sweep-fee-change', maxSweepFeeChangeMessage, (value) => {
+              const sweepValue = percentageToFactor(Number(value))
+              return (
+                !!value &&
+                isValidNumber(Number(value)) &&
+                sweepValue >= MAX_SWEEP_FEE_CHANGE_MIN &&
+                sweepValue <= MAX_SWEEP_FEE_CHANGE_MAX
+              )
+            })
+            .required(maxSweepFeeChangeMessage),
         })
-      } else {
-        const factorValue = percentageToFactor(Number(txFeesFactor))
-        if (
-          !isValidNumber(Number(txFeesFactor)) ||
-          factorValue < TX_FEES_FACTOR_MIN ||
-          factorValue > TX_FEES_FACTOR_MAX
-        ) {
-          newErrors.txFeesFactor = t('settings.fees.feedback_invalid_tx_fees_factor', {
-            min: factorToPercentage(TX_FEES_FACTOR_MIN),
-            max: factorToPercentage(TX_FEES_FACTOR_MAX),
-          })
+        .required()
+    }, [enableValidation, t])
+
+    const {
+      control,
+      register,
+      getValues,
+      reset,
+      setValue,
+      trigger,
+      formState: { errors },
+    } = useForm<MiningFeesFormValues, unknown, MiningFeesFormValues>({
+      mode: 'onChange',
+      defaultValues: getMiningFeesFormValues(initialValues),
+      resolver: yupResolver(schema as yup.AnyObjectSchema) as Resolver<
+        MiningFeesFormValues,
+        unknown,
+        MiningFeesFormValues
+      >,
+    })
+
+    const feeType = useWatch({ control, name: 'feeType' })
+    const txFeesBlocks = useWatch({ control, name: 'txFeesBlocks' })
+    const txFeesSatsPerVbyte = useWatch({ control, name: 'txFeesSatsPerVbyte' })
+
+    useEffect(() => {
+      void trigger()
+    }, [trigger, enableValidation])
+
+    const handleTxFeeUnitChange = (newUnit: TxFeeUnit) => {
+      if (newUnit !== feeType) {
+        const currentValue = feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte
+
+        if (currentValue) {
+          const numberValue = Number(currentValue)
+          if (!Number.isNaN(numberValue)) {
+            if (newUnit === txFeeUnit.SATS_PER_KILO_VBYTE && feeType === txFeeUnit.BLOCKS) {
+              setValue('txFeesSatsPerVbyte', String(Math.round(numberValue * 1_000) / 1_000), {
+                shouldDirty: true,
+                shouldValidate: true,
+              })
+            } else if (newUnit === txFeeUnit.BLOCKS && feeType === txFeeUnit.SATS_PER_KILO_VBYTE) {
+              const converted = Math.round(numberValue * 1_000)
+              setValue('txFeesBlocks', String(Math.round(converted / 1_000)), {
+                shouldDirty: true,
+                shouldValidate: true,
+              })
+            }
+          }
         }
       }
 
-      if (!maxSweepFeeChange) {
-        newErrors.maxSweepFeeChange = t('settings.fees.feedback_invalid_max_sweep_fee_change', {
-          min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN),
-          max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX),
-        })
-      } else {
-        const sweepValue = percentageToFactor(Number(maxSweepFeeChange))
-        if (
-          !isValidNumber(Number(maxSweepFeeChange)) ||
-          sweepValue < MAX_SWEEP_FEE_CHANGE_MIN ||
-          sweepValue > MAX_SWEEP_FEE_CHANGE_MAX
-        ) {
-          newErrors.maxSweepFeeChange = t('settings.fees.feedback_invalid_max_sweep_fee_change', {
-            min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN),
-            max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX),
-          })
-        }
-      }
-      setErrors(newErrors)
-      return Object.keys(newErrors).length === 0
+      setValue('feeType', newUnit, { shouldDirty: true, shouldValidate: true })
     }
 
-    useEffect(() => {
-      validate()
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [txFeesBlocks, txFeesSatsPerVbyte, txFeesFactor, maxSweepFeeChange, feeType, enableValidation])
+    const handleTxFeeValueChange = (value: string) => {
+      const fieldName = feeType === txFeeUnit.BLOCKS ? 'txFeesBlocks' : 'txFeesSatsPerVbyte'
+      setValue(fieldName, value, { shouldDirty: true, shouldValidate: true })
+    }
 
-    useImperativeHandle(ref, () => ({
-      getFormData: () => {
-        if (!validate()) {
-          return null
-        }
-        return {
-          txFees: feeType === txFeeUnit.BLOCKS ? txFeesBlocks : String(Math.round(Number(txFeesSatsPerVbyte) * 1_000)),
-          txFeesFactor: txFeesFactor ? String(percentageToFactor(Number(txFeesFactor))) : '',
-          maxSweepFeeChange: maxSweepFeeChange ? String(percentageToFactor(Number(maxSweepFeeChange))) : '',
-        }
-      },
-      setFormData: (data: { txFees: string; txFeesFactor: string; maxSweepFeeChange: string }) => {
-        // Detect unit based on value range:
-        // - Blocks: 1-1000
-        // - Sats/kilo-vbyte: 1001+ (minimum is 1001 according to JM validation)
-        const txFeesValue = Number(data.txFees)
-        if (txFeesValue >= 1_001) {
-          setFeeType(txFeeUnit.SATS_PER_KILO_VBYTE)
-          setTxFeesSatsPerVbyte(String(txFeesValue / 1_000))
-          setTxFeesBlocks('')
-        } else {
-          setFeeType(txFeeUnit.BLOCKS)
-          setTxFeesBlocks(data.txFees)
-          setTxFeesSatsPerVbyte('')
-        }
-        const factorValue = data.txFeesFactor ? factorToPercentage(Number(data.txFeesFactor)) : ''
-        const sweepValue = data.maxSweepFeeChange ? factorToPercentage(Number(data.maxSweepFeeChange)) : ''
-        setTxFeesFactor(String(factorValue))
-        setMaxSweepFeeChange(String(sweepValue))
-        setErrors({})
-      },
-      resetForm: () => {
-        setFeeType(txFeeUnit.BLOCKS)
-        setTxFeesBlocks('3')
-        setTxFeesSatsPerVbyte('')
-        setTxFeesFactor('20')
-        setMaxSweepFeeChange('80')
-        setErrors({})
-      },
-      validateForm: () => validate(),
-    }))
+    useImperativeHandle(
+      ref,
+      () => ({
+        getFormData: () => {
+          const values = getValues()
+          if (!schema.isValidSync(values)) {
+            return null
+          }
+          return {
+            txFees:
+              values.feeType === txFeeUnit.BLOCKS
+                ? values.txFeesBlocks
+                : String(Math.round(Number(values.txFeesSatsPerVbyte) * 1_000)),
+            txFeesFactor: values.txFeesFactor ? String(percentageToFactor(Number(values.txFeesFactor))) : '',
+            maxSweepFeeChange: values.maxSweepFeeChange
+              ? String(percentageToFactor(Number(values.maxSweepFeeChange)))
+              : '',
+          }
+        },
+        setFormData: (data: { txFees: string; txFeesFactor: string; maxSweepFeeChange: string }) => {
+          reset(
+            getMiningFeesFormValues({
+              txFees: data.txFees,
+              txFeesFactor: data.txFeesFactor ? String(factorToPercentage(Number(data.txFeesFactor))) : '',
+              maxSweepFeeChange: data.maxSweepFeeChange
+                ? String(factorToPercentage(Number(data.maxSweepFeeChange)))
+                : '',
+            }),
+          )
+          void trigger()
+        },
+        resetForm: () => {
+          reset(DEFAULT_MINING_FEES_FORM_VALUES)
+          void trigger()
+        },
+        validateForm: () => trigger(),
+      }),
+      [getValues, reset, schema, trigger],
+    )
+
+    const txFeesError = feeType === txFeeUnit.BLOCKS ? errors.txFeesBlocks?.message : errors.txFeesSatsPerVbyte?.message
 
     return (
       <div>
@@ -183,15 +267,9 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
           <TxFeeInputField
             value={feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte}
             unit={feeType}
-            onUnitChange={setFeeType}
-            onValueChange={(val) => {
-              if (feeType === txFeeUnit.BLOCKS) {
-                setTxFeesBlocks(val)
-              } else {
-                setTxFeesSatsPerVbyte(val)
-              }
-            }}
-            error={errors.txFees}
+            onUnitChange={handleTxFeeUnitChange}
+            onValueChange={handleTxFeeValueChange}
+            error={txFeesError}
             disabled={false}
           />
         </div>
@@ -204,18 +282,19 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
               <span className="text-sm font-medium">%</span>
             </div>
             <Input
+              {...register('txFeesFactor')}
               type="number"
               inputMode="decimal"
               min="0"
               max="100"
               step="any"
-              value={txFeesFactor}
-              onChange={(event) => setTxFeesFactor(event.target.value)}
               placeholder="20"
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.txFeesFactor && <div className="text-destructive mt-1 text-xs">{errors.txFeesFactor}</div>}
+          {errors.txFeesFactor?.message && (
+            <div className="text-destructive mt-1 text-xs">{errors.txFeesFactor.message}</div>
+          )}
         </div>
 
         <div className="space-y-2">
@@ -231,18 +310,19 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
               <span className="text-sm font-medium">%</span>
             </div>
             <Input
+              {...register('maxSweepFeeChange')}
               type="number"
               inputMode="decimal"
               min="0"
               max="100"
               step="any"
-              value={maxSweepFeeChange}
-              onChange={(event) => setMaxSweepFeeChange(event.target.value)}
               placeholder="80"
               className="h-full rounded-l-none"
             />
           </div>
-          {errors.maxSweepFeeChange && <div className="text-destructive mt-1 text-xs">{errors.maxSweepFeeChange}</div>}
+          {errors.maxSweepFeeChange?.message && (
+            <div className="text-destructive mt-1 text-xs">{errors.maxSweepFeeChange.message}</div>
+          )}
         </div>
       </div>
     )

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -64,7 +64,7 @@ export const MiningFeesForm = ({
 
   return (
     <div className={cn('flex flex-col gap-4', className)}>
-      <p className="text-muted-foreground mb-6 text-sm">{t('settings.fees.description_general_fee_settings')}</p>
+      <p className="text-muted-foreground text-sm">{t('settings.fees.description_general_fee_settings')}</p>
 
       <div className="space-y-2">
         <Label>{t('settings.fees.label_tx_fees')}</Label>
@@ -87,7 +87,9 @@ export const MiningFeesForm = ({
           <InputGroup>
             <InputGroupInput
               id="mining-fees-tx-fees-factor"
-              {...register('txFeesFactorInPercent')}
+              {...register('txFeesFactorInPercent', {
+                valueAsNumber: true,
+              })}
               type="number"
               inputMode="decimal"
               min="0"
@@ -118,7 +120,9 @@ export const MiningFeesForm = ({
           <InputGroup>
             <InputGroupInput
               id="mining-fees-sweep-fee-change"
-              {...register('maxSweepFeeChangeInPercent')}
+              {...register('maxSweepFeeChangeInPercent', {
+                valueAsNumber: true,
+              })}
               type="number"
               inputMode="decimal"
               min="0"

--- a/src/components/settings/MiningFeesForm.tsx
+++ b/src/components/settings/MiningFeesForm.tsx
@@ -1,9 +1,9 @@
 import { useEffect, forwardRef, useImperativeHandle, useMemo } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { PercentIcon } from 'lucide-react'
 import { useForm, useWatch, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import * as yup from 'yup'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
   TX_FEES_FACTOR_MIN,
@@ -13,6 +13,8 @@ import {
 } from '@/constants/jam'
 import { JM_MAX_SWEEP_FEE_CHANGE_DEFAULT, txFeeUnit, type TxFeeUnit } from '@/constants/jm'
 import { isValidNumber, factorToPercentage, percentageToFactor } from '@/lib/utils'
+import { Field, FieldDescription, FieldLabel } from '../ui/field'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
 import { TxFeeInputField } from './TxFeeInputField'
 
 interface MiningFeesFormProps {
@@ -90,20 +92,20 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
       }
 
       const txFeesBlocksMessage = t('settings.fees.feedback_invalid_tx_fees_blocks', {
-        min: 1,
-        max: 1_000,
+        min: Number(1).toLocaleString(),
+        max: Number(1_000).toLocaleString(),
       })
       const txFeesSatsMessage = t('settings.fees.feedback_invalid_tx_fees_satspervbyte', {
-        min: 1.001,
-        max: 350,
+        min: Number(1.001).toLocaleString(),
+        max: Number(350).toLocaleString(),
       })
       const txFeesFactorMessage = t('settings.fees.feedback_invalid_tx_fees_factor', {
-        min: factorToPercentage(TX_FEES_FACTOR_MIN),
-        max: factorToPercentage(TX_FEES_FACTOR_MAX),
+        min: factorToPercentage(TX_FEES_FACTOR_MIN).toLocaleString(),
+        max: factorToPercentage(TX_FEES_FACTOR_MAX).toLocaleString(),
       })
       const maxSweepFeeChangeMessage = t('settings.fees.feedback_invalid_max_sweep_fee_change', {
-        min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN),
-        max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX),
+        min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN).toLocaleString(),
+        max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX).toLocaleString(),
       })
 
       return yup
@@ -259,10 +261,10 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
     const txFeesError = feeType === txFeeUnit.BLOCKS ? errors.txFeesBlocks?.message : errors.txFeesSatsPerVbyte?.message
 
     return (
-      <div>
+      <div className="space-y-6">
         <p className="text-muted-foreground mb-6 text-sm">{t('settings.fees.description_general_fee_settings')}</p>
 
-        <div className="mb-6 space-y-2">
+        <div className="space-y-2">
           <Label>{t('settings.fees.label_tx_fees')}</Label>
           <TxFeeInputField
             value={feeType === txFeeUnit.BLOCKS ? txFeesBlocks : txFeesSatsPerVbyte}
@@ -274,55 +276,63 @@ export const MiningFeesForm = forwardRef<MiningFeesFormRef, MiningFeesFormProps>
           />
         </div>
 
-        <div className="mb-6 space-y-2">
-          <Label>{t('settings.fees.label_tx_fees_factor')}</Label>
-          <p className="text-muted-foreground text-xs">{t('settings.fees.description_tx_fees_factor_^0.9.10')}</p>
-          <div className="flex h-12 items-center">
-            <div className="bg-muted flex h-full items-center rounded-l-md border border-r-0 px-3 py-2">
-              <span className="text-sm font-medium">%</span>
-            </div>
-            <Input
-              {...register('txFeesFactor')}
-              type="number"
-              inputMode="decimal"
-              min="0"
-              max="100"
-              step="any"
-              placeholder="20"
-              className="h-full rounded-l-none"
-            />
-          </div>
+        <div className="space-y-2">
+          <Field data-invalid={errors.txFeesFactor !== undefined}>
+            <FieldLabel htmlFor="mining-fees-tx-fees-factor">{t('settings.fees.label_tx_fees_factor')}</FieldLabel>
+            <FieldDescription className="text-xs">
+              {t('settings.fees.description_tx_fees_factor_^0.9.10')}
+            </FieldDescription>
+            <InputGroup>
+              <InputGroupInput
+                id="mining-fees-tx-fees-factor"
+                {...register('txFeesFactor')}
+                type="number"
+                inputMode="decimal"
+                min="0"
+                max="100"
+                step="any"
+                placeholder="20"
+              />
+              <InputGroupAddon align="inline-start">
+                <PercentIcon />
+              </InputGroupAddon>
+            </InputGroup>
+          </Field>
           {errors.txFeesFactor?.message && (
-            <div className="text-destructive mt-1 text-xs">{errors.txFeesFactor.message}</div>
+            <div className="text-destructive text-xs">{errors.txFeesFactor.message}</div>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label>{t('settings.fees.label_max_sweep_fee_change')}</Label>
-          <p className="text-muted-foreground text-xs">
-            {t('settings.fees.description_max_sweep_fee_change', {
-              // TODO: i18n - change variable name.. `defaultValue` is used by the library!
-              defaultValue: `${factorToPercentage(JM_MAX_SWEEP_FEE_CHANGE_DEFAULT)}%`,
-            })}
-          </p>
-          <div className="flex h-12 items-center">
-            <div className="bg-muted flex h-full items-center rounded-l-md border border-r-0 px-3 py-2">
-              <span className="text-sm font-medium">%</span>
-            </div>
-            <Input
-              {...register('maxSweepFeeChange')}
-              type="number"
-              inputMode="decimal"
-              min="0"
-              max="100"
-              step="any"
-              placeholder="80"
-              className="h-full rounded-l-none"
-            />
-          </div>
-          {errors.maxSweepFeeChange?.message && (
-            <div className="text-destructive mt-1 text-xs">{errors.maxSweepFeeChange.message}</div>
-          )}
+          <Field data-invalid={errors.maxSweepFeeChange !== undefined}>
+            <FieldLabel htmlFor="mining-fees-sweep-fee-change">
+              {t('settings.fees.label_max_sweep_fee_change')}
+            </FieldLabel>
+            <FieldDescription className="text-xs">
+              {t('settings.fees.description_max_sweep_fee_change', {
+                // TODO: i18n - change variable name.. `defaultValue` is used by the library!
+                defaultValue: `${factorToPercentage(JM_MAX_SWEEP_FEE_CHANGE_DEFAULT)}%`,
+              })}
+            </FieldDescription>
+            <InputGroup>
+              <InputGroupInput
+                id="mining-fees-sweep-fee-change"
+                {...register('maxSweepFeeChange')}
+                type="number"
+                inputMode="decimal"
+                min="0"
+                max="100"
+                step="any"
+                placeholder="80"
+              />
+              <InputGroupAddon align="inline-start">
+                <PercentIcon />
+              </InputGroupAddon>
+            </InputGroup>
+            {errors.maxSweepFeeChange?.message && (
+              <div className="text-destructive text-xs">{errors.maxSweepFeeChange.message}</div>
+            )}
+          </Field>
         </div>
       </div>
     )

--- a/src/components/settings/MiningFeesFormSchema.tsx
+++ b/src/components/settings/MiningFeesFormSchema.tsx
@@ -1,0 +1,88 @@
+import type { TFunction } from 'i18next'
+import * as yup from 'yup'
+import {
+  TX_FEES_FACTOR_MIN,
+  TX_FEES_FACTOR_MAX,
+  MAX_SWEEP_FEE_CHANGE_MIN,
+  MAX_SWEEP_FEE_CHANGE_MAX,
+} from '@/constants/jam'
+import { txFeeUnit, type TxFeeUnit } from '@/constants/jm'
+import { factorToPercentage } from '@/lib/utils'
+
+export type MiningFeesFormValues = {
+  feeType: TxFeeUnit
+  txFeesBlocks?: number
+  txFeesSatsPerVbyte?: number
+  txFeesFactorInPercent?: number
+  maxSweepFeeChangeInPercent?: number
+}
+
+export function miningFeesFormSchema(enableFormValidation: boolean, t: TFunction<'translation', undefined>) {
+  if (!enableFormValidation) {
+    return yup
+      .object({
+        feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
+        txFeesBlocks: yup.string().default(''),
+        txFeesSatsPerVbyte: yup.string().default(''),
+        txFeesFactorInPercent: yup.string().default(''),
+        maxSweepFeeChange: yup.string().default(''),
+      })
+      .required()
+  }
+
+  const txFeesBlocksMessage = t('settings.fees.feedback_invalid_tx_fees_blocks', {
+    min: Number(1).toLocaleString(),
+    max: Number(1_000).toLocaleString(),
+  })
+  const txFeesSatsMessage = t('settings.fees.feedback_invalid_tx_fees_satspervbyte', {
+    min: Number(1.001).toLocaleString(),
+    max: Number(350).toLocaleString(),
+  })
+  const txFeesFactorMessage = t('settings.fees.feedback_invalid_tx_fees_factor', {
+    min: factorToPercentage(TX_FEES_FACTOR_MIN).toLocaleString(),
+    max: factorToPercentage(TX_FEES_FACTOR_MAX).toLocaleString(),
+  })
+  const maxSweepFeeChangeMessage = t('settings.fees.feedback_invalid_max_sweep_fee_change', {
+    min: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN).toLocaleString(),
+    max: factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX).toLocaleString(),
+  })
+
+  return yup
+    .object({
+      feeType: yup.string<TxFeeUnit>().oneOf([txFeeUnit.BLOCKS, txFeeUnit.SATS_PER_KILO_VBYTE]).required(),
+      txFeesBlocks: yup.number().when('feeType', {
+        is: txFeeUnit.BLOCKS,
+        then: (schema) =>
+          schema
+            .integer(txFeesBlocksMessage)
+            .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+            .min(1, txFeesBlocksMessage)
+            .max(1_000, txFeesBlocksMessage)
+            .required(txFeesBlocksMessage),
+        otherwise: (schema) => schema.nullable().optional(),
+      }),
+      txFeesSatsPerVbyte: yup.number().when('feeType', {
+        is: txFeeUnit.SATS_PER_KILO_VBYTE,
+        then: (schema) =>
+          schema
+            .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+            .min(1.001, txFeesSatsMessage)
+            .max(350, txFeesSatsMessage)
+            .required(txFeesSatsMessage),
+        otherwise: (schema) => schema.nullable().optional(),
+      }),
+      txFeesFactorInPercent: yup
+        .number()
+        .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+        .min(factorToPercentage(TX_FEES_FACTOR_MIN), txFeesFactorMessage)
+        .max(factorToPercentage(TX_FEES_FACTOR_MAX), txFeesFactorMessage)
+        .required(txFeesFactorMessage),
+      maxSweepFeeChangeInPercent: yup
+        .number()
+        .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+        .min(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN), maxSweepFeeChangeMessage)
+        .max(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX), maxSweepFeeChangeMessage)
+        .required(maxSweepFeeChangeMessage),
+    })
+    .required()
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -251,7 +251,12 @@ export const SettingsPage = ({ walletFileName, onLockWallet }: SettingPageProps)
         </>
       )}
 
-      <FeeLimitDialog walletFileName={walletFileName} open={showFeeLimitDialog} onOpenChange={setShowFeeLimitDialog} />
+      <FeeLimitDialog
+        key={`fee-dialog-open-${showFeeLimitDialog}`}
+        walletFileName={walletFileName}
+        open={showFeeLimitDialog}
+        onOpenChange={setShowFeeLimitDialog}
+      />
 
       {hashedPassword && (
         <>

--- a/src/components/settings/TxFeeInputField.tsx
+++ b/src/components/settings/TxFeeInputField.tsx
@@ -74,7 +74,7 @@ export const TxFeeInputField = ({
         </div>
         <Input
           type="number"
-          inputMode="decimal"
+          inputMode={unit === txFeeUnit.BLOCKS ? 'numeric' : 'decimal'}
           min="0"
           step="any"
           value={value}

--- a/src/components/settings/TxFeeInputField.tsx
+++ b/src/components/settings/TxFeeInputField.tsx
@@ -33,21 +33,9 @@ export const TxFeeInputField = ({
   )
 
   const handleUnitChange = (newUnit: TxFeeUnit) => {
-    if (newUnit !== unit && value) {
-      const numberValue = Number(value)
-      if (!Number.isNaN(numberValue)) {
-        if (newUnit === txFeeUnit.SATS_PER_KILO_VBYTE && unit === txFeeUnit.BLOCKS) {
-          // Convert blocks to sats/vbyte
-          const converted = Math.round(numberValue * 1_000)
-          onValueChange(String(converted / 1_000))
-        } else if (newUnit === txFeeUnit.BLOCKS && unit === txFeeUnit.SATS_PER_KILO_VBYTE) {
-          // Convert sats/vbyte to blocks
-          const converted = Math.round(numberValue * 1_000)
-          onValueChange(String(Math.round(converted / 1_000)))
-        }
-      }
+    if (newUnit !== unit) {
+      onUnitChange(newUnit)
     }
-    onUnitChange(newUnit)
   }
 
   return (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -341,8 +341,7 @@
       "text_button_submitting": "Saving...",
       "error_loading_fee_config_failed": "Error while loading fee config values.",
       "error_saving_fee_config_failed": "Error while saving fee config values. Reason: {{ reason }}",
-      "success_message": "Fee settings updated successfully.",
-      "error_message": "Failed to update fee settings. Please try again."
+      "success_message": "Fee settings updated successfully."
     }
   },
   "rescan_chain": {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -27,11 +27,13 @@ import {
 import type { WalletFileName } from './utils'
 
 const withRuntimeLocale = (locale: string, callback: () => void) => {
-  const toLocaleStringMock = vi
-    .spyOn(Number.prototype, 'toLocaleString')
-    .mockImplementation(function (this: number, locales, options) {
-      return Intl.NumberFormat(locales ?? locale, options).format(this)
-    })
+  const toLocaleStringMock = vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
+    this: number,
+    locales,
+    options,
+  ) {
+    return Intl.NumberFormat(locales ?? locale, options).format(this)
+  })
 
   try {
     callback()


### PR DESCRIPTION
summary
migrate the collaborator fee settings form to `react-hook-form` and `yup`
migrate the mining fee settings form to `react-hook-form` and `yup`
keep the existing `FeeLimitDialog` integration and simplify tx fee input callbacks
ping @theborakompanioni 