### PR TITLE
feat: add data-journey-state with tests, docs, and friction audit

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -126,3 +126,12 @@ npm install && npm run dev
 - yup (GitHub): https://github.com/jquense/yup
 - react-hook-form (GitHub): https://github.com/react-hook-form/react-hook-form
 - react-query (GitHub): https://github.com/TanStack/query
+
+## Simulating Wallet Journey States
+
+The main wallet page exposes its current state with `data-journey-state` on `data-testid="main-wallet"`. This is useful when checking UI behavior in tests or during development.
+
+- Loading state: mock the wallet info hook with `isLoading: true`. The expected state is `loading`.
+- Empty wallet: mock `walletBalanceSummary.calculatedTotalBalanceInSats` as `0`. The expected state is `empty`.
+- Missing fee config: mock `useFeeConfigValidation` with `maxFeesConfigMissing: true` and use a positive wallet balance. The expected state is `needs_fee`.
+- Ready state: mock `isLoading: false`, a positive wallet balance, and `maxFeesConfigMissing: false`. The expected state is `ready`.

--- a/docs/wallet-state-friction-audit.md
+++ b/docs/wallet-state-friction-audit.md
@@ -1,0 +1,39 @@
+# Wallet State Friction Audit
+
+This is a short audit of places where the wallet can feel unclear to a user. The goal is not to redesign the whole flow, but to make each state easier to understand.
+
+## Empty Wallet
+
+Problem: A new wallet can show a balance of zero, but the user may not know what to do next.
+
+Why it is confusing: The page still shows normal wallet actions, so it can feel like something is missing or broken.
+
+Simple improvement: Show a small empty-state message near the balance, with a clear primary action to receive bitcoin.
+
+## Missing Fee Configuration
+
+Problem: Some wallet actions depend on fee settings being available.
+
+Why it is confusing: If fee values are missing, the user may only find out after trying to send or use a coinjoin-related flow.
+
+Simple improvement: Surface a short warning earlier, with a link or button to open fee settings.
+
+## Loading State
+
+Problem: The wallet needs time to load balance, jars, addresses, and service data.
+
+Why it is confusing: A user may see partial data and not know if the wallet is ready yet.
+
+Simple improvement: Keep the loading state clear and avoid showing action prompts that depend on wallet data until loading is done.
+
+## Backend or Service Dependency
+
+Problem: Jam depends on backend services such as the JoinMarket wallet API and coinjoin-related processes.
+
+Why it is confusing: If the backend is unavailable, the UI may look fine but actions can fail or stall.
+
+Simple improvement: Show a simple service status message when the backend cannot be reached, with a retry action and plain explanation.
+
+## Summary
+
+The wallet should make the next step obvious. Empty wallets should guide users to receive funds, missing fee config should point to settings, loading should not look ready, and backend problems should be shown as service issues instead of generic failures.

