### PR TITLE
Fix render-phase state update in AccountXpubsDialog

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -100,8 +100,8 @@ const withI18next = (Story: React.ComponentType, context: GlobalContext) => {
   )
 }
 
+const queryClient = new QueryClient()
 export const withQueryClient = (Story: React.ComponentType) => {
-  const queryClient = new QueryClient()
   return (
     <QueryClientProvider client={queryClient}>
       <Story />
@@ -110,7 +110,6 @@ export const withQueryClient = (Story: React.ComponentType) => {
 }
 
 export const withJamDisplayContent = (Story: React.ComponentType) => {
-  const queryClient = new QueryClient()
   return (
     <JamDisplayContextProvider>
       <Story />

--- a/src/components/settings/AccountXpubsDialog.tsx
+++ b/src/components/settings/AccountXpubsDialog.tsx
@@ -191,12 +191,8 @@ export const AccountXpubsDialog = ({
   const { t } = useTranslation()
 
   const [passwordVerifiedAt, setPasswordVerifiedAt] = useState<number>()
-  const isPasswordVerified = useMemo(() => passwordVerifiedAt !== undefined, [passwordVerifiedAt])
   const [timeLeft, setTimeLeft] = useState(autoCloseTimeout)
-
-  if (timeLeft <= 0 && passwordVerifiedAt !== undefined) {
-    setPasswordVerifiedAt(undefined)
-  }
+  const isPasswordVerified = passwordVerifiedAt !== undefined && timeLeft > 0
 
   const secondsLeft = Math.max(0, Math.round(timeLeft / 1_000))
 
@@ -206,10 +202,14 @@ export const AccountXpubsDialog = ({
   const queryClient = useQueryClient()
   const { jars } = useJars()
 
-  const seedQueryOptions = getseedOptions({
-    client,
-    path: { walletname: walletFileName },
-  })
+  const seedQueryOptions = useMemo(
+    () =>
+      getseedOptions({
+        client,
+        path: { walletname: walletFileName },
+      }),
+    [client, walletFileName],
+  )
 
   const {
     data: seedQueryData,
@@ -225,7 +225,7 @@ export const AccountXpubsDialog = ({
     select: (data) => data.seedphrase.split(/\s+/) as MnemonicPhrase,
   })
 
-  const accountXpubsQueryKey = [walletFileName, 'xpubs']
+  const accountXpubsQueryKey = useMemo(() => [walletFileName, 'xpubs'], [walletFileName])
 
   const accountXpubs = useQuery({
     queryKey: accountXpubsQueryKey,
@@ -256,13 +256,25 @@ export const AccountXpubsDialog = ({
 
     const xpubsDisplayedAt = Math.max(accountXpubs.dataUpdatedAt, passwordVerifiedAt)
     const interval = setInterval(() => {
-      setTimeLeft(Math.max(0, xpubsDisplayedAt + autoCloseTimeout - Date.now()))
+      const nextTimeLeft = Math.max(0, xpubsDisplayedAt + autoCloseTimeout - Date.now())
+      setTimeLeft(nextTimeLeft)
+      if (nextTimeLeft <= 0) {
+        clearInterval(interval)
+        setPasswordVerifiedAt(undefined)
+      }
     }, 333)
 
     return () => {
       clearInterval(interval)
     }
   }, [accountXpubs.dataUpdatedAt, passwordVerifiedAt, autoCloseTimeout])
+
+  useEffect(() => {
+    if (timeLeft > 0) return
+
+    queryClient.removeQueries({ queryKey: seedQueryOptions.queryKey })
+    queryClient.removeQueries({ queryKey: accountXpubsQueryKey })
+  }, [queryClient, seedQueryOptions.queryKey, accountXpubsQueryKey, timeLeft])
 
   const handleClose = () => {
     onOpenChange(false)


### PR DESCRIPTION
This PR removes a render phase state update in AccountXpubsDialog and keeps timeout handling lifecycle safe.
The change prevents unnecessary re renders and makes expiry behavior more predictable and maintainable.