### PR TITLE
chore: reload utxos after blockheight change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ import { EarnReportPage } from './components/earn/report/EarnReportPage'
 import { LockWalletConfirmDialog } from './components/ui/jam/LockWalletConfirmDialog'
 import { Spinner } from './components/ui/spinner'
 import { WalletJarsDetailsPage } from './components/wallet/WalletJarsDetailsPage'
-import { useRescanStatus } from './context/JamSessionInfoContext'
+import { useJamSessionInfoContext, useRescanStatus } from './context/JamSessionInfoContext'
 import { JamSessionInfoContextProvider } from './context/JamSessionInfoContextProvider'
 import { useJamWalletInfoContext } from './context/JamWalletInfoContext'
 import { useJmWebsocket } from './hooks/useJmWebsocket'
@@ -429,6 +429,7 @@ function LoadFeeConfigData({ walletFileName }: { walletFileName: WalletFileName 
 const RELOAD_WALLET_INFO_DELAY: {
   AFTER_RESCAN: Milliseconds
   AFTER_UTXO_CHANGE: Milliseconds
+  AFTER_BLOCK_HEIGHT_CHANGE: Milliseconds
 } = {
   // After rescanning, it is necessary to give the JM backend some time to synchronize.
   // A couple of seconds should be enough, however, this depends on the user hardware
@@ -440,6 +441,9 @@ const RELOAD_WALLET_INFO_DELAY: {
 
   // Small delay is sufficient after utxo change (e.g. normal unlock of wallet)
   AFTER_UTXO_CHANGE: 210,
+
+  // Small delay is sufficient after block height change
+  AFTER_BLOCK_HEIGHT_CHANGE: 210,
 }
 
 /**
@@ -453,15 +457,17 @@ const RELOAD_WALLET_INFO_DELAY: {
  */
 const WalletInfoAutoReload = () => {
   const { rescanInfo: currentRescanInfo } = useRescanStatus()
-  const previousRescanning = useRef<boolean>(currentRescanInfo.rescanning)
+  const previousRescanningRef = useRef<boolean>(currentRescanInfo.rescanning)
+  const { blockHeight: currentBlockHeight } = useJamSessionInfoContext()
+  const previousBlockHeightRef = useRef<number | undefined>(currentBlockHeight)
 
   const { refetch: refetchWalletBalance, utxosHashHex } = useJamWalletInfoContext()
 
   useEffect(
     function refetchWalletInfoAfterRescanFinished() {
-      const wasRescanning = previousRescanning.current
+      const wasRescanning = previousRescanningRef.current
       const isRescanning = currentRescanInfo.rescanning
-      previousRescanning.current = isRescanning
+      previousRescanningRef.current = isRescanning
 
       const rescanFinished = wasRescanning === true && isRescanning === false
       if (!rescanFinished) {
@@ -474,11 +480,36 @@ const WalletInfoAutoReload = () => {
 
       const abortCtrl = new AbortController()
       refetchWalletBalance({ delayBefore, signal: abortCtrl.signal }).catch((error: unknown) => {
-        console.warn('Error while auto-reloading wallet info after rescanning finished', error)
+        console.warn('Error while auto-reloading wallet info AFTER_RESCAN finished', error)
       })
       return () => abortCtrl.abort('useEffect(AFTER_RESCAN) ended')
     },
     [refetchWalletBalance, currentRescanInfo.rescanning],
+  )
+
+  useEffect(
+    function refetchWalletInfoAfterBlockHeightIncrease() {
+      if (currentBlockHeight === undefined) return
+
+      const blockHeightIncreased =
+        previousBlockHeightRef.current !== undefined && previousBlockHeightRef.current !== currentBlockHeight
+      previousBlockHeightRef.current = currentBlockHeight
+
+      if (!blockHeightIncreased) {
+        console.debug('Abort refetching: Block height did not increase.')
+        return
+      }
+
+      const delayBefore: Milliseconds = RELOAD_WALLET_INFO_DELAY.AFTER_BLOCK_HEIGHT_CHANGE
+      console.debug('Trigger refetch looking for funds AFTER_BLOCK_HEIGHT_CHANGE with delay %d...', delayBefore)
+
+      const abortCtrl = new AbortController()
+      refetchWalletBalance({ delayBefore, signal: abortCtrl.signal }).catch((error: unknown) => {
+        console.warn('Error while auto-reloading wallet info AFTER_BLOCK_HEIGHT_CHANGE finished', error)
+      })
+      return () => abortCtrl.abort('useEffect(AFTER_BLOCK_HEIGHT_CHANGE) ended')
+    },
+    [refetchWalletBalance, currentBlockHeight],
   )
 
   useEffect(
@@ -492,7 +523,7 @@ const WalletInfoAutoReload = () => {
 
       const abortCtrl = new AbortController()
       refetchWalletBalance({ delayBefore, signal: abortCtrl.signal }).catch((error: unknown) => {
-        console.error('Error while auto-reloading wallet info after utxo change finished', error)
+        console.error('Error while auto-reloading wallet info AFTER_UTXO_CHANGE finished', error)
       })
       return () => abortCtrl.abort('useEffect(AFTER_UTXO_CHANGE) ended')
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -491,16 +491,16 @@ const WalletInfoAutoReload = () => {
     function refetchWalletInfoAfterBlockHeightIncrease() {
       if (currentBlockHeight === undefined) return
 
-      const blockHeightIncreased =
+      const blockHeightChanged =
         previousBlockHeightRef.current !== undefined && previousBlockHeightRef.current !== currentBlockHeight
       previousBlockHeightRef.current = currentBlockHeight
 
-      if (!blockHeightIncreased) {
-        console.debug('Abort refetching: Block height did not increase.')
+      if (!blockHeightChanged) {
+        console.debug('Abort refetching: Block height did not change.')
         return
       }
 
-      const delayBefore: Milliseconds = RELOAD_WALLET_INFO_DELAY.AFTER_BLOCK_HEIGHT_CHANGE
+      const delayBefore = RELOAD_WALLET_INFO_DELAY.AFTER_BLOCK_HEIGHT_CHANGE
       console.debug('Trigger refetch looking for funds AFTER_BLOCK_HEIGHT_CHANGE with delay %d...', delayBefore)
 
       const abortCtrl = new AbortController()

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -39,6 +39,7 @@ import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
 import { jmTxStore, type JmTxInfo } from '@/store/jmTxStore'
+import type { JarIndex } from '@/types/global'
 import { Button } from '../ui/button'
 import { Card, CardContent } from '../ui/card'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
@@ -81,6 +82,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
   const [paymentSuccessfulInfoAlert, setPaymentSuccessfulInfoAlert] = useState<SimpleAlert>()
   const [minimumCollaborators, setMinimumCollaborators] = useState<number>()
   const [collaborativeFlowError, setCollaborativeFlowError] = useState<string>()
+  const [sourceJarIndex, setSourceJarIndex] = useState<JarIndex>()
   // TODO: "Lifecycle" or state management should be handled outside of this component
   const collaborativeLifecycleRef = useRef({
     awaitingCompletion: false,
@@ -108,17 +110,16 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
     refetchWalletInfoRef.current = refetchWalletInfo
   }, [refetchWalletInfo])
 
-  const utxoSelectionDialog = useUtxoSelectionDialog({
-    walletFileName,
-    jars,
-    addressSummary,
-  })
-
   const sourceJar = useMemo(() => {
-    const sourceJarIndex = sendFromValuesAwaitingConfirmation?.source?.fromJar
     if (sourceJarIndex === undefined) return
     return jars.find((it) => it.jarIndex === sourceJarIndex)
-  }, [jars, sendFromValuesAwaitingConfirmation])
+  }, [jars, sourceJarIndex])
+
+  const utxoSelectionDialog = useUtxoSelectionDialog({
+    walletFileName,
+    sourceJar,
+    addressSummary,
+  })
 
   const availableUtxosForPayment = useMemo(() => {
     return (sourceJar?.utxos || []).filter((utxo) => !utxo.frozen).toSorted((a, b) => a.confirmations - b.confirmations)
@@ -594,7 +595,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
                 waitForUtxosToBeSpent.length > 0
               }
               debug={isDeveloperMode}
-              onSourceJarChange={utxoSelectionDialog.setSourceJarIndex}
+              onSourceJarChange={setSourceJarIndex}
               sourceJarLabelButton={
                 <Button
                   type="button"

--- a/src/components/send/SendPage.tsx
+++ b/src/components/send/SendPage.tsx
@@ -590,7 +590,7 @@ export const SendPage = ({ walletFileName }: SendPageProps) => {
                 jmSession?.maker_running ||
                 collaborativeFlowActive ||
                 jmSession?.rescanning ||
-                utxoSelectionDialog.isApplying ||
+                utxoSelectionDialog.isSubmitting ||
                 triggerNonCollaborativeTransaction.isPending ||
                 waitForUtxosToBeSpent.length > 0
               }

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -1,24 +1,23 @@
-import type { OnChangeFn, Row, RowSelectionState } from '@tanstack/react-table'
+import type { ComponentProps } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Spinner } from '../ui/spinner'
-import { JarUtxosTable, type UtxoTableEntry } from '../wallet/JarUtxosTable'
+import { JarUtxosTable } from '../wallet/JarUtxosTable'
 
-export interface UtxoSelectionDialogProps {
+export type UtxoSelectionDialogProps = {
   open: boolean
   isSubmitting: boolean
   selectedCount: number
   filter: string
-  tableEntries: UtxoTableEntry[]
-  initialRowSelection: RowSelectionState
-  enableRowSelection?: boolean | ((row: Row<UtxoTableEntry>) => boolean)
   onOpenChange: (open: boolean) => void
   onFilterChange: (value: string) => void
-  onRowSelectionChange: OnChangeFn<RowSelectionState>
   onSubmit: () => Promise<void>
-}
+} & Pick<
+  ComponentProps<typeof JarUtxosTable>,
+  'tableEntries' | 'initialRowSelection' | 'enableRowSelection' | 'onRowSelectionChange'
+>
 
 export const UtxoSelectionDialog = ({
   open,

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -13,7 +13,7 @@ export interface UtxoSelectionDialogProps {
   filter: string
   tableEntries: UtxoTableEntry[]
   initialRowSelection: RowSelectionState
-  enableRowSelection: boolean | ((row: Row<UtxoTableEntry>) => boolean)
+  enableRowSelection?: boolean | ((row: Row<UtxoTableEntry>) => boolean)
   onOpenChange: (open: boolean) => void
   onFilterChange: (value: string) => void
   onRowSelectionChange: OnChangeFn<RowSelectionState>

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -8,7 +8,7 @@ import { JarUtxosTable, type UtxoTableEntry } from '../wallet/JarUtxosTable'
 
 export interface UtxoSelectionDialogProps {
   open: boolean
-  isApplying: boolean
+  isSubmitting: boolean
   selectedCount: number
   filter: string
   tableEntries: UtxoTableEntry[]
@@ -17,12 +17,12 @@ export interface UtxoSelectionDialogProps {
   onOpenChange: (open: boolean) => void
   onFilterChange: (value: string) => void
   onRowSelectionChange: OnChangeFn<RowSelectionState>
-  onApply: () => void
+  onSubmit: () => Promise<void>
 }
 
 export const UtxoSelectionDialog = ({
   open,
-  isApplying,
+  isSubmitting,
   selectedCount,
   filter,
   tableEntries,
@@ -31,7 +31,7 @@ export const UtxoSelectionDialog = ({
   onOpenChange,
   onFilterChange,
   onRowSelectionChange,
-  onApply,
+  onSubmit,
 }: UtxoSelectionDialogProps) => {
   const { t } = useTranslation()
 
@@ -49,6 +49,7 @@ export const UtxoSelectionDialog = ({
           value={filter}
           onChange={(event) => onFilterChange(event.target.value)}
           placeholder={t('jar_details.utxo_list.placeholder_search')}
+          disabled={isSubmitting}
         />
         <div className="max-h-[55vh] overflow-hidden">
           <JarUtxosTable
@@ -62,11 +63,11 @@ export const UtxoSelectionDialog = ({
         </div>
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isApplying}>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
             {t('modal.confirm_button_reject')}
           </Button>
-          <Button type="button" onClick={onApply} disabled={isApplying}>
-            {isApplying ? <Spinner /> : undefined}
+          <Button type="button" onClick={() => void onSubmit()} disabled={isSubmitting}>
+            {isSubmitting ? <Spinner /> : undefined}
             {t('modal.confirm_button_accept')}
           </Button>
         </DialogFooter>

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -102,12 +102,13 @@ const UtxoTableRow = ({ row }: { row: Row<UtxoTableEntry> }) => {
 const AUTO_CHANGE_SELECTION_TOAST_ID = 'utxo.selection_changed_automatically'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
+const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
   return [
     {
       id: 'select-col',
       header: ({ table }: HeaderContext<UtxoTableEntry, unknown>) => (
         <Checkbox
+          disabled={enableSelectAllToggle === false}
           checked={table.getIsAllRowsSelected() ? true : table.getIsSomeRowsSelected() ? 'indeterminate' : false}
           onCheckedChange={(checked) => {
             table.toggleAllRowsSelected(checked === true)
@@ -260,7 +261,7 @@ interface JarUtxosTableProps {
   tableEntries: UtxoTableEntry[]
   pinnedEntries: UtxoTableEntry[]
   initialRowSelection?: RowSelectionState
-  enableRowSelection?: boolean | ((row: Row<UtxoTableEntry>) => boolean)
+  enableRowSelection?: RowSelectionOptions<UtxoTableEntry>['enableRowSelection']
   onChange?: (table: TableType<UtxoTableEntry>) => void
   onRowSelectionChange?: OnChangeFn<RowSelectionState>
 }
@@ -279,8 +280,12 @@ export const JarUtxosTable = ({
   const [sorting, setSorting] = useState<SortingState>([])
   const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: ITEMS_PER_PAGE })
   const [isShowAll, setIsShowAll] = useState(false)
+  const enableSelectAllToggle = useMemo(
+    () => enableRowSelection !== undefined && enableRowSelection !== false,
+    [enableRowSelection],
+  )
 
-  const columns = useMemo(() => utxoTableColumns(t), [t])
+  const columns = useMemo(() => utxoTableColumns(enableSelectAllToggle, t), [enableSelectAllToggle, t])
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     minerFeeContribution: false,

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -332,12 +332,6 @@ export const JarUtxosTable = ({
   }, [table, pinnedEntries])
 
   useEffect(() => {
-    if (!initialRowSelection) return
-    setRowSelection(initialRowSelection)
-    onRowSelectionChange?.(initialRowSelection)
-  }, [initialRowSelection, onRowSelectionChange])
-
-  useEffect(() => {
     if (isShowAll) {
       table.setPageSize(tableEntries.length || 1)
     }

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -22,6 +22,7 @@ import {
   type OnChangeFn,
   type HeaderContext,
   type CellContext,
+  type RowSelectionOptions,
 } from '@tanstack/react-table'
 import type { TFunction } from 'i18next'
 import { ChevronDownIcon, SnowflakeIcon } from 'lucide-react'
@@ -30,6 +31,7 @@ import { toast } from 'sonner'
 import { TablePagination } from '@/components/ui/jam/TablePagination'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import type { Utxo } from '@/hooks/useQueryUtxos'
+import * as fb from '@/lib/fidelityBondUtils'
 import type { UtxoTag } from '@/lib/tags'
 import { cn } from '@/lib/utils'
 import { Button } from '../ui/button'
@@ -249,6 +251,10 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
   ]
 }
 
+const defaultRowSelection: RowSelectionOptions<UtxoTableEntry>['enableRowSelection'] = (row: Row<UtxoTableEntry>) => {
+  return !fb.utxo.isFidelityBond(row.original.utxo)
+}
+
 interface JarUtxosTableProps {
   globalFilter?: string
   tableEntries: UtxoTableEntry[]
@@ -264,7 +270,7 @@ export const JarUtxosTable = ({
   tableEntries,
   pinnedEntries,
   initialRowSelection,
-  enableRowSelection,
+  enableRowSelection = defaultRowSelection,
   onChange,
   onRowSelectionChange,
 }: JarUtxosTableProps) => {
@@ -302,7 +308,7 @@ export const JarUtxosTable = ({
     },
     globalFilterFn: 'fuzzy' as FilterFnOption<UtxoTableEntry>,
     keepPinnedRows: true,
-    enableRowSelection: enableRowSelection ?? true,
+    enableRowSelection,
     enableMultiRowSelection: true,
     autoResetPageIndex: true,
     getRowId: (row) => row.utxo.utxo,

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -189,21 +189,6 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
         numeric: true,
       },
     }),
-    columnHelper.accessor<'utxo.address', UtxoTableEntry['utxo']['address']>('utxo.address', {
-      header: () => <div className="flex items-center">{t('jar_details.utxo_list.column_title_address')}</div>,
-      sortingFn: (a, b) => {
-        const val = a.original.utxo.address.localeCompare(b.original.utxo.address)
-        if (val !== 0) return val
-        // tie-break using confirmations
-        const aid = Number(a.original.utxo.confirmations)
-        const bid = Number(b.original.utxo.confirmations)
-        return aid - bid
-      },
-      cell: (info) => <Address value={info.getValue()} className="text-sm" copyable={true} />,
-      meta: {
-        alphabetic: true,
-      },
-    }),
     columnHelper.accessor('utxo.confirmations', {
       header: () => t('jar_details.utxo_list.column_title_confirmations'),
       cell: (info) => <>{info.getValue()}</>,
@@ -229,6 +214,21 @@ const utxoTableColumns = (t: TFunction): ColumnDef<UtxoTableEntry, any>[] => {
         </div>
       ),
       enableSorting: false,
+    }),
+    columnHelper.accessor<'utxo.address', UtxoTableEntry['utxo']['address']>('utxo.address', {
+      header: () => <div className="flex items-center">{t('jar_details.utxo_list.column_title_address')}</div>,
+      sortingFn: (a, b) => {
+        const val = a.original.utxo.address.localeCompare(b.original.utxo.address)
+        if (val !== 0) return val
+        // tie-break using confirmations
+        const aid = Number(a.original.utxo.confirmations)
+        const bid = Number(b.original.utxo.confirmations)
+        return aid - bid
+      },
+      cell: (info) => <Address value={info.getValue()} className="text-sm" copyable={true} />,
+      meta: {
+        alphabetic: true,
+      },
     }),
     {
       id: 'expand-col',

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -123,8 +123,12 @@ const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnD
           disabled={!row.getCanSelect()}
           onCheckedChange={(checked) => {
             const address = row.original.utxo.address
-            const eligibleRows = table.getRowModel().rows.filter((it) => it.original.utxo.address === address)
-            eligibleRows.forEach((it) => it.getToggleSelectedHandler()(checked))
+            const eligibleRows = table
+              .getRowModel()
+              .rows.filter((it) => it.original.utxo.address === address)
+              .filter((it) => it.getIsSelected() !== checked)
+
+            eligibleRows.forEach((it) => it.toggleSelected())
 
             if (eligibleRows.length > 1) {
               if (checked) {

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -134,6 +134,7 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
 
   // TODO: makerRunning, takerRunner, rescanRunning, etc.
   const operationsEnabled = enabled && !(walletInfoIsFetching || freezeUtxos.isPending || unfreezeUtxos.isPending)
+  const enableRowSelection = enabled && !(freezeUtxos.isPending || unfreezeUtxos.isPending)
 
   const onFreezeClick = async () => {
     const selectedAddresses = new Set(selectedUtxos.map((it) => it.address))
@@ -245,6 +246,7 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
         tableEntries={tableEntries}
         pinnedEntries={[]}
         globalFilter={searchFilter}
+        enableRowSelection={enableRowSelection !== true ? false : undefined}
         onRowSelectionChange={setRowSelection}
       />
     </>

--- a/src/context/JamSessionInfoContext.ts
+++ b/src/context/JamSessionInfoContext.ts
@@ -7,6 +7,7 @@ export interface RescanInfo {
 }
 
 interface JamSessionInfoContextType {
+  blockHeight?: number
   rescanInfo: RescanInfo
   setRescanInfo: Dispatch<SetStateAction<RescanInfo>>
 }

--- a/src/context/JamSessionInfoContextProvider.tsx
+++ b/src/context/JamSessionInfoContextProvider.tsx
@@ -19,11 +19,11 @@ export const JamSessionInfoContextProvider = ({
   walletFileName,
   children,
 }: PropsWithChildren<JamSessionInfoContextProviderProps>) => {
-  const jmSession = useStore(jmSessionStore, (state) => state)
+  const { state } = useStore(jmSessionStore, (state) => state)
   const client = useApiClient()
   const [rescanInfo, setRescanInfo] = useState<RescanInfo>({
     updatedAt: 0,
-    rescanning: jmSession.state?.rescanning === true,
+    rescanning: state?.rescanning === true,
   })
 
   const getrescaninfoQueryOptions = useMemo(
@@ -42,7 +42,7 @@ export const JamSessionInfoContextProvider = ({
     }),
     refetchInterval: JAM_RESCAN_PROGRESS_INTERVAL,
     refetchIntervalInBackground: true,
-    enabled: rescanInfo.rescanning || jmSession.state?.rescanning === true,
+    enabled: rescanInfo.rescanning || state?.rescanning === true,
   })
 
   // only update rescan info if data is available and the current rescan info is younger than the latest data from the query
@@ -52,8 +52,8 @@ export const JamSessionInfoContextProvider = ({
     (rescanInfo.updatedAt === undefined || rescanInfo.updatedAt < getrescaninfoQuery.dataUpdatedAt)
 
   if (shouldUpdateRescanInfo) {
-    const isRescanning = getrescaninfoQuery.data.rescanning || jmSession.state?.rescanning === true
-    const rescanningFinished = getrescaninfoQuery.data.rescanning === false && jmSession.state?.rescanning === true
+    const isRescanning = getrescaninfoQuery.data.rescanning || state?.rescanning === true
+    const rescanningFinished = getrescaninfoQuery.data.rescanning === false && state?.rescanning === true
 
     setRescanInfo({
       updatedAt: getrescaninfoQuery.dataUpdatedAt,
@@ -63,6 +63,7 @@ export const JamSessionInfoContextProvider = ({
   }
 
   const value = {
+    blockHeight: state?.block_height,
     rescanInfo,
     setRescanInfo,
   }

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -232,10 +232,8 @@ export const JamWalletInfoContextProvider = ({
       }
 
       return await utxosQueryResult
-        .refetch({ cancelRefetch: true, throwOnError: true })
-        .then((utxos) =>
-          displayWalletQueryResult.refetch({ cancelRefetch: true, throwOnError: true }).then(() => utxos),
-        )
+        .refetch({ throwOnError: true })
+        .then((utxos) => displayWalletQueryResult.refetch({ throwOnError: true }).then(() => utxos))
         .then((utxos) => toBalanceSummary((utxos.data?.utxos || []) as Utxo[]))
     },
     retry: false,

--- a/src/hooks/useUtxoSelectionDialog.ts
+++ b/src/hooks/useUtxoSelectionDialog.ts
@@ -56,7 +56,7 @@ export const useUtxoSelectionDialog = ({ walletFileName, sourceJar, addressSumma
     retry: false,
   })
 
-  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isApplying } = useMutation({
+  const { mutateAsync: applyUtxoSelectionMutateAsync, isPending: isSubmitting } = useMutation({
     mutationFn: async ({ utxosToFreeze, utxosToUnfreeze }: { utxosToFreeze: Utxo[]; utxosToUnfreeze: Utxo[] }) => {
       const [freezeResult, unfreezeResult] = await Promise.all([
         Promise.allSettled(
@@ -99,7 +99,7 @@ export const useUtxoSelectionDialog = ({ walletFileName, sourceJar, addressSumma
     setOpen(true)
   }
 
-  const onApplyUtxoSelection = async () => {
+  const onSubmit = async () => {
     if (!sourceJar) return
 
     const selectedUtxoIds = new Set(selectedUtxos.map((it) => it.utxo))
@@ -168,25 +168,25 @@ export const useUtxoSelectionDialog = ({ walletFileName, sourceJar, addressSumma
 
   const dialogProps: UtxoSelectionDialogProps = {
     open,
-    isApplying,
+    isSubmitting,
     selectedCount: selectedUtxos.length,
     filter,
     tableEntries,
     initialRowSelection,
-    enableRowSelection: isApplying ? false : undefined,
+    enableRowSelection: isSubmitting ? false : undefined,
     onOpenChange: (nextOpen: boolean) => {
-      if (isApplying) return
+      if (isSubmitting) return
       setOpen(nextOpen)
     },
     onFilterChange: setFilter,
     onRowSelectionChange: setRowSelection,
-    onApply: () => void onApplyUtxoSelection(),
+    onSubmit,
   }
 
   return {
-    isApplying,
+    isSubmitting,
     onOpenUtxoSelector,
-    utxoSelectorDisabled: isApplying || sourceJar === undefined || sourceJar.utxos.length === 0,
+    utxoSelectorDisabled: isSubmitting || sourceJar === undefined || sourceJar.utxos.length === 0,
     dialogProps,
   }
 }

--- a/src/hooks/useUtxoSelectionDialog.ts
+++ b/src/hooks/useUtxoSelectionDialog.ts
@@ -11,17 +11,16 @@ import type { Utxo } from '@/hooks/useQueryUtxos'
 import * as fb from '@/lib/fidelityBondUtils'
 import { utxoTags } from '@/lib/tags'
 import type { WalletFileName } from '@/lib/utils'
-import type { JarIndex } from '@/types/global'
 
 const SEND_AUTO_SELECTION_TOAST_ID = 'send.utxo.selection_changed_automatically'
 
 interface UseUtxoSelectionDialogProps {
   walletFileName: WalletFileName
-  jars: Jar[]
+  sourceJar?: Jar
   addressSummary: AddressSummary
 }
 
-export const useUtxoSelectionDialog = ({ walletFileName, jars, addressSummary }: UseUtxoSelectionDialogProps) => {
+export const useUtxoSelectionDialog = ({ walletFileName, sourceJar, addressSummary }: UseUtxoSelectionDialogProps) => {
   const { t } = useTranslation()
   const client = useApiClient()
 
@@ -29,12 +28,6 @@ export const useUtxoSelectionDialog = ({ walletFileName, jars, addressSummary }:
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState('')
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
-  const [sourceJarIndex, setSourceJarIndex] = useState<JarIndex>()
-
-  const sourceJar = useMemo(() => {
-    if (sourceJarIndex === undefined) return
-    return jars.find((it) => it.jarIndex === sourceJarIndex)
-  }, [jars, sourceJarIndex])
 
   const tableEntries = useMemo(() => {
     return (sourceJar?.utxos || []).map((utxo) => ({
@@ -192,8 +185,6 @@ export const useUtxoSelectionDialog = ({ walletFileName, jars, addressSummary }:
 
   return {
     isApplying,
-    sourceJarIndex,
-    setSourceJarIndex,
     onOpenUtxoSelector,
     utxoSelectorDisabled: isApplying || sourceJar === undefined || sourceJar.utxos.length === 0,
     dialogProps,

--- a/src/hooks/useUtxoSelectionDialog.ts
+++ b/src/hooks/useUtxoSelectionDialog.ts
@@ -173,7 +173,7 @@ export const useUtxoSelectionDialog = ({ walletFileName, sourceJar, addressSumma
     filter,
     tableEntries,
     initialRowSelection,
-    enableRowSelection: (row) => !fb.utxo.isFidelityBond(row.original.utxo),
+    enableRowSelection: isApplying ? false : undefined,
     onOpenChange: (nextOpen: boolean) => {
       if (isApplying) return
       setOpen(nextOpen)


### PR DESCRIPTION
After a collaborative transaction, a warning is displayed that some UTXOs need more confirmation to be included in as inputs: "To run the scheduler you need UTXOs with 5 or more confirmations. Fund your wallet and wait for 5 more blocks.".

Before this PR, the message stays until the user reload, even if the UTXOs have the need amount of confirmations.
After this PR, UTXOs are reloaded when blockheight changes and the messages disappears automatically if confirmation preconditions are satifisfied.

Additionally: 
- Change update handling of "initialRowSelection" in `UtxoTable` (e.g. utxos can change anytime, prevent update to selection while user is editing)
- Display "tags" and "confirmations" before "address" in `UtxoTable`