### PR TITLE
feat: implement wallet journey states and refactor MainWalletPage to MainWalletView

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -126,3 +126,17 @@ npm install && npm run dev
 - yup (GitHub): https://github.com/jquense/yup
 - react-hook-form (GitHub): https://github.com/react-hook-form/react-hook-form
 - react-query (GitHub): https://github.com/TanStack/query
+- zustand (GitHub): https://github.com/pmndrs/zustand
+
+## Simulating Wallet Journey States
+
+For manual verification of the UI flow, you can simulate different wallet journey states in the regtest environment:
+
+- **Idle State**: A funded wallet with no active processes and valid fee configuration.
+- **Empty State**: Use a freshly created wallet with no funds.
+- **Syncing State**: Trigger a wallet rescan from the Settings page. This will set the `rescanning` flag in the session.
+- **Fee Config Missing**: Temporarily rename or remove the `max_jupiter_fee_abs` and `max_jupiter_fee_rel` fields in your `joinmarket.cfg` policy section.
+- **Coinjoining State**: Start a collaborative send (CoinJoin) from the Send page.
+- **Making State**: Start the Yield Generator from the Earn page.
+
+You can verify the active state by inspecting the `data-journey-state` attribute on the main container in the browser's developer tools.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import {
 import { toast } from 'sonner'
 import { useStore } from 'zustand'
 import { LogsPage } from '@/components/LogsPage'
-import MainWalletPage from '@/components/MainWalletPage'
+import MainWalletView from '@/components/MainWalletView'
 import CreateWalletPage from '@/components/create/CreateWalletPage'
 import { EarnPage } from '@/components/earn/EarnPage'
 import ErrorPage from '@/components/error/ErrorPage'
@@ -210,7 +210,7 @@ function App() {
               </Layout>
             }
           >
-            <Route path={routes.home} element={<MainWalletPage walletFileName={walletFileName!} />} />
+            <Route path={routes.home} element={<MainWalletView walletFileName={walletFileName!} />} />
             <Route path={routes.receive} element={<ReceivePage walletFileName={walletFileName!} />} />
             <Route path={routes.send} element={<SendPage walletFileName={walletFileName!} />} />
             <Route path={routes.earn} element={<EarnPage walletFileName={walletFileName!} />} />

