### PR TITLE
chore: valid number must be finite

### DIFF
--- a/src/components/earn/EarnForm.tsx
+++ b/src/components/earn/EarnForm.tsx
@@ -13,7 +13,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Tabs, TabsContent } from '@/components/ui/tabs'
 import * as JAM from '@/constants/jam'
 import type { OfferType } from '@/constants/jm'
-import { cn, factorToPercentage } from '@/lib/utils'
+import { cn, factorToPercentage, isValidInteger, isValidNumber } from '@/lib/utils'
 import type { AmountSats } from '@/types/global'
 import { DevBadge } from '../dev/DevBadge'
 import { Card, CardContent, CardHeader } from '../ui/card'
@@ -60,7 +60,7 @@ const earnFormBaseSchema = (t: TFunction) => {
       offerAbsoluteFee: yup
         .number()
         .integer(t('earn.feedback_invalid_abs_fee'))
-        .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+        .transform((value) => (isValidInteger(value) ? value : null))
         .when('offerType', {
           is: (val: OfferType) => val === OFFERTYPE_ABS,
           then: (schema) =>
@@ -71,7 +71,7 @@ const earnFormBaseSchema = (t: TFunction) => {
         }),
       offerRelativeFeeInPercent: yup
         .number()
-        .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+        .transform((value) => (isValidNumber(value) ? value : null))
         .when('offerType', {
           is: (val: OfferType) => val === OFFERTYPE_REL,
           then: (schema) =>
@@ -79,11 +79,7 @@ const earnFormBaseSchema = (t: TFunction) => {
               .min(factorToPercentage(JAM.OFFER_FEE_REL_MIN), invalidRelativeFeeMessage)
               .max(factorToPercentage(JAM.OFFER_FEE_REL_MAX), invalidRelativeFeeMessage)
               .required(invalidRelativeFeeMessage),
-          otherwise: (schema) =>
-            schema
-              .transform((value) => (Number.isFinite(value) ? Number(value) : null))
-              .nullable()
-              .optional(),
+          otherwise: (schema) => schema.nullable().optional(),
         }),
     })
     .required()
@@ -151,7 +147,7 @@ export function EarnForm({
         yup.object({
           offerMinAmount: yup
             .number()
-            .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+            .transform((value) => (isValidInteger(value) ? value : null))
             .integer(t('earn.feedback_invalid_min_amount'))
             .min(
               JAM.OFFER_MINSIZE_MIN,

--- a/src/components/import/ImportDetailsForm.tsx
+++ b/src/components/import/ImportDetailsForm.tsx
@@ -20,7 +20,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { isDebugFeatureEnabled, isDevMode } from '@/constants/debugFeatures'
 import { GAPLIMIT_WARN_THRESHOLD } from '@/constants/jam'
 import { JM_GAPLIMIT_DEFAULT } from '@/constants/jm'
-import { cn, DUMMY_SEED_PHRASE, SEGWIT_ACTIVATION_BLOCK } from '@/lib/utils'
+import { cn, DUMMY_SEED_PHRASE, isValidInteger, SEGWIT_ACTIVATION_BLOCK } from '@/lib/utils'
 import { DevBadge } from '../dev/DevBadge'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion'
 import { Alert, AlertDescription, AlertTitle } from '../ui/alert'
@@ -116,14 +116,14 @@ const importDetailsFormSchema = (t: TFunction) => {
         ),
       blockheight: yup
         .number()
-        .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+        .transform((value) => (isValidInteger(value) ? value : null))
         .integer(invalidBlockheightMessage)
         .min(MIN_BLOCKHEIGHT_VALUE, invalidBlockheightMessage)
         .max(MAX_BLOCKHEIGHT_VALUE, invalidBlockheightMessage)
         .required(invalidBlockheightMessage),
       gaplimit: yup
         .number()
-        .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+        .transform((value) => (isValidInteger(value) ? value : null))
         .integer(invalidGaplimitMessage)
         .min(MIN_GAPLIMIT_VALUE, invalidGaplimitMessage)
         .max(MAX_GAPLIMIT_VALUE, invalidGaplimitMessage)

--- a/src/components/receive/ReceiveForm.tsx
+++ b/src/components/receive/ReceiveForm.tsx
@@ -7,7 +7,7 @@ import * as yup from 'yup'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { SelectableJar } from '@/components/ui/jam/SelectableJar'
 import { useWalletBalanceSummary, type Jar } from '@/context/JamWalletInfoContext'
-import { cn } from '@/lib/utils'
+import { cn, isValidInteger } from '@/lib/utils'
 import { DevBadge } from '../dev/DevBadge'
 import { Field, FieldLabel } from '../ui/field'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
@@ -48,7 +48,7 @@ const receiveFormSchema = (jars: Jar[], t: TFunction) => {
         .integer(t('receive.feedback_invalid_amount'))
         .min(1, t('receive.feedback_invalid_amount'))
         .max(21_000_000 * 100_000_000, t('receive.feedback_invalid_amount'))
-        .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+        .transform((value) => (isValidInteger(value) ? value : null))
         .nullable()
         .optional(),
     })

--- a/src/components/send/SendForm.schema.ts
+++ b/src/components/send/SendForm.schema.ts
@@ -5,7 +5,7 @@ import { TOTAL_COIN_SUPPLY } from '@/constants/jam'
 import type { AddressSummary, Jar } from '@/context/JamWalletInfoContext'
 import { TX_FEE_UNITS } from '@/lib/feeConfig'
 import type { JamFeeConfigValues } from '@/lib/feeConfig'
-import { pseudoRandomInteger } from '@/lib/utils'
+import { isValidInteger, pseudoRandomInteger } from '@/lib/utils'
 import type { AmountSats } from '@/types/global'
 import { toTxFeeFormDefaultValues, createTxFeeFormSchema } from './TxFeeForm.schema'
 import type { SendFormValues } from './types'
@@ -58,6 +58,10 @@ export const createSendFormSchema = (
   network: Network,
   t: TFunction,
 ) => {
+  const invalidNumberOfCollaboratorsMessage = t('send.error_invalid_num_collaborators', {
+    minNumCollaborators: minNumberOfCollaborators,
+    maxNumCollaborators: MAX_NUM_COLLABORATORS,
+  })
   return (
     yup
       .object({
@@ -119,7 +123,7 @@ export const createSendFormSchema = (
               otherwise: (schema) =>
                 schema
                   .integer(t('send.feedback_invalid_amount'))
-                  .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+                  .transform((value) => (isValidInteger(value) ? value : null))
                   .nonNullable(t('send.feedback_invalid_amount'))
                   .min(MIN_SEND_AMOUNT, t('send.feedback_invalid_amount'))
                   .max(MAX_SEND_AMOUNT, t('send.feedback_invalid_amount'))
@@ -134,26 +138,10 @@ export const createSendFormSchema = (
             schema
               .integer()
               .default(initialNumberOfCollaborators(minNumberOfCollaborators))
-              .min(
-                minNumberOfCollaborators,
-                t('send.error_invalid_num_collaborators', {
-                  minNumCollaborators: minNumberOfCollaborators,
-                  maxNumCollaborators: MAX_NUM_COLLABORATORS,
-                }),
-              )
-              .max(
-                MAX_NUM_COLLABORATORS,
-                t('send.error_invalid_num_collaborators', {
-                  minNumCollaborators: minNumberOfCollaborators,
-                  maxNumCollaborators: MAX_NUM_COLLABORATORS,
-                }),
-              )
-              .required(
-                t('send.error_invalid_num_collaborators', {
-                  minNumCollaborators: minNumberOfCollaborators,
-                  maxNumCollaborators: MAX_NUM_COLLABORATORS,
-                }),
-              ),
+              .transform((value) => (isValidInteger(value) ? value : null))
+              .min(minNumberOfCollaborators, invalidNumberOfCollaboratorsMessage)
+              .max(MAX_NUM_COLLABORATORS, invalidNumberOfCollaboratorsMessage)
+              .required(invalidNumberOfCollaboratorsMessage),
           otherwise: (schema) =>
             schema
               .transform(() => null)

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -16,7 +16,12 @@ import { useApiClient } from '@/hooks/useApiClient'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { parseBip21Uri, type Bip21ParseResult } from '@/lib/bip21'
 import type { JamFeeConfigValues } from '@/lib/feeConfig'
-import { cn, delayedPromise, factorToPercentage, isValidNumber, type WalletFileName } from '@/lib/utils'
+import {
+  cn,
+  delayedPromise,
+  factorToPercentage,
+  type WalletFileName,
+} from '@/lib/utils'
 import type { JarIndex } from '@/types/global'
 import { DevBadge } from '../dev/DevBadge'
 import { buildSweepPreconditionSummary } from '../sweep/preconditions'
@@ -593,7 +598,7 @@ export function SendForm({
                     <Field data-invalid={errors.numCollaborators !== undefined}>
                       <FieldLabel htmlFor="send-num-collaborators">
                         {t('send.label_num_collaborators', {
-                          numCollaborators: isValidNumber(values.numCollaborators) ? values.numCollaborators : '-',
+                          numCollaborators: values.numCollaborators ?? '?',
                         })}
                       </FieldLabel>
                       <FieldDescription>{t('send.description_num_collaborators')}</FieldDescription>

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -16,12 +16,7 @@ import { useApiClient } from '@/hooks/useApiClient'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { parseBip21Uri, type Bip21ParseResult } from '@/lib/bip21'
 import type { JamFeeConfigValues } from '@/lib/feeConfig'
-import {
-  cn,
-  delayedPromise,
-  factorToPercentage,
-  type WalletFileName,
-} from '@/lib/utils'
+import { cn, delayedPromise, factorToPercentage, type WalletFileName } from '@/lib/utils'
 import type { JarIndex } from '@/types/global'
 import { DevBadge } from '../dev/DevBadge'
 import { buildSweepPreconditionSummary } from '../sweep/preconditions'

--- a/src/components/send/TxFeeForm.schema.ts
+++ b/src/components/send/TxFeeForm.schema.ts
@@ -3,6 +3,7 @@ import * as yup from 'yup'
 import { type TxFeeUnit } from '@/lib/feeConfig'
 import { TX_FEE_UNITS } from '@/lib/feeConfig'
 import type { JamFeeConfigValues } from '@/lib/feeConfig'
+import { isValidInteger, isValidNumber } from '@/lib/utils'
 
 export const MIN_TX_FEE_IN_BLOCKS = 1
 export const MAX_TX_FEE_IN_BLOCKS = 1_000
@@ -52,7 +53,7 @@ export function createTxFeeFormSchema({
             then: (schema) =>
               schema
                 .integer(feedbackInvalidTxFeesBlocks)
-                .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+                .transform((value) => (isValidInteger(value) ? value : null))
                 .min(MIN_TX_FEE_IN_BLOCKS, feedbackInvalidTxFeesBlocks)
                 .max(MAX_TX_FEE_IN_BLOCKS, feedbackInvalidTxFeesBlocks)
                 .required(feedbackInvalidTxFeesBlocks),
@@ -66,7 +67,7 @@ export function createTxFeeFormSchema({
             is: (val: TxFeeUnit) => val === TX_FEE_UNITS.SATS_PER_VBYTE,
             then: (schema) =>
               schema
-                .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+                .transform((value) => (isValidNumber(value) ? value : null))
                 .min(MIN_TX_FEE_IN_SATS_PER_VBYTE, feedbackInvalidTxFeeInSatsPerVbyte)
                 .max(MAX_TX_FEE_IN_SATS_PER_VBYTE, feedbackInvalidTxFeeInSatsPerVbyte)
                 .required(feedbackInvalidTxFeeInSatsPerVbyte),

--- a/src/components/send/collaborativeSend.ts
+++ b/src/components/send/collaborativeSend.ts
@@ -1,11 +1,11 @@
 import type { DirectSendRequest, DoCoinjoinRequest } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
 import { TX_FEE_UNITS } from '@/lib/feeConfig'
-import { isValidNumber } from '@/lib/utils'
+import { isValidInteger, isValidNumber } from '@/lib/utils'
 import type { SendFormValues } from './types'
 
 const ensureInteger = (value: unknown, message: string): number => {
-  if (!isValidNumber(value) || !Number.isSafeInteger(value)) {
+  if (!isValidInteger(value)) {
     throw new TypeError(message)
   }
   return value

--- a/src/components/settings/fees/CollaboratorFeesForm.schema.ts
+++ b/src/components/settings/fees/CollaboratorFeesForm.schema.ts
@@ -1,7 +1,7 @@
 import type { TFunction } from 'i18next'
 import * as yup from 'yup'
 import { CJ_FEE_ABS_MAX, CJ_FEE_ABS_MIN, CJ_FEE_REL_MAX, CJ_FEE_REL_MIN } from '@/constants/jam'
-import { factorToPercentage, formatSats } from '@/lib/utils'
+import { factorToPercentage, formatSats, isValidInteger } from '@/lib/utils'
 import type { AmountSats } from '@/types/global'
 
 export type CollaboratorFeesFormValues = {
@@ -28,13 +28,13 @@ export function createCollaboratorFeesFormSchema({
       maxCjFeeAbs: yup
         .number()
         .integer(maxCjFeeAbsoluteMessage)
-        .transform((value) => (Number.isSafeInteger(value) ? Number(value) : null))
+        .transform((value) => (isValidInteger(value) ? value : null))
         .min(CJ_FEE_ABS_MIN, maxCjFeeAbsoluteMessage)
         .max(CJ_FEE_ABS_MAX, maxCjFeeAbsoluteMessage)
         .required(maxCjFeeAbsoluteMessage),
       maxCjFeeRelInPercent: yup
         .number()
-        .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+        .transform((value) => (isValidInteger(value) ? value : null))
         .min(factorToPercentage(CJ_FEE_REL_MIN), maxCjFeeRelativeMessage)
         .max(factorToPercentage(CJ_FEE_REL_MAX), maxCjFeeRelativeMessage)
         .required(maxCjFeeRelativeMessage),

--- a/src/components/settings/fees/FeeConfigDialog.tsx
+++ b/src/components/settings/fees/FeeConfigDialog.tsx
@@ -25,7 +25,7 @@ import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
 import { getErrorReason } from '@/lib/errorReason'
 import { TX_FEE_UNITS } from '@/lib/feeConfig'
-import { cn, factorToPercentage, percentageToFactorString } from '@/lib/utils'
+import { cn, factorToPercentage, isValidInteger, isValidNumber, percentageToFactorString } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
 import type { WithRequiredProperty } from '@/types/global'
@@ -41,12 +41,10 @@ const factorToPercentageOrUndefined = (value: number | undefined) => {
 }
 
 const safePercentageToFactorStringOrUndefined = (value: number | undefined) => {
-  const isSafe = value !== undefined && Number.isFinite(value)
-  return isSafe ? percentageToFactorString(value) : undefined
+  return isValidNumber(value) ? percentageToFactorString(value) : undefined
 }
 const safeIntegerOrUndefined = (value: number | undefined) => {
-  const isSafe = value !== undefined && Number.isSafeInteger(value)
-  return isSafe ? value : undefined
+  return isValidInteger(value) ? value : undefined
 }
 
 type FeeConfigDialogProps = WithRequiredProperty<
@@ -136,7 +134,7 @@ export const FeeConfigDialog = ({
         safePercentageToFactorStringOrUndefined(miningData.maxSweepFeeChangeInPercent) ?? ''
 
       const txFeesSatsPerKvByteValue =
-        miningData.txFee.txFeeInSatsPerVbyte !== undefined && Number.isFinite(miningData.txFee.txFeeInSatsPerVbyte)
+        miningData.txFee.txFeeInSatsPerVbyte !== undefined && isValidNumber(miningData.txFee.txFeeInSatsPerVbyte)
           ? String(Math.ceil(miningData.txFee.txFeeInSatsPerVbyte * 1_000))
           : ''
       const txFeesValue =

--- a/src/components/settings/fees/MiningFeesForm.schema.ts
+++ b/src/components/settings/fees/MiningFeesForm.schema.ts
@@ -6,7 +6,7 @@ import {
   MAX_SWEEP_FEE_CHANGE_MIN,
   MAX_SWEEP_FEE_CHANGE_MAX,
 } from '@/constants/jam'
-import { factorToPercentage } from '@/lib/utils'
+import { factorToPercentage, isValidNumber } from '@/lib/utils'
 import { createTxFeeFormSchema, type TxFeeFormValues } from '../../send/TxFeeForm.schema'
 
 export type MiningFeesFormValues = {
@@ -34,13 +34,13 @@ export function createMiningFeesFormSchema({
       .object({
         txFeesFactorInPercent: yup
           .number()
-          .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+          .transform((value) => (isValidNumber(value) ? value : null))
           .min(factorToPercentage(TX_FEES_FACTOR_MIN), txFeesFactorMessage)
           .max(factorToPercentage(TX_FEES_FACTOR_MAX), txFeesFactorMessage)
           .required(txFeesFactorMessage),
         maxSweepFeeChangeInPercent: yup
           .number()
-          .transform((value) => (Number.isFinite(value) ? Number(value) : null))
+          .transform((value) => (isValidNumber(value) ? value : null))
           .min(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MIN), maxSweepFeeChangeMessage)
           .max(factorToPercentage(MAX_SWEEP_FEE_CHANGE_MAX), maxSweepFeeChangeMessage)
           .required(maxSweepFeeChangeMessage),

--- a/src/components/sweep/scheduleUtils.ts
+++ b/src/components/sweep/scheduleUtils.ts
@@ -1,3 +1,4 @@
+import { isValidNumber } from '@/lib/utils'
 import type { TxId } from '@/store/jmTxStore'
 import type { BitcoinAddress, JarIndex, Minutes } from '@/types/global'
 
@@ -70,7 +71,7 @@ export interface ScheduleProgressSummary {
 const MIN_STEP_WIDTH_PERCENT = 8
 
 const toNumberOrDefault = (value: unknown, fallback: number): number => {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+  return isValidNumber(value) ? value : fallback
 }
 
 const getScheduleEntryWaitMinutes = (entry: ScheduleEntry): number => {

--- a/src/components/wallet/AccountDetailsTabContent.tsx
+++ b/src/components/wallet/AccountDetailsTabContent.tsx
@@ -4,7 +4,7 @@ import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import type { AccountBranch, AccountMeta } from '@/context/JamWalletInfoContext'
 import { statusTags } from '@/lib/tags'
-import { tryBtcToSat, isValidNumber } from '@/lib/utils'
+import { tryBtcToSat, isValidInteger } from '@/lib/utils'
 import type { HdPath } from '@/types/global'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion'
 import { BranchEntryTable, type BranchEntryApiObject, type BranchEntryTableRow } from './BranchEntryTable'
@@ -30,8 +30,8 @@ const toLastHdPathIndex = (hdPath: HdPath): number | null => {
   const indexOfFirstColon = stringValue.indexOf(':') // value can be `/76:1777593600`
 
   const sanitizedStringValue = indexOfFirstColon === -1 ? stringValue : stringValue.substring(0, indexOfFirstColon)
-  const numberValue = Number.parseInt(sanitizedStringValue, 10)
-  return !isValidNumber(numberValue) ? null : numberValue
+  const numberValue = Number(sanitizedStringValue)
+  return !isValidInteger(numberValue) ? null : numberValue
 }
 
 const branchToTableEntry = (value: BranchEntryApiObject): BranchEntryTableRow => {

--- a/src/lib/feeConfig.ts
+++ b/src/lib/feeConfig.ts
@@ -1,4 +1,5 @@
 import type { AmountSats, Factor } from '@/types/global'
+import { isValidInteger, isValidNumber } from './utils'
 
 export interface JmRawFeeConfigValues {
   max_cj_fee_abs?: string
@@ -38,7 +39,7 @@ export const toJamFeeConfigValues = (values: JmRawFeeConfigValues): JamFeeConfig
   const txFeeFactor = Number.parseFloat(values.tx_fees_factor || '')
 
   const rawTxFeeValue = Number.parseInt(values.tx_fees || '', 10)
-  const txFeesInBlocksOrSatsPerKiloVByte = Number.isSafeInteger(rawTxFeeValue) ? rawTxFeeValue : undefined
+  const txFeesInBlocksOrSatsPerKiloVByte = isValidInteger(rawTxFeeValue) ? rawTxFeeValue : undefined
   const txFeeUnit =
     txFeesInBlocksOrSatsPerKiloVByte !== undefined && txFeesInBlocksOrSatsPerKiloVByte > 1_000
       ? TX_FEE_UNITS.SATS_PER_VBYTE
@@ -49,10 +50,10 @@ export const toJamFeeConfigValues = (values: JmRawFeeConfigValues): JamFeeConfig
     txFeeUnit === TX_FEE_UNITS.SATS_PER_VBYTE ? txFeesInBlocksOrSatsPerKiloVByte! / 1_000 : undefined
 
   return {
-    maxCjAbsoluteFee: Number.isSafeInteger(maxCjAbsoluteFee) ? maxCjAbsoluteFee : undefined,
-    maxCjRelativeFee: Number.isFinite(maxCjRelativeFee) ? maxCjRelativeFee : undefined,
-    txFeeFactor: Number.isFinite(txFeeFactor) ? txFeeFactor : undefined,
-    maxSweepFeeChangeFactor: Number.isFinite(maxSweepFeeChangeFactor) ? maxSweepFeeChangeFactor : undefined,
+    maxCjAbsoluteFee: isValidInteger(maxCjAbsoluteFee) ? maxCjAbsoluteFee : undefined,
+    maxCjRelativeFee: isValidNumber(maxCjRelativeFee) ? maxCjRelativeFee : undefined,
+    txFeeFactor: isValidNumber(txFeeFactor) ? txFeeFactor : undefined,
+    maxSweepFeeChangeFactor: isValidNumber(maxSweepFeeChangeFactor) ? maxSweepFeeChangeFactor : undefined,
     txFee: {
       txFeeUnit,
       txFeeInBlocks,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -8,6 +8,7 @@ import {
   tryBtcToSat,
   percentageToFactor,
   isValidNumber,
+  isValidInteger,
   factorToPercentage,
   parseSemanticVersion,
   UNKNOWN_VERSION,
@@ -298,18 +299,59 @@ describe('isValidNumber', () => {
     expect(isValidNumber(1)).toBe(true)
     expect(isValidNumber(-1)).toBe(true)
     expect(isValidNumber(3.14)).toBe(true)
+    expect(isValidNumber(1_234_567_890)).toBe(true)
+    expect(isValidNumber(1_234_567_890.123)).toBe(true)
     expect(isValidNumber(Number('2e307'))).toBe(true)
     expect(isValidNumber(Number('-2e307'))).toBe(true)
+    expect(isValidNumber(Math.PI)).toBe(true)
+    expect(isValidNumber(Math.E)).toBe(true)
+    expect(isValidNumber(Number.MIN_SAFE_INTEGER)).toBe(true)
+    expect(isValidNumber(Number.MAX_SAFE_INTEGER)).toBe(true)
+    expect(isValidNumber(Number.MIN_VALUE)).toBe(true)
+    expect(isValidNumber(Number.MAX_VALUE)).toBe(true)
   })
 
   it('should return false for invalid values', () => {
+    expect(isValidNumber(undefined)).toBe(false)
+    expect(isValidNumber(null)).toBe(false)
     expect(isValidNumber(Number.POSITIVE_INFINITY)).toBe(false)
     expect(isValidNumber(Number.NEGATIVE_INFINITY)).toBe(false)
     expect(isValidNumber(Number.NaN)).toBe(false)
-    expect(isValidNumber(undefined)).toBe(false)
-    expect(isValidNumber(null)).toBe(false)
     expect(isValidNumber(Number('2e308'))).toBe(false) // Number(2e308) := Number.POSITIVE_INFINITY
     expect(isValidNumber(Number('-2e308'))).toBe(false) // Number(-2e308) := Number.NEGATIVE_INFINITY
+  })
+})
+
+describe('isValidInteger', () => {
+  it('should return true for valid integers', () => {
+    expect(isValidInteger(0)).toBe(true)
+    expect(isValidInteger(1)).toBe(true)
+    expect(isValidInteger(21)).toBe(true)
+    expect(isValidInteger(1_234_567_890)).toBe(true)
+    expect(isValidInteger(-1)).toBe(true)
+    expect(isValidInteger(-1_234_567_890)).toBe(true)
+    expect(isValidInteger(Number.MIN_SAFE_INTEGER)).toBe(true)
+    expect(isValidInteger(Number.MAX_SAFE_INTEGER)).toBe(true)
+  })
+
+  it('should return false for invalid values', () => {
+    expect(isValidInteger(undefined)).toBe(false)
+    expect(isValidInteger(null)).toBe(false)
+    expect(isValidInteger(-42.1337)).toBe(false)
+    expect(isValidInteger(3.1415)).toBe(false)
+    expect(isValidInteger(Math.PI)).toBe(false)
+    expect(isValidInteger(Math.E)).toBe(false)
+    expect(isValidInteger(1 / 3)).toBe(false)
+    expect(isValidInteger(1_234_567_890.123)).toBe(false)
+    expect(isValidInteger(Number.MIN_SAFE_INTEGER - 1)).toBe(false)
+    expect(isValidInteger(Number.MAX_SAFE_INTEGER + 1)).toBe(false)
+    expect(isValidInteger(Number.MIN_VALUE)).toBe(false)
+    expect(isValidInteger(Number.MAX_VALUE)).toBe(false)
+    expect(isValidInteger(Number.POSITIVE_INFINITY)).toBe(false)
+    expect(isValidInteger(Number.NEGATIVE_INFINITY)).toBe(false)
+    expect(isValidInteger(Number.NaN)).toBe(false)
+    expect(isValidInteger(Number('2e308'))).toBe(false) // Number(2e308) := Number.POSITIVE_INFINITY
+    expect(isValidInteger(Number('-2e308'))).toBe(false) // Number(-2e308) := Number.NEGATIVE_INFINITY
   })
 })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -298,14 +298,18 @@ describe('isValidNumber', () => {
     expect(isValidNumber(1)).toBe(true)
     expect(isValidNumber(-1)).toBe(true)
     expect(isValidNumber(3.14)).toBe(true)
-    expect(isValidNumber(Number.POSITIVE_INFINITY)).toBe(true)
-    expect(isValidNumber(Number.NEGATIVE_INFINITY)).toBe(true)
+    expect(isValidNumber(Number('2e307'))).toBe(true)
+    expect(isValidNumber(Number('-2e307'))).toBe(true)
   })
 
   it('should return false for invalid values', () => {
+    expect(isValidNumber(Number.POSITIVE_INFINITY)).toBe(false)
+    expect(isValidNumber(Number.NEGATIVE_INFINITY)).toBe(false)
     expect(isValidNumber(Number.NaN)).toBe(false)
     expect(isValidNumber(undefined)).toBe(false)
     expect(isValidNumber(null)).toBe(false)
+    expect(isValidNumber(Number('2e308'))).toBe(false) // Number(2e308) := Number.POSITIVE_INFINITY
+    expect(isValidNumber(Number('-2e308'))).toBe(false) // Number(-2e308) := Number.NEGATIVE_INFINITY
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -150,7 +150,11 @@ export const percentageToFactor = (val: number, precision = 6) => {
 }
 
 export const isValidNumber = (val: unknown): val is number => {
-  return val !== undefined && Number.isFinite(val)
+  return Number.isFinite(val)
+}
+
+export const isValidInteger = (val: unknown): val is number => {
+  return Number.isSafeInteger(val)
 }
 
 export const formatBtc = (value: number) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -150,7 +150,7 @@ export const percentageToFactor = (val: number, precision = 6) => {
 }
 
 export const isValidNumber = (val: unknown): val is number => {
-  return val !== undefined && typeof val === 'number' && !Number.isNaN(val)
+  return val !== undefined && Number.isFinite(val)
 }
 
 export const formatBtc = (value: number) => {


### PR DESCRIPTION
Change semantic of `isValidNumber` and introcude new utility function `isValidInteger`.

Before, `+Infinity` and `-Infinity` were treated as valid numbers, did not make any sense.
Using `isValidInteger` ensures numbers dont grow too large. However, validation of user inputs should still set min/max boundaries (e.g. checking for a **positive** integer, etc.)