### PR TITLE
refactor(forms): use react-hook-form for sweep and fidelity bond flows

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.test.ts
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.test.ts
@@ -9,9 +9,10 @@ import {
 
 const t = ((key: string) => key) as unknown as TFunction<'translation', undefined>
 const lockdateOptions = [{ value: '2026-07' as fb.Lockdate }, { value: '2026-08' as fb.Lockdate }]
+const jarIndexes = [0, 1]
 
 const validate = async (values: CreateFidelityBondFormValues) => {
-  return await createFidelityBondFormSchema(lockdateOptions, t).validate(values, { abortEarly: false })
+  return await createFidelityBondFormSchema(lockdateOptions, jarIndexes, t).validate(values, { abortEarly: false })
 }
 
 describe('createFidelityBondFormSchema', () => {
@@ -61,6 +62,19 @@ describe('createFidelityBondFormSchema', () => {
       }),
     ).rejects.toMatchObject({
       inner: [expect.objectContaining({ path: 'lockdate' })],
+    })
+  })
+
+  it('rejects jar index values that are not in the available jar list', async () => {
+    await expect(
+      validate({
+        lockdate: '2026-07' as fb.Lockdate,
+        jarIndex: 99,
+        utxoIds: ['txid:0'],
+        confirmationAccepted: true,
+      }),
+    ).rejects.toMatchObject({
+      inner: [expect.objectContaining({ path: 'jarIndex' })],
     })
   })
 })

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.test.ts
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.test.ts
@@ -19,7 +19,9 @@ describe('createFidelityBondFormSchema', () => {
   it('provides defaults for the wizard form', () => {
     expect(CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES).toEqual({
       lockdate: undefined,
-      jarIndex: undefined,
+      source: {
+        fromJar: undefined,
+      },
       utxoIds: [],
       confirmationAccepted: false,
     })
@@ -29,13 +31,17 @@ describe('createFidelityBondFormSchema', () => {
     await expect(
       validate({
         lockdate: '2026-07' as fb.Lockdate,
-        jarIndex: 0,
+        source: {
+          fromJar: 0,
+        },
         utxoIds: ['txid:0'],
         confirmationAccepted: true,
       }),
     ).resolves.toEqual({
       lockdate: '2026-07',
-      jarIndex: 0,
+      source: {
+        fromJar: 0,
+      },
       utxoIds: ['txid:0'],
       confirmationAccepted: true,
     })
@@ -45,7 +51,7 @@ describe('createFidelityBondFormSchema', () => {
     await expect(validate(CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES)).rejects.toMatchObject({
       inner: [
         expect.objectContaining({ path: 'lockdate' }),
-        expect.objectContaining({ path: 'jarIndex' }),
+        expect.objectContaining({ path: 'source.fromJar' }),
         expect.objectContaining({ path: 'utxoIds' }),
         expect.objectContaining({ path: 'confirmationAccepted' }),
       ],
@@ -56,7 +62,9 @@ describe('createFidelityBondFormSchema', () => {
     await expect(
       validate({
         lockdate: '2025-01' as fb.Lockdate,
-        jarIndex: 0,
+        source: {
+          fromJar: 0,
+        },
         utxoIds: ['txid:0'],
         confirmationAccepted: true,
       }),
@@ -69,12 +77,14 @@ describe('createFidelityBondFormSchema', () => {
     await expect(
       validate({
         lockdate: '2026-07' as fb.Lockdate,
-        jarIndex: 99,
+        source: {
+          fromJar: 99,
+        },
         utxoIds: ['txid:0'],
         confirmationAccepted: true,
       }),
     ).rejects.toMatchObject({
-      inner: [expect.objectContaining({ path: 'jarIndex' })],
+      inner: [expect.objectContaining({ path: 'source.fromJar' })],
     })
   })
 })

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.test.ts
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.test.ts
@@ -1,0 +1,66 @@
+import type { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+import * as fb from '@/lib/fidelityBondUtils'
+import {
+  CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES,
+  createFidelityBondFormSchema,
+  type CreateFidelityBondFormValues,
+} from './CreateFidelityBondFormSchema'
+
+const t = ((key: string) => key) as unknown as TFunction<'translation', undefined>
+const lockdateOptions = [{ value: '2026-07' as fb.Lockdate }, { value: '2026-08' as fb.Lockdate }]
+
+const validate = async (values: CreateFidelityBondFormValues) => {
+  return await createFidelityBondFormSchema(lockdateOptions, t).validate(values, { abortEarly: false })
+}
+
+describe('createFidelityBondFormSchema', () => {
+  it('provides defaults for the wizard form', () => {
+    expect(CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES).toEqual({
+      lockdate: undefined,
+      jarIndex: undefined,
+      utxoIds: [],
+      confirmationAccepted: false,
+    })
+  })
+
+  it('accepts complete fidelity bond form values', async () => {
+    await expect(
+      validate({
+        lockdate: '2026-07' as fb.Lockdate,
+        jarIndex: 0,
+        utxoIds: ['txid:0'],
+        confirmationAccepted: true,
+      }),
+    ).resolves.toEqual({
+      lockdate: '2026-07',
+      jarIndex: 0,
+      utxoIds: ['txid:0'],
+      confirmationAccepted: true,
+    })
+  })
+
+  it('rejects incomplete fidelity bond form values', async () => {
+    await expect(validate(CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES)).rejects.toMatchObject({
+      inner: [
+        expect.objectContaining({ path: 'lockdate' }),
+        expect.objectContaining({ path: 'jarIndex' }),
+        expect.objectContaining({ path: 'utxoIds' }),
+        expect.objectContaining({ path: 'confirmationAccepted' }),
+      ],
+    })
+  })
+
+  it('rejects lockdates outside the generated options', async () => {
+    await expect(
+      validate({
+        lockdate: '2025-01' as fb.Lockdate,
+        jarIndex: 0,
+        utxoIds: ['txid:0'],
+        confirmationAccepted: true,
+      }),
+    ).rejects.toMatchObject({
+      inner: [expect.objectContaining({ path: 'lockdate' })],
+    })
+  })
+})

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.ts
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.ts
@@ -1,0 +1,35 @@
+import type { TFunction } from 'i18next'
+import * as yup from 'yup'
+import * as fb from '@/lib/fidelityBondUtils'
+import type { JarIndex } from '@/types/global'
+
+export type CreateFidelityBondFormValues = {
+  lockdate?: fb.Lockdate
+  jarIndex?: JarIndex
+  utxoIds: string[]
+  confirmationAccepted: boolean
+}
+
+export const CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES: CreateFidelityBondFormValues = {
+  lockdate: undefined,
+  jarIndex: undefined,
+  utxoIds: [],
+  confirmationAccepted: false,
+}
+
+export const createFidelityBondFormSchema = (
+  lockdateOptions: Array<{ value: fb.Lockdate }>,
+  t: TFunction<'translation', undefined>,
+) => {
+  const requiredMessage = t('global.errors.reason_unknown')
+  const validLockdates = lockdateOptions.map((option) => option.value)
+
+  return yup
+    .object({
+      lockdate: yup.string<fb.Lockdate>().oneOf(validLockdates, requiredMessage).required(requiredMessage),
+      jarIndex: yup.number<JarIndex>().integer(requiredMessage).required(requiredMessage),
+      utxoIds: yup.array().of(yup.string().required(requiredMessage)).min(1, requiredMessage).required(requiredMessage),
+      confirmationAccepted: yup.boolean().oneOf([true], requiredMessage).required(requiredMessage),
+    })
+    .required()
+}

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.ts
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.ts
@@ -19,15 +19,24 @@ export const CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES: CreateFidelityBondFormVal
 
 export const createFidelityBondFormSchema = (
   lockdateOptions: Array<{ value: fb.Lockdate }>,
+  jarIndexes: JarIndex[],
   t: TFunction<'translation', undefined>,
 ) => {
   const requiredMessage = t('global.errors.reason_unknown')
+  const invalidSourceJarFeedbackMessage = t('receive.feedback_invalid_source_jar', {
+    /* TODO: i18n: provide dedicated fidelity-bond source-jar validation copy */
+    defaultValue: 'Please select a source jar.',
+  })
   const validLockdates = lockdateOptions.map((option) => option.value)
 
   return yup
     .object({
       lockdate: yup.string<fb.Lockdate>().oneOf(validLockdates, requiredMessage).required(requiredMessage),
-      jarIndex: yup.number<JarIndex>().integer(requiredMessage).required(requiredMessage),
+      jarIndex: yup
+        .number<JarIndex>()
+        .integer(invalidSourceJarFeedbackMessage)
+        .required(invalidSourceJarFeedbackMessage)
+        .test('valid-source-jar-index-test', invalidSourceJarFeedbackMessage, (value) => jarIndexes.includes(value)),
       utxoIds: yup.array().of(yup.string().required(requiredMessage)).min(1, requiredMessage).required(requiredMessage),
       confirmationAccepted: yup.boolean().oneOf([true], requiredMessage).required(requiredMessage),
     })

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.ts
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondFormSchema.ts
@@ -3,16 +3,22 @@ import * as yup from 'yup'
 import * as fb from '@/lib/fidelityBondUtils'
 import type { JarIndex } from '@/types/global'
 
+export type SourceValue = {
+  fromJar?: JarIndex
+}
+
 export type CreateFidelityBondFormValues = {
   lockdate?: fb.Lockdate
-  jarIndex?: JarIndex
+  source: SourceValue
   utxoIds: string[]
   confirmationAccepted: boolean
 }
 
 export const CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES: CreateFidelityBondFormValues = {
   lockdate: undefined,
-  jarIndex: undefined,
+  source: {
+    fromJar: undefined,
+  },
   utxoIds: [],
   confirmationAccepted: false,
 }
@@ -32,11 +38,19 @@ export const createFidelityBondFormSchema = (
   return yup
     .object({
       lockdate: yup.string<fb.Lockdate>().oneOf(validLockdates, requiredMessage).required(requiredMessage),
-      jarIndex: yup
-        .number<JarIndex>()
-        .integer(invalidSourceJarFeedbackMessage)
-        .required(invalidSourceJarFeedbackMessage)
-        .test('valid-source-jar-index-test', invalidSourceJarFeedbackMessage, (value) => jarIndexes.includes(value)),
+      source: yup
+        .object({
+          fromJar: yup
+            .number<JarIndex>()
+            .integer(invalidSourceJarFeedbackMessage)
+            .required(invalidSourceJarFeedbackMessage)
+            .test(
+              'valid-source-jar-index-test',
+              invalidSourceJarFeedbackMessage,
+              (value) => typeof value === 'number' && jarIndexes.includes(value),
+            ),
+        })
+        .required(),
       utxoIds: yup.array().of(yup.string().required(requiredMessage)).min(1, requiredMessage).required(requiredMessage),
       confirmationAccepted: yup.boolean().oneOf([true], requiredMessage).required(requiredMessage),
     })

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -44,7 +44,11 @@ export function useCreateFidelityBondWizard(
   const [error, setError] = useState<string | undefined>()
 
   const lockdateOptions = useMemo(() => generateLockdateOptions(isDeveloperMode), [isDeveloperMode])
-  const formSchema = useMemo(() => createFidelityBondFormSchema(lockdateOptions, t), [lockdateOptions, t])
+  const jarIndexes = useMemo(() => walletInfo.jars.map((jar) => jar.jarIndex), [walletInfo.jars])
+  const formSchema = useMemo(
+    () => createFidelityBondFormSchema(lockdateOptions, jarIndexes, t),
+    [lockdateOptions, jarIndexes, t],
+  )
   const form = useForm<CreateFidelityBondFormValues, unknown, CreateFidelityBondFormValues>({
     mode: 'onChange',
     defaultValues: CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES,

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
 import {
   directsendMutation,
   freezeMutation,
@@ -6,8 +7,10 @@ import {
 } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { DirectSendResponse, ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
+import { useForm, useWatch, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import * as yup from 'yup'
 import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import type { Utxo } from '@/hooks/useQueryUtxos'
@@ -16,6 +19,11 @@ import * as fb from '@/lib/fidelityBondUtils'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import type { JarIndex } from '@/types/global'
+import {
+  CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES,
+  createFidelityBondFormSchema,
+  type CreateFidelityBondFormValues,
+} from './CreateFidelityBondFormSchema'
 import type { Step } from './types'
 import { generateLockdateOptions, getYearOptions, getMonthOptions } from './types'
 
@@ -30,16 +38,29 @@ export function useCreateFidelityBondWizard(
   const { enabled: isDeveloperMode } = useDeveloperMode()
 
   const [step, setStep] = useState<Step>('select_date')
-  const [selectedLockdate, setSelectedLockdate] = useState<fb.Lockdate | ''>('')
-  const [selectedJarIndex, setSelectedJarIndex] = useState<JarIndex | undefined>()
-  const [selectedUtxos, setSelectedUtxos] = useState<Utxo[]>([])
   const [frozenUtxos, setFrozenUtxos] = useState<Utxo[]>([])
   const [utxoPage, setUtxoPage] = useState(0)
-  const [confirmationChecked, setConfirmationChecked] = useState(false)
   const [txResult, setTxResult] = useState<DirectSendResponse | undefined>()
   const [error, setError] = useState<string | undefined>()
 
   const lockdateOptions = useMemo(() => generateLockdateOptions(isDeveloperMode), [isDeveloperMode])
+  const formSchema = useMemo(() => createFidelityBondFormSchema(lockdateOptions, t), [lockdateOptions, t])
+  const form = useForm<CreateFidelityBondFormValues, unknown, CreateFidelityBondFormValues>({
+    mode: 'onChange',
+    defaultValues: CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES,
+    resolver: yupResolver(formSchema as yup.AnyObjectSchema) as Resolver<
+      CreateFidelityBondFormValues,
+      unknown,
+      CreateFidelityBondFormValues
+    >,
+  })
+
+  const watchedLockdate = useWatch({ control: form.control, name: 'lockdate' })
+  const selectedLockdate = watchedLockdate ?? ''
+  const selectedJarIndex = useWatch({ control: form.control, name: 'jarIndex' })
+  const selectedUtxoIds = useWatch({ control: form.control, name: 'utxoIds' }) ?? []
+  const confirmationChecked = useWatch({ control: form.control, name: 'confirmationAccepted' }) ?? false
+
   const yearOptions = useMemo(() => getYearOptions(lockdateOptions), [lockdateOptions])
   const monthOptions = useMemo(() => getMonthOptions(), [])
 
@@ -54,6 +75,22 @@ export function useCreateFidelityBondWizard(
   const selectedMonth = selectedLockdate ? selectedLockdate.slice(5, 7) : ''
   const minYear = minLockdate ? Number.parseInt(minLockdate.slice(0, 4), 10) : 0
   const minMonth = minLockdate ? Number.parseInt(minLockdate.slice(5, 7), 10) : 1
+  const setSelectedLockdate = (lockdate: fb.Lockdate | '') => {
+    form.setValue('lockdate', lockdate || undefined, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
+  }
+  const setSelectedJarIndex = (jarIndex: JarIndex | undefined) => {
+    form.setValue('jarIndex', jarIndex, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
+  }
+  const setSelectedUtxoIds = (utxoIds: string[]) => {
+    form.setValue('utxoIds', utxoIds, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
+  }
+  const setConfirmationChecked = (checked: boolean) => {
+    form.setValue('confirmationAccepted', checked, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    })
+  }
 
   const existingFbLockdates = useMemo(() => {
     return walletInfo.fidelityBondSummary.fbOutputs
@@ -89,6 +126,14 @@ export function useCreateFidelityBondWizard(
         .toSorted((a, b) => b.value - a.value)
     )
   }, [selectedJar])
+
+  const selectedUtxos = useMemo(() => {
+    const availableUtxosById = new Map<string, Utxo>(availableUtxos.map((utxo) => [utxo.utxo, utxo]))
+    return selectedUtxoIds.flatMap((utxoId) => {
+      const utxo = availableUtxosById.get(utxoId)
+      return utxo === undefined ? [] : [utxo]
+    })
+  }, [availableUtxos, selectedUtxoIds])
 
   const utxosToFreeze = useMemo(() => {
     if (selectedJar === undefined) return []
@@ -145,12 +190,9 @@ export function useCreateFidelityBondWizard(
 
   const handleReset = () => {
     setStep('select_date')
-    setSelectedLockdate('')
-    setSelectedJarIndex(undefined)
-    setSelectedUtxos([])
+    form.reset(CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES)
     setFrozenUtxos([])
     setUtxoPage(0)
-    setConfirmationChecked(false)
     setTxResult(undefined)
     setError(undefined)
   }
@@ -171,10 +213,10 @@ export function useCreateFidelityBondWizard(
       case 'select_utxos':
         if (jarsWithUtxos.length === 1) {
           setSelectedJarIndex(undefined)
-          setSelectedUtxos([])
+          setSelectedUtxoIds([])
           setStep('select_date')
         } else {
-          setSelectedUtxos([])
+          setSelectedUtxoIds([])
           setStep('select_jar')
         }
         break
@@ -197,6 +239,7 @@ export function useCreateFidelityBondWizard(
     setError(undefined)
     switch (step) {
       case 'select_date':
+        if (!(await form.trigger('lockdate'))) return
         if (jarsWithUtxos.length === 1) {
           setSelectedJarIndex(jarsWithUtxos[0].jarIndex)
           setUtxoPage(0)
@@ -206,10 +249,12 @@ export function useCreateFidelityBondWizard(
         }
         break
       case 'select_jar':
+        if (!(await form.trigger('jarIndex'))) return
         setUtxoPage(0)
         setStep('select_utxos')
         break
       case 'select_utxos':
+        if (!(await form.trigger('utxoIds'))) return
         if (utxosToFreeze.length > 0) {
           setStep('freeze_utxos')
         } else {
@@ -220,6 +265,7 @@ export function useCreateFidelityBondWizard(
         await handleFreezeUtxos()
         break
       case 'review':
+        if (!(await form.trigger())) return
         await handleCreateFidelityBond()
         break
     }
@@ -318,17 +364,14 @@ export function useCreateFidelityBondWizard(
 
   const toggleUtxoSelection = (utxo: Utxo) => {
     // TODO: select/deselect all utxos to the same address
-    setSelectedUtxos((current) => {
-      const isSelected = current.some((u) => u.utxo === utxo.utxo)
-      if (isSelected) {
-        return current.filter((u) => u.utxo !== utxo.utxo)
-      }
-      return [...current, utxo]
-    })
+    const isSelected = selectedUtxoIds.includes(utxo.utxo)
+    setSelectedUtxoIds(
+      isSelected ? selectedUtxoIds.filter((utxoId) => utxoId !== utxo.utxo) : [...selectedUtxoIds, utxo.utxo],
+    )
   }
 
-  const selectAllUtxos = () => setSelectedUtxos([...availableUtxos])
-  const deselectAllUtxos = () => setSelectedUtxos([])
+  const selectAllUtxos = () => setSelectedUtxoIds(availableUtxos.map((utxo) => utxo.utxo))
+  const deselectAllUtxos = () => setSelectedUtxoIds([])
 
   const selectedDateLabel = selectedLockdate
     ? new Date(fb.lockdate.toTimestamp(selectedLockdate)).toLocaleDateString(undefined, {

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -61,7 +61,7 @@ export function useCreateFidelityBondWizard(
 
   const watchedLockdate = useWatch({ control: form.control, name: 'lockdate' })
   const selectedLockdate = watchedLockdate ?? ''
-  const selectedJarIndex = useWatch({ control: form.control, name: 'jarIndex' })
+  const selectedJarIndex = useWatch({ control: form.control, name: 'source.fromJar' })
   const selectedUtxoIds = useWatch({
     control: form.control,
     name: 'utxoIds',
@@ -91,7 +91,7 @@ export function useCreateFidelityBondWizard(
     form.setValue('lockdate', lockdate || undefined, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
   }
   const setSelectedJarIndex = (jarIndex: JarIndex | undefined) => {
-    form.setValue('jarIndex', jarIndex, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
+    form.setValue('source.fromJar', jarIndex, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
   }
   const setSelectedUtxoIds = (utxoIds: string[]) => {
     form.setValue('utxoIds', utxoIds, { shouldDirty: true, shouldTouch: true, shouldValidate: true })
@@ -261,7 +261,7 @@ export function useCreateFidelityBondWizard(
         }
         break
       case 'select_jar':
-        if (!(await form.trigger('jarIndex'))) return
+        if (!(await form.trigger('source.fromJar'))) return
         setUtxoPage(0)
         setStep('select_utxos')
         break

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -62,8 +62,16 @@ export function useCreateFidelityBondWizard(
   const watchedLockdate = useWatch({ control: form.control, name: 'lockdate' })
   const selectedLockdate = watchedLockdate ?? ''
   const selectedJarIndex = useWatch({ control: form.control, name: 'jarIndex' })
-  const selectedUtxoIds = useWatch({ control: form.control, name: 'utxoIds' }) ?? []
-  const confirmationChecked = useWatch({ control: form.control, name: 'confirmationAccepted' }) ?? false
+  const selectedUtxoIds = useWatch({
+    control: form.control,
+    name: 'utxoIds',
+    defaultValue: CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES.utxoIds,
+  })
+  const confirmationChecked = useWatch({
+    control: form.control,
+    name: 'confirmationAccepted',
+    defaultValue: CREATE_FIDELITY_BOND_FORM_DEFAULT_VALUES.confirmationAccepted,
+  })
 
   const yearOptions = useMemo(() => getYearOptions(lockdateOptions), [lockdateOptions])
   const monthOptions = useMemo(() => getMonthOptions(), [])

--- a/src/components/sweep/SweepDestinationInputs.tsx
+++ b/src/components/sweep/SweepDestinationInputs.tsx
@@ -1,49 +1,48 @@
+import type { FieldArrayWithId, UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { Field, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
+import type { SweepFormValues } from './SweepFormSchema'
 
 interface SweepDestinationInputsProps {
-  addresses: string[]
-  errors: Array<string | undefined>
-  touched: boolean[]
+  form: UseFormReturn<SweepFormValues, unknown, SweepFormValues>
+  fields: Array<FieldArrayWithId<SweepFormValues, 'destinations', 'id'>>
   disabled: boolean
-  onChange: (index: number, value: string) => void
-  onBlur: (index: number) => void
 }
 
-export const SweepDestinationInputs = ({
-  addresses,
-  errors,
-  touched,
-  disabled,
-  onChange,
-  onBlur,
-}: SweepDestinationInputsProps) => {
+export const SweepDestinationInputs = ({ form, fields, disabled }: SweepDestinationInputsProps) => {
   const { t } = useTranslation()
+  const {
+    formState: { errors, isSubmitted, touchedFields },
+    register,
+  } = form
 
   return (
     <div className="space-y-3">
-      {addresses.map((address, index) => (
-        <div key={index} className="space-y-1">
-          <Field data-invalid={touched[index] && errors[index] !== undefined}>
-            <FieldLabel htmlFor={`sweep-destination-${index}`}>
-              {t('scheduler.label_destination_input', { destination: index + 1 })}
-            </FieldLabel>
-            <Input
-              id={`sweep-destination-${index}`}
-              value={address}
-              onChange={(event) => onChange(index, event.currentTarget.value)}
-              onBlur={() => onBlur(index)}
-              className="font-mono"
-              placeholder={t('scheduler.placeholder_destination_input')}
-              disabled={disabled}
-              autoComplete="off"
-              spellCheck={false}
-            />
-          </Field>
-          {touched[index] && errors[index] && <div className="text-destructive text-xs">{errors[index]}</div>}
-        </div>
-      ))}
+      {fields.map((field, index) => {
+        const fieldError = errors.destinations?.[index]?.address?.message
+        const showFieldError = isSubmitted || touchedFields.destinations?.[index]?.address === true
+
+        return (
+          <div key={field.id} className="space-y-1">
+            <Field data-invalid={showFieldError && fieldError !== undefined}>
+              <FieldLabel htmlFor={`sweep-destination-${index}`}>
+                {t('scheduler.label_destination_input', { destination: index + 1 })}
+              </FieldLabel>
+              <Input
+                id={`sweep-destination-${index}`}
+                {...register(`destinations.${index}.address`)}
+                className="font-mono"
+                placeholder={t('scheduler.placeholder_destination_input')}
+                disabled={disabled}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </Field>
+            {showFieldError && fieldError && <div className="text-destructive text-xs">{fieldError}</div>}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/sweep/SweepFormSchema.test.ts
+++ b/src/components/sweep/SweepFormSchema.test.ts
@@ -9,6 +9,7 @@ import {
 } from './SweepFormSchema'
 
 const t = ((key: string) => key) as unknown as TFunction<'translation', undefined>
+const validRegtestAddress = 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx'
 
 const validate = async (values: SweepFormValues, addressSummary = {} as AddressSummary) => {
   return await sweepFormSchema(addressSummary, t).validate(values, { abortEarly: false })
@@ -22,9 +23,9 @@ describe('sweepFormSchema', () => {
   it('normalizes destination addresses', () => {
     expect(
       getSweepDestinationAddresses({
-        destinations: [{ address: '  1BoatSLRHtKNngkdXEeobR76b53LETtpyT  ' }],
+        destinations: [{ address: `  ${validRegtestAddress}  ` }],
       }),
-    ).toEqual(['1BoatSLRHtKNngkdXEeobR76b53LETtpyT'])
+    ).toEqual([validRegtestAddress])
   })
 
   it('rejects invalid addresses per destination field', async () => {
@@ -47,11 +48,9 @@ describe('sweepFormSchema', () => {
   })
 
   it('rejects duplicate destination addresses', async () => {
-    const validAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
-
     await expect(
       validate({
-        destinations: [{ address: validAddress }, { address: validAddress }],
+        destinations: [{ address: validRegtestAddress }, { address: validRegtestAddress }],
       }),
     ).rejects.toMatchObject({
       inner: [
@@ -68,7 +67,7 @@ describe('sweepFormSchema', () => {
   })
 
   it('rejects reused wallet addresses', async () => {
-    const usedAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+    const usedAddress = validRegtestAddress
     const addressSummary = {
       [usedAddress]: {
         used: true,

--- a/src/components/sweep/SweepFormSchema.test.ts
+++ b/src/components/sweep/SweepFormSchema.test.ts
@@ -1,0 +1,94 @@
+import type { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+import type { AddressSummary } from '@/context/JamWalletInfoContext'
+import {
+  buildSweepDestinationValues,
+  getSweepDestinationAddresses,
+  sweepFormSchema,
+  type SweepFormValues,
+} from './SweepFormSchema'
+
+const t = ((key: string) => key) as unknown as TFunction<'translation', undefined>
+
+const validate = async (values: SweepFormValues, addressSummary = {} as AddressSummary) => {
+  return await sweepFormSchema(addressSummary, t).validate(values, { abortEarly: false })
+}
+
+describe('sweepFormSchema', () => {
+  it('builds empty destination defaults', () => {
+    expect(buildSweepDestinationValues(3)).toEqual([{ address: '' }, { address: '' }, { address: '' }])
+  })
+
+  it('normalizes destination addresses', () => {
+    expect(
+      getSweepDestinationAddresses({
+        destinations: [{ address: '  1BoatSLRHtKNngkdXEeobR76b53LETtpyT  ' }],
+      }),
+    ).toEqual(['1BoatSLRHtKNngkdXEeobR76b53LETtpyT'])
+  })
+
+  it('rejects invalid addresses per destination field', async () => {
+    await expect(
+      validate({
+        destinations: [{ address: 'invalid-address' }, { address: '' }],
+      }),
+    ).rejects.toMatchObject({
+      inner: [
+        expect.objectContaining({
+          path: 'destinations[0].address',
+          message: 'scheduler.feedback_invalid_destination_address',
+        }),
+        expect.objectContaining({
+          path: 'destinations[1].address',
+          message: 'scheduler.feedback_invalid_destination_address',
+        }),
+      ],
+    })
+  })
+
+  it('rejects duplicate destination addresses', async () => {
+    const validAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+
+    await expect(
+      validate({
+        destinations: [{ address: validAddress }, { address: validAddress }],
+      }),
+    ).rejects.toMatchObject({
+      inner: [
+        expect.objectContaining({
+          path: 'destinations[0].address',
+          message: 'scheduler.feedback_reused_destination_address',
+        }),
+        expect.objectContaining({
+          path: 'destinations[1].address',
+          message: 'scheduler.feedback_reused_destination_address',
+        }),
+      ],
+    })
+  })
+
+  it('rejects reused wallet addresses', async () => {
+    const usedAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+    const addressSummary = {
+      [usedAddress]: {
+        used: true,
+      },
+    } as unknown as AddressSummary
+
+    await expect(
+      validate(
+        {
+          destinations: [{ address: usedAddress }],
+        },
+        addressSummary,
+      ),
+    ).rejects.toMatchObject({
+      inner: [
+        expect.objectContaining({
+          path: 'destinations[0].address',
+          message: 'scheduler.feedback_reused_destination_address',
+        }),
+      ],
+    })
+  })
+})

--- a/src/components/sweep/SweepFormSchema.ts
+++ b/src/components/sweep/SweepFormSchema.ts
@@ -1,0 +1,68 @@
+import type { TFunction } from 'i18next'
+import * as yup from 'yup'
+import type { AddressSummary } from '@/context/JamWalletInfoContext'
+import { buildDestinationErrors, normalizeDestinationAddresses } from './destinationValidation'
+
+export type SweepFormValues = {
+  destinations: Array<{
+    address: string
+  }>
+}
+
+export const buildSweepDestinationValues = (count: number): SweepFormValues['destinations'] =>
+  Array.from({ length: count }, () => ({ address: '' }))
+
+export const getSweepDestinationAddresses = (values: SweepFormValues): string[] =>
+  normalizeDestinationAddresses(values.destinations.map((destination) => destination.address))
+
+const getDestinationIndex = (path?: string): number | undefined => {
+  const match = path?.match(/^destinations\[(\d+)\]\.address$/)
+  if (!match) return undefined
+  return Number.parseInt(match[1], 10)
+}
+
+const getRootDestinations = (context: yup.TestContext): SweepFormValues['destinations'] | undefined => {
+  const rootValue = context.from?.at(-1)?.value as Partial<SweepFormValues> | undefined
+  return rootValue?.destinations
+}
+
+export const sweepFormSchema = (addressSummary: AddressSummary, t: TFunction<'translation', undefined>) => {
+  const invalidDestinationAddressMessage = t('scheduler.feedback_invalid_destination_address')
+
+  return yup
+    .object({
+      destinations: yup
+        .array()
+        .of(
+          yup
+            .object({
+              address: yup
+                .string()
+                .transform((_, originalValue: unknown) =>
+                  typeof originalValue === 'string' ? normalizeDestinationAddresses([originalValue])[0] : '',
+                )
+                .defined()
+                .test('valid-sweep-destination', invalidDestinationAddressMessage, function () {
+                  const destinations = getRootDestinations(this)
+                  const index = getDestinationIndex(this.path)
+
+                  if (!destinations || index === undefined) {
+                    return this.createError({ message: invalidDestinationAddressMessage })
+                  }
+
+                  const errors = buildDestinationErrors(
+                    destinations.map((destination) => destination.address),
+                    addressSummary,
+                    t,
+                  )
+                  const error = errors[index]
+
+                  return error === undefined || this.createError({ message: error })
+                }),
+            })
+            .required(),
+        )
+        .required(),
+    })
+    .required()
+}

--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -97,10 +97,11 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
   }, [allUtxos])
 
   const schema = useMemo(() => sweepFormSchema(walletInfo.addressSummary, t), [walletInfo.addressSummary, t])
+  const initialDestinations = useMemo(() => buildSweepDestinationValues(DESTINATION_ADDRESS_COUNT_PROD), [])
   const form = useForm<SweepFormValues, unknown, SweepFormValues>({
     mode: 'onChange',
     defaultValues: {
-      destinations: buildSweepDestinationValues(DESTINATION_ADDRESS_COUNT_PROD),
+      destinations: initialDestinations,
     },
     resolver: yupResolver(schema as yup.AnyObjectSchema) as Resolver<SweepFormValues, unknown, SweepFormValues>,
   })
@@ -111,7 +112,11 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
   })
   const { trigger } = form
 
-  const destinationValues = useWatch({ control: form.control, name: 'destinations' }) ?? []
+  const destinationValues = useWatch({
+    control: form.control,
+    name: 'destinations',
+    defaultValue: initialDestinations,
+  })
   const normalizedDestinationAddresses = useMemo(
     () => getSweepDestinationAddresses({ destinations: destinationValues }),
     [destinationValues],

--- a/src/components/sweep/SweepPage.tsx
+++ b/src/components/sweep/SweepPage.tsx
@@ -1,18 +1,26 @@
 import { useEffect, useMemo, useState } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
 import { runscheduleMutation, stopcoinjoinOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { getschedule, type ErrorMessage } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { HourglassIcon } from 'lucide-react'
+import { useFieldArray, useForm, useWatch, type Resolver } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import * as yup from 'yup'
 import { useStore } from 'zustand'
 import { DevBadge } from '@/components/dev/DevBadge'
 import { FeeLimitDialog } from '@/components/settings/FeeLimitDialog'
 import { SweepDestinationInputs } from '@/components/sweep/SweepDestinationInputs'
+import {
+  buildSweepDestinationValues,
+  getSweepDestinationAddresses,
+  sweepFormSchema,
+  type SweepFormValues,
+} from '@/components/sweep/SweepFormSchema'
 import { SweepPreconditionAlert } from '@/components/sweep/SweepPreconditionAlert'
 import { SweepScheduleProgress } from '@/components/sweep/SweepScheduleProgress'
 import { SweepStartConfirmDialog } from '@/components/sweep/SweepStartConfirmDialog'
-import { buildDestinationErrors, normalizeDestinationAddresses } from '@/components/sweep/destinationValidation'
 import { buildSweepPreconditionSummary } from '@/components/sweep/preconditions'
 import { isScheduleValue, type Schedule } from '@/components/sweep/scheduleUtils'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -55,9 +63,6 @@ const INSECURE_SCHEDULE_TUMBLER_OPTIONS = {
   waittime: 0,
 }
 
-const initialDestinationAddresses = (count: number) => Array.from({ length: count }, () => '')
-const initialTouchedValues = (count: number) => Array.from({ length: count }, () => false)
-
 const getNewTestingDestinationAddress = (addressSummary: AddressSummary): string => {
   const newAddressFromDefaultJar =
     Object.values(addressSummary).find((addressMeta) => addressMeta.status === 'new' && addressMeta.jarIndex === 0)
@@ -77,12 +82,6 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
 
   const [showFeeConfigDialog, setShowFeeConfigDialog] = useState(false)
   const [showScheduleConfirmDialog, setShowScheduleConfirmDialog] = useState(false)
-  const [destinationAddresses, setDestinationAddresses] = useState(() =>
-    initialDestinationAddresses(DESTINATION_ADDRESS_COUNT_PROD),
-  )
-  const [destinationTouched, setDestinationTouched] = useState(() =>
-    initialTouchedValues(DESTINATION_ADDRESS_COUNT_PROD),
-  )
   const [useInsecureTestingSettings, setUseInsecureTestingSettings] = useState(false)
   const [alertMessage, setAlertMessage] = useState<string>()
   const [localSchedule, setLocalSchedule] = useState<Schedule>()
@@ -97,16 +96,32 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
     return buildSweepPreconditionSummary(allUtxos)
   }, [allUtxos])
 
-  const destinationErrors = useMemo(() => {
-    return buildDestinationErrors(destinationAddresses, walletInfo.addressSummary, t)
-  }, [destinationAddresses, walletInfo.addressSummary, t])
+  const schema = useMemo(() => sweepFormSchema(walletInfo.addressSummary, t), [walletInfo.addressSummary, t])
+  const form = useForm<SweepFormValues, unknown, SweepFormValues>({
+    mode: 'onChange',
+    defaultValues: {
+      destinations: buildSweepDestinationValues(DESTINATION_ADDRESS_COUNT_PROD),
+    },
+    resolver: yupResolver(schema as yup.AnyObjectSchema) as Resolver<SweepFormValues, unknown, SweepFormValues>,
+  })
 
-  const normalizedDestinationAddresses = useMemo(() => {
-    return normalizeDestinationAddresses(destinationAddresses)
-  }, [destinationAddresses])
+  const { fields, replace } = useFieldArray({
+    control: form.control,
+    name: 'destinations',
+  })
+  const { trigger } = form
 
-  const hasDestinationErrors = destinationErrors.some((error) => error !== undefined)
+  const destinationValues = useWatch({ control: form.control, name: 'destinations' }) ?? []
+  const normalizedDestinationAddresses = useMemo(
+    () => getSweepDestinationAddresses({ destinations: destinationValues }),
+    [destinationValues],
+  )
+  const hasDestinationErrors = !form.formState.isValid
   const allDestinationAddressesPresent = normalizedDestinationAddresses.every((address) => address !== '')
+
+  useEffect(() => {
+    void trigger('destinations')
+  }, [trigger, schema])
 
   const getScheduleQuery = useQuery({
     queryKey: ['sweep-get-schedule', walletFileName],
@@ -236,60 +251,47 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
     hasDestinationErrors ||
     !allDestinationAddressesPresent
 
-  const touchAllDestinations = () => {
-    setDestinationTouched((current) => current.map(() => true))
-  }
-
   const onInsecureTestingToggleChange = (checked: boolean) => {
     setUseInsecureTestingSettings(checked)
 
     if (checked) {
-      setDestinationAddresses([getNewTestingDestinationAddress(walletInfo.addressSummary)])
-      setDestinationTouched(initialTouchedValues(DESTINATION_ADDRESS_COUNT_TEST))
+      replace([{ address: getNewTestingDestinationAddress(walletInfo.addressSummary) }])
+      void trigger('destinations')
       return
     }
 
-    setDestinationAddresses(initialDestinationAddresses(DESTINATION_ADDRESS_COUNT_PROD))
-    setDestinationTouched(initialTouchedValues(DESTINATION_ADDRESS_COUNT_PROD))
-  }
-
-  const updateDestinationAddress = (index: number, value: string) => {
-    setDestinationAddresses((current) =>
-      current.map((address, currentIndex) => (currentIndex === index ? value : address)),
-    )
-  }
-
-  const markDestinationTouched = (index: number) => {
-    setDestinationTouched((current) =>
-      current.map((touched, currentIndex) => (currentIndex === index ? true : touched)),
-    )
+    replace(buildSweepDestinationValues(DESTINATION_ADDRESS_COUNT_PROD))
+    void trigger('destinations')
   }
 
   const startSchedule = async () => {
-    touchAllDestinations()
-    if (isStartDisabled) {
+    if (isOperationDisabled || isWaitingSchedulerStart || isWaitingSchedulerStop) {
       return
     }
 
-    const body = {
-      destination_addresses: normalizeDestinationAddresses(destinationAddresses),
-      ...(showInsecureScheduleTestingToggle && useInsecureTestingSettings
-        ? { tumbler_options: INSECURE_SCHEDULE_TUMBLER_OPTIONS }
-        : {}),
-    }
+    await form.handleSubmit(async (values) => {
+      const body = {
+        destination_addresses: getSweepDestinationAddresses(values),
+        ...(showInsecureScheduleTestingToggle && useInsecureTestingSettings
+          ? { tumbler_options: INSECURE_SCHEDULE_TUMBLER_OPTIONS }
+          : {}),
+      }
 
-    await startScheduleMutationMutateAsync({
-      path: { walletname: walletFileName },
-      body,
-    })
+      await startScheduleMutationMutateAsync({
+        path: { walletname: walletFileName },
+        body,
+      })
+    })()
   }
 
-  const onOpenScheduleConfirm = () => {
-    touchAllDestinations()
-    if (isStartDisabled) {
+  const onOpenScheduleConfirm = async () => {
+    if (isOperationDisabled || isWaitingSchedulerStart || isWaitingSchedulerStop) {
       return
     }
-    setShowScheduleConfirmDialog(true)
+
+    await form.handleSubmit(() => {
+      setShowScheduleConfirmDialog(true)
+    })()
   }
 
   const stopSchedule = async () => {
@@ -399,19 +401,16 @@ export const SweepPage = ({ walletFileName }: SweepPageProps) => {
               )}
 
               <SweepDestinationInputs
-                addresses={destinationAddresses}
-                errors={destinationErrors}
-                touched={destinationTouched}
+                form={form}
+                fields={fields}
                 disabled={isOperationDisabled || isWaitingSchedulerStart || isWaitingSchedulerStop}
-                onChange={updateDestinationAddress}
-                onBlur={markDestinationTouched}
               />
 
               <p className="text-muted-foreground text-sm">{t('scheduler.description_fees')}</p>
 
               <Button
                 type="button"
-                onClick={onOpenScheduleConfirm}
+                onClick={() => void onOpenScheduleConfirm()}
                 disabled={isStartDisabled}
                 size="xxl"
                 className="w-full"


### PR DESCRIPTION
summary
migrate the sweep destination form to react-hook-form and yup
migrate the fidelity bond creation flow to react-hook-form and yup
kept the existing validation behaviour while removing manual form state


ping @theborakompanioni 