### PR TITLE
fix(v2): remove manual walletname encoding and rely on generated client path serialization 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,7 +93,7 @@ function App() {
     {
       ...lockwalletOptions({
         client,
-        path: { walletname: encodeURIComponent(walletFileName || '') },
+        path: { walletname: walletFileName || '' },
       }),
       enabled: false,
     },

--- a/src/components/create/CreateWalletPage.tsx
+++ b/src/components/create/CreateWalletPage.tsx
@@ -80,7 +80,7 @@ const CreateWalletPage = () => {
     mutationFn: async (parameters: { walletFileName: WalletFileName; token: ApiToken }) => {
       const { data } = await lockwallet({
         client,
-        path: { walletname: encodeURIComponent(parameters.walletFileName) },
+        path: { walletname: parameters.walletFileName },
         headers: { ...buildAuthHeaderMap(parameters.token) },
         throwOnError: true,
       })
@@ -196,7 +196,7 @@ const CreateWalletPage = () => {
   const handleMnemonicVerified = async ({ walletFileName, password, hashedPassword }: CreateWalletSuccessInfo) => {
     try {
       const response = await unlockWalletMutation.mutateAsync({
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
         body: {
           password,
         },

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -108,7 +108,7 @@ export function useCreateFidelityBondWizard(
     ...gettimelockaddressOptions({
       client,
       path: {
-        walletname: encodeURIComponent(walletFileName),
+        walletname: walletFileName,
         lockdate: selectedLockdate || '',
       },
     }),
@@ -230,7 +230,7 @@ export function useCreateFidelityBondWizard(
     try {
       for (const utxo of utxosToFreeze) {
         await freezeUtxo.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: { 'utxo-string': utxo.utxo, freeze: true },
         })
         frozen.push(utxo)
@@ -242,7 +242,7 @@ export function useCreateFidelityBondWizard(
       for (const utxo of frozen) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': utxo.utxo, freeze: false },
           })
         } catch {
@@ -259,7 +259,7 @@ export function useCreateFidelityBondWizard(
 
     try {
       const result = await directSend.mutateAsync({
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
         body: {
           mixdepth: selectedJar.jarIndex,
           amount_sats: 0,
@@ -274,7 +274,7 @@ export function useCreateFidelityBondWizard(
       for (const utxo of frozenUtxos) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': utxo.utxo, freeze: false },
           })
         } catch {
@@ -288,7 +288,7 @@ export function useCreateFidelityBondWizard(
       for (const utxo of frozenUtxos) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': utxo.utxo, freeze: false },
           })
         } catch {
@@ -304,7 +304,7 @@ export function useCreateFidelityBondWizard(
     try {
       for (const utxo of frozenUtxos) {
         await unfreezeUtxo.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: { 'utxo-string': utxo.utxo, freeze: false },
         })
       }

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -85,7 +85,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
 
   const stopMakerQueryOptions = stopmakerOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName) },
+    path: { walletname: walletFileName },
   })
 
   const stopMakerQuery = useQuery({
@@ -147,7 +147,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     stopMaker.reset()
     await startMaker.mutateAsync({
       path: {
-        walletname: encodeURIComponent(walletFileName),
+        walletname: walletFileName,
       },
       body: toStartMakerRequest(data),
     })

--- a/src/components/earn/MoveToJarDialog.tsx
+++ b/src/components/earn/MoveToJarDialog.tsx
@@ -77,7 +77,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
   const getAddressQueryOptions = getaddressOptions({
     client,
     path: {
-      walletname: encodeURIComponent(walletFileName),
+      walletname: walletFileName,
       mixdepth: String(selectedJarIndex ?? 0),
     },
   })
@@ -145,7 +145,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
       // Freeze other UTXOs in the source jar so only the FB gets swept
       for (const u of utxosToFreeze) {
         await freezeUtxo.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: { 'utxo-string': u.utxo, freeze: true },
         })
         frozen.push(u)
@@ -153,13 +153,13 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
 
       if (utxo.frozen) {
         await unfreezeUtxo.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: { 'utxo-string': utxo.utxo, freeze: false },
         })
       }
 
       const result = await directSend.mutateAsync({
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
         body: {
           mixdepth: utxo.mixdepth,
           amount_sats: 0,
@@ -175,7 +175,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
       for (const u of frozen) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': u.utxo, freeze: false },
           })
         } catch {
@@ -189,7 +189,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
       for (const u of frozen) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': u.utxo, freeze: false },
           })
         } catch {

--- a/src/components/earn/RenewBondDialog.tsx
+++ b/src/components/earn/RenewBondDialog.tsx
@@ -100,7 +100,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
     ...gettimelockaddressOptions({
       client,
       path: {
-        walletname: encodeURIComponent(walletFileName),
+        walletname: walletFileName,
         lockdate: selectedLockdate || '',
       },
     }),
@@ -165,7 +165,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
       // Freeze other UTXOs in the source jar so only the FB gets swept
       for (const u of utxosToFreeze) {
         await freezeUtxo.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: { 'utxo-string': u.utxo, freeze: true },
         })
         frozen.push(u)
@@ -173,13 +173,13 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
 
       if (utxo.frozen) {
         await unfreezeUtxo.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: { 'utxo-string': utxo.utxo, freeze: false },
         })
       }
 
       const result = await directSend.mutateAsync({
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
         body: {
           mixdepth: utxo.mixdepth,
           amount_sats: 0,
@@ -195,7 +195,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
       for (const u of frozen) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': u.utxo, freeze: false },
           })
         } catch {
@@ -209,7 +209,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
       for (const u of frozen) {
         try {
           await unfreezeUtxo.mutateAsync({
-            path: { walletname: encodeURIComponent(walletFileName) },
+            path: { walletname: walletFileName },
             body: { 'utxo-string': u.utxo, freeze: false },
           })
         } catch {

--- a/src/components/import/ImportWalletPage.tsx
+++ b/src/components/import/ImportWalletPage.tsx
@@ -112,7 +112,7 @@ const ImportWalletPage = () => {
     mutationFn: async (parameters: { walletFileName: WalletFileName; token: ApiToken }) => {
       const { data } = await lockwallet({
         client,
-        path: { walletname: encodeURIComponent(parameters.walletFileName) },
+        path: { walletname: parameters.walletFileName },
         headers: { ...buildAuthHeaderMap(parameters.token) },
         throwOnError: true,
       })
@@ -133,7 +133,7 @@ const ImportWalletPage = () => {
       const { data } = await rescanblockchain({
         client,
         path: {
-          walletname: encodeURIComponent(parameters.walletFileName),
+          walletname: parameters.walletFileName,
           blockheight: parameters.blockHeight,
         },
         headers: { ...buildAuthHeaderMap(parameters.token) },
@@ -188,7 +188,7 @@ const ImportWalletPage = () => {
       }
       // Step #2: update the gaplimit config value if necessary
       const originalGaplimitResponse = await fetchConfig.mutateAsync({
-        path: { walletname: encodeURIComponent(authState.walletFileName) },
+        path: { walletname: authState.walletFileName },
         headers: { ...buildAuthHeaderMap(authState.auth.token) },
         body: JM_GAPLIMIT_CONFIGKEY,
       })
@@ -199,7 +199,7 @@ const ImportWalletPage = () => {
         console.info('Will update gaplimit from %d to %d', originalGaplimit, importDetails.gaplimit)
 
         await updateConfig.mutateAsync({
-          path: { walletname: encodeURIComponent(authState.walletFileName) },
+          path: { walletname: authState.walletFileName },
           headers: { ...buildAuthHeaderMap(authState.auth.token) },
           body: {
             ...JM_GAPLIMIT_CONFIGKEY,
@@ -214,7 +214,7 @@ const ImportWalletPage = () => {
       })
 
       const unlockResponse = await unlockWallet.mutateAsync({
-        path: { walletname: encodeURIComponent(authState.walletFileName) },
+        path: { walletname: authState.walletFileName },
         body: {
           password: walletDetails.password,
         },
@@ -231,7 +231,7 @@ const ImportWalletPage = () => {
       if (gaplimitUpdateNecessary) {
         console.info('Will reset gaplimit to previous value %d', originalGaplimit)
         await updateConfig.mutateAsync({
-          path: { walletname: encodeURIComponent(authState.walletFileName) },
+          path: { walletname: authState.walletFileName },
           headers: { ...buildAuthHeaderMap(authState.auth.token) },
           body: {
             ...JM_GAPLIMIT_CONFIGKEY,

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -61,7 +61,7 @@ const LoginPage = () => {
     mutationFn: async (data: LoginFormData) => {
       const response = await unlockWallet.mutateAsync({
         path: {
-          walletname: encodeURIComponent(data.walletFileName),
+          walletname: data.walletFileName,
         },
         body: {
           password: data.password,

--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -56,7 +56,7 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
   const getAddressOptions = {
     client,
     path: {
-      walletname: encodeURIComponent(walletFileName),
+      walletname: walletFileName,
       mixdepth: String(selectedSourceJar?.jarIndex),
     },
   }

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -71,7 +71,7 @@ const AddressFromJarSelectorDialog = ({
           getaddress({
             client,
             path: {
-              walletname: encodeURIComponent(walletFileName),
+              walletname: walletFileName,
               mixdepth: String(selectedJarIndex),
             },
           }),

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -158,7 +158,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   })
   const stopCoinjoinQueryOptions = stopcoinjoinOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName) },
+    path: { walletname: walletFileName },
   })
   const stopCoinjoinQuery = useQuery({
     ...stopCoinjoinQueryOptions,
@@ -335,7 +335,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
         }
         const response = await directSendMutation.mutateAsync({
           path: {
-            walletname: encodeURIComponent(walletFileName),
+            walletname: walletFileName,
           },
           body,
         })
@@ -399,7 +399,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
         setPaymentSuccessfulInfoAlert(undefined)
         collaborativeLifecycleRef.current.utxoSnapshotAtStart = currentUtxoSnapshot
         await startCoinjoinMutationMutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body,
         })
         collaborativeLifecycleRef.current.awaitingCompletion = true

--- a/src/components/settings/AccountXpubsDialog.tsx
+++ b/src/components/settings/AccountXpubsDialog.tsx
@@ -208,7 +208,7 @@ export const AccountXpubsDialog = ({
 
   const seedQueryOptions = getseedOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName) },
+    path: { walletname: walletFileName },
   })
 
   const {

--- a/src/components/settings/FeeLimitDialog.tsx
+++ b/src/components/settings/FeeLimitDialog.tsx
@@ -105,7 +105,7 @@ export const FeeLimitDialog = ({ open, onOpenChange, walletFileName, ...dialogPr
 
       for (const { key, value } of configUpdates) {
         await setconfigMutation.mutateAsync({
-          path: { walletname: encodeURIComponent(walletFileName) },
+          path: { walletname: walletFileName },
           body: {
             ...FEE_CONFIG_KEYS[key],
             value,

--- a/src/components/settings/RescanChainPage.tsx
+++ b/src/components/settings/RescanChainPage.tsx
@@ -112,7 +112,7 @@ export const RescanChainPage = ({ walletFileName }: RescanChainProps) => {
       const { data } = await rescanblockchain({
         client,
         path: {
-          walletname: encodeURIComponent(walletFileName),
+          walletname: walletFileName,
           blockheight: blockHeight,
         },
         throwOnError: true,

--- a/src/components/settings/SeedPhraseDialog.tsx
+++ b/src/components/settings/SeedPhraseDialog.tsx
@@ -60,7 +60,7 @@ export const SeedPhraseDialog = ({
 
   const seedQueryOptions = getseedOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName) },
+    path: { walletname: walletFileName },
   })
 
   const {

--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -118,7 +118,7 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
       const result = await getschedule({
         client,
         signal,
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
         throwOnError: false,
       })
 
@@ -135,7 +135,7 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
 
   const stopScheduleQueryOptions = stopcoinjoinOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName) },
+    path: { walletname: walletFileName },
   })
 
   const stopScheduleQuery = useQuery({
@@ -279,7 +279,7 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
     }
 
     await startScheduleMutationMutateAsync({
-      path: { walletname: encodeURIComponent(walletFileName) },
+      path: { walletname: walletFileName },
       body,
     })
   }

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -78,7 +78,7 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
           freezeOrUnfreezeUtxo
             .mutateAsync({
               path: {
-                walletname: encodeURIComponent(walletFileName),
+                walletname: walletFileName,
               },
               body: {
                 'utxo-string': utxo.utxo,

--- a/src/context/JamSessionInfoContextProvider.tsx
+++ b/src/context/JamSessionInfoContextProvider.tsx
@@ -30,7 +30,7 @@ export const JamSessionInfoContextProvider = ({
     () =>
       getrescaninfoOptions({
         client,
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
       }),
     [client, walletFileName],
   )

--- a/src/hooks/useJmConfig.ts
+++ b/src/hooks/useJmConfig.ts
@@ -18,7 +18,7 @@ export const useJmConfig = ({ walletFileName }: UseJmConfigProps) => {
   const { mutateAsync: fetchConfigAsync } = useMutation({
     ...configgetMutation({
       client,
-      path: { walletname: encodeURIComponent(walletFileName) },
+      path: { walletname: walletFileName },
     }),
     retry: 3,
   })
@@ -26,7 +26,7 @@ export const useJmConfig = ({ walletFileName }: UseJmConfigProps) => {
   const refetch = useCallback(
     async (key: ConfigKey): Promise<ConfigValue> => {
       const { configvalue } = await fetchConfigAsync({
-        path: { walletname: encodeURIComponent(walletFileName) },
+        path: { walletname: walletFileName },
         body: {
           section: key.section,
           field: key.field,

--- a/src/hooks/useQueryDisplayWallet.ts
+++ b/src/hooks/useQueryDisplayWallet.ts
@@ -29,7 +29,7 @@ export function useQueryDisplayWallet({
 
   const displaywalletQueryOptions = displaywalletOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName || '') },
+    path: { walletname: walletFileName || '' },
     query: {
       // cache busting: reload whenever local utxos change
       '#cb': utxosHashHex,

--- a/src/hooks/useQueryUtxos.ts
+++ b/src/hooks/useQueryUtxos.ts
@@ -46,7 +46,7 @@ export function useQueryUtxos({ walletFileName }: UseQueryUtxosProps): UseQueryU
 
   const listutxosQueryOptions = listutxosOptions({
     client,
-    path: { walletname: encodeURIComponent(walletFileName || '') },
+    path: { walletname: walletFileName || '' },
   })
 
   const queryResult = useQuery({

--- a/src/hooks/useUtxoSelectionDialog.ts
+++ b/src/hooks/useUtxoSelectionDialog.ts
@@ -70,7 +70,7 @@ export const useUtxoSelectionDialog = ({ walletFileName, jars, addressSummary }:
           utxosToFreeze.map((utxo) =>
             freezeOrUnfreezeUtxoMutateAsync({
               path: {
-                walletname: encodeURIComponent(walletFileName),
+                walletname: walletFileName,
               },
               body: {
                 'utxo-string': utxo.utxo,
@@ -83,7 +83,7 @@ export const useUtxoSelectionDialog = ({ walletFileName, jars, addressSummary }:
           utxosToUnfreeze.map((utxo) =>
             freezeOrUnfreezeUtxoMutateAsync({
               path: {
-                walletname: encodeURIComponent(walletFileName),
+                walletname: walletFileName,
               },
               body: {
                 'utxo-string': utxo.utxo,

--- a/src/lib/walletnamePathEncoding.test.ts
+++ b/src/lib/walletnamePathEncoding.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const current_dir= dirname(fileURLToPath(import.meta.url))
+const src_dir=resolve(current_dir, '..')
+
+const walletname_pre_encoding= /walletname\s*:\s*encodeURIComponent\s*\(/
+
+const collectSourceFiles = (dirPath: string): string[] => {
+  const children = readdirSync(dirPath)
+  return children.flatMap((name) => {
+    const absolute = join(dirPath, name)
+    const stats = statSync(absolute)
+    if (stats.isDirectory()) {
+    return collectSourceFiles(absolute)
+    }
+    if (!/\.(ts|tsx)$/.test(name) || /\.test\.(ts|tsx)$/.test(name)) {
+      return []
+    }
+
+    return [absolute]
+  })
+}
+
+describe('walletname path encoding ownership', () => {
+  it('does not manually pre-encode walletname in src callsites', () => {
+    const files = collectSourceFiles(src_dir)
+    const offenders = files
+      .filter((filePath) => walletname_pre_encoding.test(readFileSync(filePath, 'utf8')))
+      .map((filePath) => relative(src_dir, filePath))
+
+    expect(offenders).toEqual([])
+  })
+
+  it('requires raw walletname values so path params are encoded exactly once', () => {
+    const pathTemplate = '/wallet/{walletname}/lock'
+    const buildPath = (walletname: string) => {
+      return pathTemplate.replace('{walletname}', encodeURIComponent(walletname))
+    }
+    expect(buildPath('my wallet.jmdat')).toBe('/wallet/my%20wallet.jmdat/lock')
+    expect(buildPath('my100%wallet.jmdat')).toBe('/wallet/my100%25wallet.jmdat/lock')
+    expect(buildPath('my%20wallet.jmdat')).toBe('/wallet/my%2520wallet.jmdat/lock')
+  })
+})

--- a/src/lib/walletnamePathEncoding.test.ts
+++ b/src/lib/walletnamePathEncoding.test.ts
@@ -1,20 +1,20 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
-const current_dir= dirname(fileURLToPath(import.meta.url))
-const src_dir=resolve(current_dir, '..')
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
+const sourceDirectory = path.resolve(currentDirectory, '..')
 
-const walletname_pre_encoding= /walletname\s*:\s*encodeURIComponent\s*\(/
+const walletnamePreEncoding = /walletname\s*:\s*encodeURIComponent\s*\(/
 
-const collectSourceFiles = (dirPath: string): string[] => {
-  const children = readdirSync(dirPath)
+const collectSourceFiles = (directoryPath: string): string[] => {
+  const children = readdirSync(directoryPath)
   return children.flatMap((name) => {
-    const absolute = join(dirPath, name)
+    const absolute = path.join(directoryPath, name)
     const stats = statSync(absolute)
     if (stats.isDirectory()) {
-    return collectSourceFiles(absolute)
+      return collectSourceFiles(absolute)
     }
     if (!/\.(ts|tsx)$/.test(name) || /\.test\.(ts|tsx)$/.test(name)) {
       return []
@@ -26,10 +26,10 @@ const collectSourceFiles = (dirPath: string): string[] => {
 
 describe('walletname path encoding ownership', () => {
   it('does not manually pre-encode walletname in src callsites', () => {
-    const files = collectSourceFiles(src_dir)
+    const files = collectSourceFiles(sourceDirectory)
     const offenders = files
-      .filter((filePath) => walletname_pre_encoding.test(readFileSync(filePath, 'utf8')))
-      .map((filePath) => relative(src_dir, filePath))
+      .filter((filePath) => walletnamePreEncoding.test(readFileSync(filePath, 'utf8')))
+      .map((filePath) => path.relative(sourceDirectory, filePath))
 
     expect(offenders).toEqual([])
   })


### PR DESCRIPTION

## Summary
This PR removes manual walletname URL encoding at generated-client callsites and standardizes on passing raw walletname values.

## Why
The generated API client already encodes path params internally. Pre-encoding at callsites can cause double-encoding edge cases, especially for wallets created outside Jam.

## What changed
- Replaced manual walletname encoding with raw walletname in generated-client path usage.
- Kept behavior consistent with the existing raw walletname flow.

## Validation
- Lint: passes (only existing warnings, no new ones).
- Build: passes.
- Targeted unit tests for touched send/sweep logic: pass.

## Notes
No functional API shape changes were introduced; this is a consistency and safety cleanup.