--- a/src/components/MainWalletView.test.tsx
+++ b/src/components/MainWalletView.test.tsx
@@ -1,13 +1,15 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
+import type { SessionResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import MainWalletView from './MainWalletView'
 import { useStore } from 'zustand'
 import { useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import type { BalanceSummary } from '@/lib/balanceSummary'
 
 vi.mock('zustand', async (importOriginal) => {
-  const actual = (await importOriginal()) as any
+  const actual = await importOriginal<typeof import('zustand')>()
   return {
     ...actual,
     useStore: vi.fn(),
@@ -69,6 +71,27 @@ vi.mock('@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query', () => ({
   lockwalletOptions: vi.fn(),
 }))
 
+const createWalletBalanceSummary = (calculatedTotalBalanceInSats: number): ReturnType<typeof useWalletBalanceSummary> => {
+  const walletBalanceSummary: BalanceSummary = {
+    calculatedTotalBalanceInSats,
+    calculatedAvailableBalanceInSats: calculatedTotalBalanceInSats,
+    calculatedFrozenOrLockedBalanceInSats: 0,
+  }
+  return { walletBalanceSummary, isLoading: false }
+}
+
+const createFeeConfigValidationResult = (maxFeesConfigMissing: boolean): ReturnType<typeof useFeeConfigValidation> => ({
+  feeConfigValues: {},
+  maxFeesConfigMissing,
+  refetchAll: vi.fn(() => Promise.resolve([])),
+  fetchMissing: vi.fn(() => Promise.resolve([])),
+  isLoading: false,
+})
+
+const setSession = (session?: SessionResponse) => {
+  vi.mocked(useStore).mockReturnValue(session)
+}
+
 describe('MainWalletView', () => {
   const setup = () => {
     return render(
@@ -78,67 +101,59 @@ describe('MainWalletView', () => {
     )
   }
 
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should have data-journey-state="syncing" when rescanning', () => {
-    vi.mocked(useStore).mockReturnValue({ rescanning: true })
-    vi.mocked(useWalletBalanceSummary).mockReturnValue({
-      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
-    } as any)
-    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+    setSession({ rescanning: true } as SessionResponse)
+    vi.mocked(useWalletBalanceSummary).mockReturnValue(createWalletBalanceSummary(1000))
+    vi.mocked(useFeeConfigValidation).mockReturnValue(createFeeConfigValidationResult(false))
 
     setup()
     expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'syncing')
   })
 
   it('should have data-journey-state="empty" when balance is 0', () => {
-    vi.mocked(useStore).mockReturnValue({ rescanning: false })
-    vi.mocked(useWalletBalanceSummary).mockReturnValue({
-      walletBalanceSummary: { calculatedTotalBalanceInSats: 0 },
-    } as any)
-    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+    setSession({ rescanning: false } as SessionResponse)
+    vi.mocked(useWalletBalanceSummary).mockReturnValue(createWalletBalanceSummary(0))
+    vi.mocked(useFeeConfigValidation).mockReturnValue(createFeeConfigValidationResult(false))
 
     setup()
     expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'empty')
   })
 
   it('should have data-journey-state="fee-config-missing" when fee config is missing', () => {
-    vi.mocked(useStore).mockReturnValue({ rescanning: false })
-    vi.mocked(useWalletBalanceSummary).mockReturnValue({
-      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
-    } as any)
-    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: true } as any)
+    setSession({ rescanning: false } as SessionResponse)
+    vi.mocked(useWalletBalanceSummary).mockReturnValue(createWalletBalanceSummary(1000))
+    vi.mocked(useFeeConfigValidation).mockReturnValue(createFeeConfigValidationResult(true))
 
     setup()
     expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'fee-config-missing')
   })
 
   it('should have data-journey-state="coinjoining" when coinjoin is active', () => {
-    vi.mocked(useStore).mockReturnValue({ rescanning: false, coinjoin_in_process: true })
-    vi.mocked(useWalletBalanceSummary).mockReturnValue({
-      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
-    } as any)
-    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+    setSession({ rescanning: false, coinjoin_in_process: true } as SessionResponse)
+    vi.mocked(useWalletBalanceSummary).mockReturnValue(createWalletBalanceSummary(1000))
+    vi.mocked(useFeeConfigValidation).mockReturnValue(createFeeConfigValidationResult(false))
 
     setup()
     expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'coinjoining')
   })
 
   it('should have data-journey-state="making" when maker is running', () => {
-    vi.mocked(useStore).mockReturnValue({ rescanning: false, maker_running: true })
-    vi.mocked(useWalletBalanceSummary).mockReturnValue({
-      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
-    } as any)
-    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+    setSession({ rescanning: false, maker_running: true } as SessionResponse)
+    vi.mocked(useWalletBalanceSummary).mockReturnValue(createWalletBalanceSummary(1000))
+    vi.mocked(useFeeConfigValidation).mockReturnValue(createFeeConfigValidationResult(false))
 
     setup()
     expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'making')
   })
 
   it('should have data-journey-state="idle" by default', () => {
-    vi.mocked(useStore).mockReturnValue({ rescanning: false })
-    vi.mocked(useWalletBalanceSummary).mockReturnValue({
-      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
-    } as any)
-    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+    setSession({ rescanning: false } as SessionResponse)
+    vi.mocked(useWalletBalanceSummary).mockReturnValue(createWalletBalanceSummary(1000))
+    vi.mocked(useFeeConfigValidation).mockReturnValue(createFeeConfigValidationResult(false))
 
     setup()
     expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'idle')

--- a/src/components/MainWalletView.test.tsx
+++ b/src/components/MainWalletView.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import MainWalletView from './MainWalletView'
+import { useStore } from 'zustand'
+import { useWalletBalanceSummary } from '@/context/JamWalletInfoContext'
+import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+
+vi.mock('zustand', async (importOriginal) => {
+  const actual = (await importOriginal()) as any
+  return {
+    ...actual,
+    useStore: vi.fn(),
+  }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock('@/context/JamDisplayContext', () => ({
+  useJamDisplayContext: () => ({
+    toggleDisplayMode: vi.fn(),
+  }),
+}))
+
+vi.mock('@/context/JamWalletInfoContext', () => ({
+  useJamWalletInfoContext: () => ({
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useWalletBalanceSummary: vi.fn(),
+  useJars: () => ({
+    jars: [],
+  }),
+}))
+
+vi.mock('@/hooks/useFeeConfigValidation', () => ({
+  useFeeConfigValidation: vi.fn(),
+}))
+
+vi.mock('@joinmarket-webui/joinmarket-api-ts', () => ({
+  createClient: vi.fn(() => ({
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+      error: { use: vi.fn() },
+    },
+  })),
+}))
+
+vi.mock('@joinmarket-webui/joinmarket-api-ts/jm', () => ({
+  token: vi.fn(),
+}))
+
+vi.mock('@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query', () => ({
+  lockwalletOptions: vi.fn(),
+}))
+
+describe('MainWalletView', () => {
+  const setup = () => {
+    return render(
+      <MemoryRouter>
+        <MainWalletView walletFileName="test.jmdat" />
+      </MemoryRouter>
+    )
+  }
+
+  it('should have data-journey-state="syncing" when rescanning', () => {
+    vi.mocked(useStore).mockReturnValue({ rescanning: true })
+    vi.mocked(useWalletBalanceSummary).mockReturnValue({
+      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
+    } as any)
+    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+
+    setup()
+    expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'syncing')
+  })
+
+  it('should have data-journey-state="empty" when balance is 0', () => {
+    vi.mocked(useStore).mockReturnValue({ rescanning: false })
+    vi.mocked(useWalletBalanceSummary).mockReturnValue({
+      walletBalanceSummary: { calculatedTotalBalanceInSats: 0 },
+    } as any)
+    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+
+    setup()
+    expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'empty')
+  })
+
+  it('should have data-journey-state="fee-config-missing" when fee config is missing', () => {
+    vi.mocked(useStore).mockReturnValue({ rescanning: false })
+    vi.mocked(useWalletBalanceSummary).mockReturnValue({
+      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
+    } as any)
+    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: true } as any)
+
+    setup()
+    expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'fee-config-missing')
+  })
+
+  it('should have data-journey-state="coinjoining" when coinjoin is active', () => {
+    vi.mocked(useStore).mockReturnValue({ rescanning: false, coinjoin_in_process: true })
+    vi.mocked(useWalletBalanceSummary).mockReturnValue({
+      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
+    } as any)
+    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+
+    setup()
+    expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'coinjoining')
+  })
+
+  it('should have data-journey-state="making" when maker is running', () => {
+    vi.mocked(useStore).mockReturnValue({ rescanning: false, maker_running: true })
+    vi.mocked(useWalletBalanceSummary).mockReturnValue({
+      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
+    } as any)
+    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+
+    setup()
+    expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'making')
+  })
+
+  it('should have data-journey-state="idle" by default', () => {
+    vi.mocked(useStore).mockReturnValue({ rescanning: false })
+    vi.mocked(useWalletBalanceSummary).mockReturnValue({
+      walletBalanceSummary: { calculatedTotalBalanceInSats: 1000 },
+    } as any)
+    vi.mocked(useFeeConfigValidation).mockReturnValue({ maxFeesConfigMissing: false } as any)
+
+    setup()
+    expect(screen.getByTestId('main-wallet-view')).toHaveAttribute('data-journey-state', 'idle')
+  })
+})

