### PR TITLE
chore: fix features path and rename jam api lib file

### DIFF
--- a/src/components/logging/useJmwalletdStdoutLog.ts
+++ b/src/components/logging/useJmwalletdStdoutLog.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useStore } from 'zustand'
 import { Alert } from '@/components/ui/alert'
-import { fetchLog } from '@/lib/api/logs'
+import { fetchLog } from '@/lib/api/jam'
 import { getErrorReason } from '@/lib/errorReason'
 import { authStore } from '@/store/authStore'
 

--- a/src/hooks/useFeatures.ts
+++ b/src/hooks/useFeatures.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useStore } from 'zustand'
-import { fetchFeatures } from '@/lib/api/logs'
+import { fetchFeatures } from '@/lib/api/jam'
 import { authStore } from '@/store/authStore'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 

--- a/src/lib/api/jam.ts
+++ b/src/lib/api/jam.ts
@@ -28,7 +28,7 @@ const withExpectedContentTypeOrThrow = (response: Response, expectedContentType:
  * @returns Promise<Response>
  */
 export const fetchFeatures = async ({ token, signal }: AuthApiRequestContext) => {
-  return await fetch(`/features`, {
+  return await fetch(`/jam/api/v0/features`, {
     headers: { ...buildAuthHeaderMap(token) },
     signal,
   }).then((response) => withExpectedContentTypeOrThrow(response, 'application/json'))


### PR DESCRIPTION
Fixes the path to the "features" endpoint and renames the `api/logs.ts` file to `api/jam.ts`.
See https://github.com/joinmarket-webui/jam-docker/blob/master/standalone/nginx/default.conf#L135