--- a/src/components/MainWalletPage.test.tsx
+++ b/src/components/MainWalletPage.test.tsx
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MainWalletPage from './MainWalletPage'
+
+const mockState = vi.hoisted(() => ({
+  isLoading: false,
+  balance: 1000,
+  maxFeesConfigMissing: false,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@/context/JamDisplayContext', () => ({
+  useJamDisplayContext: () => ({
+    toggleDisplayMode: vi.fn(),
+  }),
+}))
+
+vi.mock('@/context/JamWalletInfoContext', () => ({
+  useJamWalletInfoContext: () => ({
+    isLoading: mockState.isLoading,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useWalletBalanceSummary: () => ({
+    walletBalanceSummary: {
+      calculatedTotalBalanceInSats: mockState.balance,
+    },
+  }),
+  useJars: () => ({
+    jars: [],
+  }),
+}))
+
+vi.mock('@/hooks/useFeeConfigValidation', () => ({
+  useFeeConfigValidation: () => ({
+    maxFeesConfigMissing: mockState.maxFeesConfigMissing,
+  }),
+}))
+
+vi.mock('./wallet/WalletJarsDetailsOverlay', () => ({
+  WalletJarsDetailsOverlay: () => null,
+}))
+
+const renderMainWallet = ({
+  balance = 1000,
+  isLoading = false,
+  maxFeesConfigMissing = false,
+}: {
+  balance?: number
+  isLoading?: boolean
+  maxFeesConfigMissing?: boolean
+} = {}) => {
+  mockState.balance = balance
+  mockState.isLoading = isLoading
+  mockState.maxFeesConfigMissing = maxFeesConfigMissing
+
+  return render(<MainWalletPage walletFileName="test.jmdat" />)
+}
+
+describe('<MainWalletPage />', () => {
+  beforeEach(() => {
+    mockState.balance = 1000
+    mockState.isLoading = false
+    mockState.maxFeesConfigMissing = false
+  })
+
+  it('should render main wallet with journey state attribute', () => {
+    renderMainWallet()
+
+    const mainWallet = screen.getByTestId('main-wallet')
+
+    expect(mainWallet).toBeInTheDocument()
+    expect(mainWallet).toHaveAttribute('data-journey-state', 'ready')
+  })
+
+  it('should use mocked wallet and fee state predictably', () => {
+    renderMainWallet({ balance: 1000, maxFeesConfigMissing: true })
+
+    expect(screen.getByTestId('main-wallet')).toHaveAttribute('data-journey-state', 'needs_fee')
+  })
+
+  it('should return loading journey state when wallet is loading', () => {
+    renderMainWallet({ isLoading: true })
+
+    expect(screen.getByTestId('main-wallet')).toHaveAttribute('data-journey-state', 'loading')
+  })
+
+  it('should return empty journey state when wallet balance is zero', () => {
+    renderMainWallet({ balance: 0 })
+
+    expect(screen.getByTestId('main-wallet')).toHaveAttribute('data-journey-state', 'empty')
+  })
+})

--- a/src/components/MainWalletPage.tsx
+++ b/src/components/MainWalletPage.tsx
@@ -14,6 +14,8 @@ import {
   useWalletBalanceSummary,
   type Jar as JarObject,
 } from '@/context/JamWalletInfoContext'
+import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import { getJourneyState } from '@/lib/journeyState'
 import type { WalletFileName } from '@/lib/utils'
 import { cn, shortenStringMiddle, walletDisplayName } from '@/lib/utils'
 import { Balance } from './ui/jam/Balance'
@@ -34,10 +36,14 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
   const { isLoading, isFetching, error, refetch: refetchWalletData } = useJamWalletInfoContext()
   const { walletBalanceSummary } = useWalletBalanceSummary()
   const { jars } = useJars()
+  const { maxFeesConfigMissing } = useFeeConfigValidation({ walletFileName })
 
   const walletName = walletDisplayName(walletFileName)
   const walletNameTitle = shortenStringMiddle(walletName, 32)
-  const journeyState = 'initial'
+  const journeyState = getJourneyState(
+    isLoading ? undefined : { balanceSats: walletBalanceSummary.calculatedTotalBalanceInSats },
+    { feeConfigMissing: maxFeesConfigMissing },
+  )
 
   const onJarClicked = (jar: JarObject) => {
     setSelectedJar(jar)
@@ -58,7 +64,7 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
       <div
         className="flex flex-col items-center justify-center gap-8 px-4 py-12"
         data-journey-state={journeyState}
-        data-testid="wallet-view"
+        data-testid="main-wallet"
       >
         <div className="flex w-full max-w-xl flex-col items-center justify-center gap-2">
           <p className="text-muted-foreground hover:text-foreground text-xl select-all" title={walletName}>

--- a/src/components/MainWalletPage.tsx
+++ b/src/components/MainWalletPage.tsx
@@ -37,6 +37,7 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
 
   const walletName = walletDisplayName(walletFileName)
   const walletNameTitle = shortenStringMiddle(walletName, 32)
+  const journeyState = 'initial'
 
   const onJarClicked = (jar: JarObject) => {
     setSelectedJar(jar)
@@ -54,7 +55,11 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
         walletFileName={walletFileName}
         selectedJarIndex={selectedJar?.jarIndex}
       />
-      <div className="flex flex-col items-center justify-center gap-8 px-4 py-12">
+      <div
+        className="flex flex-col items-center justify-center gap-8 px-4 py-12"
+        data-journey-state={journeyState}
+        data-testid="wallet-view"
+      >
         <div className="flex w-full max-w-xl flex-col items-center justify-center gap-2">
           <p className="text-muted-foreground hover:text-foreground text-xl select-all" title={walletName}>
             {walletNameTitle}

--- a/src/lib/journeyState.test.ts
+++ b/src/lib/journeyState.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getJourneyState } from './journeyState'
+
+describe('getJourneyState', () => {
+  it('should return loading when wallet is undefined', () => {
+    expect(getJourneyState(undefined, { feeConfigMissing: false })).toBe('loading')
+  })
+
+  it('should return empty when balance is zero', () => {
+    expect(getJourneyState({ balanceSats: 0 }, { feeConfigMissing: false })).toBe('empty')
+  })
+
+  it('should return needs_fee when fee config is missing', () => {
+    expect(getJourneyState({ balanceSats: 1 }, { feeConfigMissing: true })).toBe('needs_fee')
+  })
+
+  it('should return ready when wallet is valid and fee config is present', () => {
+    expect(getJourneyState({ balanceSats: 1 }, { feeConfigMissing: false })).toBe('ready')
+  })
+
+  it('should return loading when balance is invalid', () => {
+    expect(getJourneyState({ balanceSats: undefined }, { feeConfigMissing: false })).toBe('loading')
+    expect(getJourneyState({ balanceSats: null }, { feeConfigMissing: false })).toBe('loading')
+    expect(getJourneyState({ balanceSats: Number.NaN }, { feeConfigMissing: false })).toBe('loading')
+  })
+})

--- a/src/lib/journeyState.ts
+++ b/src/lib/journeyState.ts
@@ -1,0 +1,20 @@
+export type JourneyState = 'loading' | 'empty' | 'needs_fee' | 'ready'
+
+export type JourneyWalletState = {
+  balanceSats?: number | null
+}
+
+export type JourneyFeeState = {
+  feeConfigMissing: boolean
+}
+
+// Journey state is ordered from unavailable wallet data to actionable states.
+// Empty comes before needs_fee because fee setup is not relevant without funds.
+export function getJourneyState(wallet: JourneyWalletState | undefined, feeState: JourneyFeeState): JourneyState {
+  const balanceSats = wallet?.balanceSats
+
+  if (typeof balanceSats !== 'number' || !Number.isFinite(balanceSats) || balanceSats < 0) return 'loading'
+  if (balanceSats === 0) return 'empty'
+  if (feeState.feeConfigMissing) return 'needs_fee'
+  return 'ready'
+}


### PR DESCRIPTION
What:
Added a data-journey-state attribute to the main wallet container.

How:
Used a small helper to derive the state based on wallet balance and fee configuration (loading, empty, needs_fee, ready). Also handled a few edge cases like invalid or negative balance and added unit + component tests.

Why:
The goal is to make the UI a bit more aware of the wallet state so it can guide users better.

Also:
Added a short wallet state friction audit and updated the developer docs with how to simulate different journey states during testing.

Note:
Some unrelated tests fail locally due to locale formatting and Playwright setup, but tests related to this change pass.