--- a/src/components/MainWalletView.tsx
+++ b/src/components/MainWalletView.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { DownloadIcon, InfoIcon, RefreshCwIcon, UploadIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { useStore } from 'zustand'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { ClickableJar } from '@/components/ui/jam/ClickableJar'
@@ -16,15 +17,17 @@ import {
 } from '@/context/JamWalletInfoContext'
 import type { WalletFileName } from '@/lib/utils'
 import { cn, shortenStringMiddle, walletDisplayName } from '@/lib/utils'
+import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
+import { jmSessionStore } from '@/store/jmSessionStore'
 import { Balance } from './ui/jam/Balance'
 import { Spinner } from './ui/spinner'
 import { WalletJarsDetailsOverlay } from './wallet/WalletJarsDetailsOverlay'
 
-interface MainWalletPageProps {
+interface MainWalletViewProps {
   walletFileName: WalletFileName
 }
 
-export default function MainWalletPage({ walletFileName }: MainWalletPageProps) {
+export default function MainWalletView({ walletFileName }: MainWalletViewProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [selectedJar, setSelectedJar] = useState<JarObject>()
@@ -34,6 +37,18 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
   const { isLoading, isFetching, error, refetch: refetchWalletData } = useJamWalletInfoContext()
   const { walletBalanceSummary } = useWalletBalanceSummary()
   const { jars } = useJars()
+
+  const jmSession = useStore(jmSessionStore, (state) => state.state)
+  const { maxFeesConfigMissing } = useFeeConfigValidation({ walletFileName })
+
+  const journeyState = useMemo(() => {
+    if (jmSession?.rescanning) return 'syncing'
+    if (walletBalanceSummary.calculatedTotalBalanceInSats === 0) return 'empty'
+    if (maxFeesConfigMissing) return 'fee-config-missing'
+    if (jmSession?.coinjoin_in_process || (jmSession?.schedule?.length || 0) > 0) return 'coinjoining'
+    if (jmSession?.maker_running) return 'making'
+    return 'idle'
+  }, [jmSession, walletBalanceSummary, maxFeesConfigMissing])
 
   const walletName = walletDisplayName(walletFileName)
   const walletNameTitle = shortenStringMiddle(walletName, 32)
@@ -54,7 +69,11 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
         walletFileName={walletFileName}
         selectedJarIndex={selectedJar?.jarIndex}
       />
-      <div className="flex flex-col items-center justify-center gap-8 px-4 py-12">
+      <div
+        className="flex flex-col items-center justify-center gap-8 px-4 py-12"
+        data-journey-state={journeyState}
+        data-testid="main-wallet-view"
+      >
         <div className="flex w-full max-w-xl flex-col items-center justify-center gap-2">
           <p className="text-muted-foreground hover:text-foreground text-xl select-all" title={walletName}>
             {walletNameTitle}

--- a/src/components/earn/report/EarnReportContent.tsx
+++ b/src/components/earn/report/EarnReportContent.tsx
@@ -121,6 +121,7 @@ export const EarnReportContent = ({ className, enabled }: EarnReportContentProps
     [t],
   )
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable<EarnReportEntry>({
     data: allEntries,
     columns,

--- a/src/components/orderbook/OrderbookTable.tsx
+++ b/src/components/orderbook/OrderbookTable.tsx
@@ -231,6 +231,7 @@ export const OrderbookTable = ({
     bottom: [],
   })
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable<OrderTableEntry>({
     data: tableEntries,
     columns,

--- a/src/components/wallet/BranchEntryTable.tsx
+++ b/src/components/wallet/BranchEntryTable.tsx
@@ -164,6 +164,7 @@ export const BranchEntryTable = ({
     bottom: [],
   })
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable<BranchEntryTableRow>({
     data: tableEntries,
     columns,

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -294,6 +294,7 @@ export const JarUtxosTable = ({
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>(initialRowSelection ?? {})
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable<UtxoTableEntry>({
     data: tableEntries,
     columns,


### PR DESCRIPTION
## What does this PR do?

This PR implements the "Wallet Journey States" logic as part of the competency test requirements. It introduces a `data-journey-state` attribute to the main wallet view to reflect the current status of the wallet and its active services.

### Key Changes:
- **Refactoring**: Renamed `MainWalletPage` to `MainWalletView` to better align with the project's component naming conventions and updated all corresponding routes in `App.tsx`.
- **Journey State Logic**: Implemented logic in `MainWalletView` to derive a `data-journey-state` attribute. Supported states:
  - `idle`: Default state for a funded wallet.
  - `empty`: Wallet has zero balance.
  - `syncing`: Wallet is currently rescanning the blockchain.
  - `fee-config-missing`: Required policy fee configurations are missing from `joinmarket.cfg`.
  - `coinjoining`: A collaborative send (CoinJoin) is in process.
  - `making`: The Yield Generator (Maker) service is running.
- **Testing**: Added a comprehensive React Testing Library (RTL) suite in `MainWalletView.test.tsx` with mocks for `zustand` and `joinmarket-api-ts` to assert correct attribute values under all scenarios.
- **Documentation**: Updated `docs/developing.md` with a new "Simulating Wallet Journey States" section to help other contributors manually verify these flows in regtest.

## Visual Demo

This change adds an internal metadata attribute to the DOM to facilitate state-dependent UI logic and automated testing.

### Verification (DOM Inspection):
You can verify the active state by inspecting the main container in the browser developer tools:
```html
<div data-journey-state="coinjoining" data-testid="main-wallet-view" ...>
```

### Automated Tests:
All tests in the new suite pass successfully:
```bash
 ✓ |unit| src/components/MainWalletView.test.tsx (6 tests)
   ✓ MainWalletView (6)
     ✓ should have data-journey-state="syncing" when rescanning
     ✓ should have data-journey-state="empty" when balance is 0
     ...
```

--- 
