### PR TITLE
chore(storybook): add core component stories

### DIFF
--- a/src/stories/ButtonGroup.stories.tsx
+++ b/src/stories/ButtonGroup.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MinusIcon, PlusIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ButtonGroup, ButtonGroupSeparator, ButtonGroupText } from '@/components/ui/button-group'
+import { Input } from '@/components/ui/input'
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: 'Core/ButtonGroup',
+  component: ButtonGroup,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof ButtonGroup>
+
+export const Default: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button variant="outline">Cancel</Button>
+      <Button>Continue</Button>
+    </ButtonGroup>
+  ),
+}
+
+export const WithText: Story = {
+  render: () => (
+    <ButtonGroup>
+      <ButtonGroupText>Fee</ButtonGroupText>
+      <Input defaultValue="21" className="w-24" />
+      <ButtonGroupText>sats</ButtonGroupText>
+    </ButtonGroup>
+  ),
+}
+
+export const WithSeparator: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button variant="outline" size="icon-sm">
+        <MinusIcon />
+      </Button>
+      <ButtonGroupSeparator />
+      <Button variant="outline" size="icon-sm">
+        <PlusIcon />
+      </Button>
+    </ButtonGroup>
+  ),
+}
+
+export const Vertical: Story = {
+  render: () => (
+    <ButtonGroup orientation="vertical">
+      <Button variant="outline">Top</Button>
+      <Button variant="outline">Middle</Button>
+      <Button variant="outline">Bottom</Button>
+    </ButtonGroup>
+  ),
+}

--- a/src/stories/ButtonGroup.stories.tsx
+++ b/src/stories/ButtonGroup.stories.tsx
@@ -35,11 +35,11 @@ export const WithText: Story = {
 export const WithSeparator: Story = {
   render: () => (
     <ButtonGroup>
-      <Button variant="outline" size="icon-sm">
+      <Button variant="outline" size="icon-sm" aria-label="Decrease value">
         <MinusIcon />
       </Button>
       <ButtonGroupSeparator />
-      <Button variant="outline" size="icon-sm">
+      <Button variant="outline" size="icon-sm" aria-label="Increase value">
         <PlusIcon />
       </Button>
     </ButtonGroup>

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Core/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Checkbox>
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="terms" />
+      <Label htmlFor="terms">Accept terms</Label>
+    </div>
+  ),
+}
+
+export const Checked: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="checked" defaultChecked />
+      <Label htmlFor="checked">Selected option</Label>
+    </div>
+  ),
+}
+
+export const Indeterminate: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="indeterminate" checked="indeterminate" />
+      <Label htmlFor="indeterminate">Partially selected</Label>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="disabled" disabled />
+      <Label htmlFor="disabled" className="text-muted-foreground">
+        Disabled option
+      </Label>
+    </div>
+  ),
+}
+
+export const Invalid: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="invalid" aria-invalid="true" />
+      <Label htmlFor="invalid">Needs attention</Label>
+    </div>
+  ),
+}

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -14,8 +14,8 @@ type Story = StoryObj<typeof Checkbox>
 export const Default: Story = {
   render: () => (
     <div className="flex items-center gap-2">
-      <Checkbox id="terms" />
-      <Label htmlFor="terms">Accept terms</Label>
+      <Checkbox id="checkbox-terms-default" />
+      <Label htmlFor="checkbox-terms-default">Accept terms</Label>
     </div>
   ),
 }
@@ -23,8 +23,8 @@ export const Default: Story = {
 export const Checked: Story = {
   render: () => (
     <div className="flex items-center gap-2">
-      <Checkbox id="checked" defaultChecked />
-      <Label htmlFor="checked">Selected option</Label>
+      <Checkbox id="checkbox-checked" defaultChecked />
+      <Label htmlFor="checkbox-checked">Selected option</Label>
     </div>
   ),
 }
@@ -32,8 +32,8 @@ export const Checked: Story = {
 export const Indeterminate: Story = {
   render: () => (
     <div className="flex items-center gap-2">
-      <Checkbox id="indeterminate" checked="indeterminate" />
-      <Label htmlFor="indeterminate">Partially selected</Label>
+      <Checkbox id="checkbox-indeterminate" checked="indeterminate" />
+      <Label htmlFor="checkbox-indeterminate">Partially selected</Label>
     </div>
   ),
 }
@@ -41,8 +41,8 @@ export const Indeterminate: Story = {
 export const Disabled: Story = {
   render: () => (
     <div className="flex items-center gap-2">
-      <Checkbox id="disabled" disabled />
-      <Label htmlFor="disabled" className="text-muted-foreground">
+      <Checkbox id="checkbox-disabled" disabled />
+      <Label htmlFor="checkbox-disabled" className="text-muted-foreground">
         Disabled option
       </Label>
     </div>
@@ -52,8 +52,8 @@ export const Disabled: Story = {
 export const Invalid: Story = {
   render: () => (
     <div className="flex items-center gap-2">
-      <Checkbox id="invalid" aria-invalid="true" />
-      <Label htmlFor="invalid">Needs attention</Label>
+      <Checkbox id="checkbox-invalid" aria-invalid="true" />
+      <Label htmlFor="checkbox-invalid">Needs attention</Label>
     </div>
   ),
 }

--- a/src/stories/Dialog.stories.tsx
+++ b/src/stories/Dialog.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Button } from '@/components/ui/button'
 import {
@@ -19,6 +20,24 @@ const meta: Meta<typeof Dialog> = {
 export default meta
 
 type Story = StoryObj<typeof Dialog>
+
+const DialogWithoutCloseButtonStory = () => {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>No close button</DialogTitle>
+          <DialogDescription>Some flows own their close action through footer buttons.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={() => setOpen(false)}>Continue</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 export const Default: Story = {
   render: () => (
@@ -56,17 +75,5 @@ export const Open: Story = {
 }
 
 export const WithoutCloseButton: Story = {
-  render: () => (
-    <Dialog open>
-      <DialogContent showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>No close button</DialogTitle>
-          <DialogDescription>Some flows own their close action through footer buttons.</DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button>Continue</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  ),
+  render: () => <DialogWithoutCloseButtonStory />,
 }

--- a/src/stories/Dialog.stories.tsx
+++ b/src/stories/Dialog.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Core/Dialog',
+  component: Dialog,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Dialog>
+
+export const Default: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Open dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm action</DialogTitle>
+          <DialogDescription>This dialog shows the default content, description, and footer layout.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button>Confirm</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+
+export const Open: Story = {
+  render: () => (
+    <Dialog open>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Open dialog</DialogTitle>
+          <DialogDescription>This story keeps the dialog open for visual review.</DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+
+export const WithoutCloseButton: Story = {
+  render: () => (
+    <Dialog open>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>No close button</DialogTitle>
+          <DialogDescription>Some flows own their close action through footer buttons.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button>Continue</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+}

--- a/src/stories/DropdownMenu.stories.tsx
+++ b/src/stories/DropdownMenu.stories.tsx
@@ -60,3 +60,20 @@ export const WithSelectionItems: Story = {
     </DropdownMenu>
   ),
 }
+
+export const WithDisabledItem: Story = {
+  render: () => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Wallet actions</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>Wallet actions</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Rename wallet</DropdownMenuItem>
+        <DropdownMenuItem disabled>Export backup</DropdownMenuItem>
+        <DropdownMenuItem variant="destructive">Delete wallet</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+}

--- a/src/stories/DropdownMenu.stories.tsx
+++ b/src/stories/DropdownMenu.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'Core/DropdownMenu',
+  component: DropdownMenu,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof DropdownMenu>
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>Wallet actions</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Rename wallet</DropdownMenuItem>
+        <DropdownMenuItem>
+          Export backup
+          <DropdownMenuShortcut>⌘B</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem variant="destructive">Delete wallet</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+}
+
+export const WithSelectionItems: Story = {
+  render: () => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Display options</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuCheckboxItem checked>Show balances</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem>Show frozen coins</DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup value="btc">
+          <DropdownMenuRadioItem value="btc">BTC</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="sats">Sats</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+}

--- a/src/stories/Field.stories.tsx
+++ b/src/stories/Field.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+} from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+
+const meta: Meta<typeof Field> = {
+  title: 'Core/Field',
+  component: Field,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Field>
+
+export const Default: Story = {
+  render: () => (
+    <FieldGroup className="max-w-sm">
+      <Field>
+        <FieldLabel htmlFor="wallet-name">Wallet name</FieldLabel>
+        <Input id="wallet-name" placeholder="Enter wallet name" />
+        <FieldDescription>This name is only used locally in Jam.</FieldDescription>
+      </Field>
+    </FieldGroup>
+  ),
+}
+
+export const Horizontal: Story = {
+  render: () => (
+    <Field orientation="horizontal" className="max-w-sm">
+      <Checkbox id="remember-wallet" />
+      <FieldContent>
+        <FieldLabel htmlFor="remember-wallet">Remember wallet</FieldLabel>
+        <FieldDescription>Keep this wallet available in the wallet list.</FieldDescription>
+      </FieldContent>
+    </Field>
+  ),
+}
+
+export const WithError: Story = {
+  render: () => (
+    <FieldGroup className="max-w-sm">
+      <Field data-invalid="true">
+        <FieldLabel htmlFor="wallet-password">Wallet password</FieldLabel>
+        <Input id="wallet-password" type="password" aria-invalid="true" />
+        <FieldError>Password is required.</FieldError>
+      </Field>
+    </FieldGroup>
+  ),
+}
+
+export const Fieldset: Story = {
+  render: () => (
+    <FieldSet className="max-w-sm">
+      <FieldLegend>Fee settings</FieldLegend>
+      <FieldGroup>
+        <Field>
+          <FieldLabel htmlFor="min-fee">Minimum fee</FieldLabel>
+          <Input id="min-fee" defaultValue="21" />
+        </Field>
+        <FieldSeparator>or</FieldSeparator>
+        <Field>
+          <FieldTitle>Use default fee</FieldTitle>
+          <FieldDescription>Let Jam choose the default fee for this wallet.</FieldDescription>
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  ),
+}

--- a/src/stories/InputGroup.stories.tsx
+++ b/src/stories/InputGroup.stories.tsx
@@ -22,7 +22,7 @@ export const WithPrefix: Story = {
   render: () => (
     <InputGroup className="max-w-sm">
       <InputGroupAddon>
-        <SearchIcon />
+        <SearchIcon aria-hidden="true" />
       </InputGroupAddon>
       <InputGroupInput placeholder="Search transactions..." />
     </InputGroup>
@@ -44,7 +44,7 @@ export const WithButton: Story = {
   render: () => (
     <InputGroup className="max-w-sm">
       <InputGroupAddon>
-        <BitcoinIcon />
+        <BitcoinIcon aria-hidden="true" />
       </InputGroupAddon>
       <InputGroupInput placeholder="Amount" />
       <InputGroupAddon align="inline-end">

--- a/src/stories/InputGroup.stories.tsx
+++ b/src/stories/InputGroup.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { BitcoinIcon, SearchIcon } from 'lucide-react'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+} from '@/components/ui/input-group'
+
+const meta: Meta<typeof InputGroup> = {
+  title: 'Core/InputGroup',
+  component: InputGroup,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof InputGroup>
+
+export const WithPrefix: Story = {
+  render: () => (
+    <InputGroup className="max-w-sm">
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <InputGroupInput placeholder="Search transactions..." />
+    </InputGroup>
+  ),
+}
+
+export const WithSuffix: Story = {
+  render: () => (
+    <InputGroup className="max-w-sm">
+      <InputGroupInput defaultValue="21000" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupText>sats</InputGroupText>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+}
+
+export const WithButton: Story = {
+  render: () => (
+    <InputGroup className="max-w-sm">
+      <InputGroupAddon>
+        <BitcoinIcon />
+      </InputGroupAddon>
+      <InputGroupInput placeholder="Amount" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton>Max</InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+}
+
+export const WithTextarea: Story = {
+  render: () => (
+    <InputGroup className="max-w-sm">
+      <InputGroupAddon align="block-start">Note</InputGroupAddon>
+      <InputGroupTextarea placeholder="Add a wallet note..." />
+    </InputGroup>
+  ),
+}

--- a/src/stories/Pagination.stories.tsx
+++ b/src/stories/Pagination.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Pagination, PaginationContent, PaginationItem, PaginationLink } from '@/components/ui/pagination'
+
+const meta: Meta<typeof Pagination> = {
+  title: 'Core/Pagination',
+  component: Pagination,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Pagination>
+
+export const Default: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink size="default">Previous</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink isActive>1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink>2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink>3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink size="default">Next</PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+}
+
+export const Compact: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink aria-label="Previous page">{'<'}</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink isActive>4</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink aria-label="Next page">{'>'}</PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+}

--- a/src/stories/Popover.stories.tsx
+++ b/src/stories/Popover.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
+const meta: Meta<typeof Popover> = {
+  title: 'Core/Popover',
+  component: Popover,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Popover>
+
+export const Default: Story = {
+  render: () => (
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent align="start">
+        <div className="grid gap-3">
+          <div className="space-y-1">
+            <h4 className="leading-none font-medium">Fee target</h4>
+            <p className="text-muted-foreground text-sm">Tune how quickly the transaction should confirm.</p>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="fee-target">Blocks</Label>
+            <Input id="fee-target" defaultValue="6" />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+}
+
+export const Compact: Story = {
+  render: () => (
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant="secondary">
+          Details
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56" align="start">
+        <p className="text-sm">This jar has enough confirmed balance to be used for spending.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+}

--- a/src/stories/Popover.stories.tsx
+++ b/src/stories/Popover.stories.tsx
@@ -26,8 +26,8 @@ export const Default: Story = {
             <p className="text-muted-foreground text-sm">Tune how quickly the transaction should confirm.</p>
           </div>
           <div className="grid gap-2">
-            <Label htmlFor="fee-target">Blocks</Label>
-            <Input id="fee-target" defaultValue="6" />
+            <Label htmlFor="popover-fee-target-default">Blocks</Label>
+            <Input id="popover-fee-target-default" defaultValue="6" />
           </div>
         </div>
       </PopoverContent>

--- a/src/stories/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup.stories.tsx
@@ -15,12 +15,12 @@ export const Default: Story = {
   render: () => (
     <RadioGroup defaultValue="absolute">
       <div className="flex items-center gap-2">
-        <RadioGroupItem id="absolute" value="absolute" />
-        <Label htmlFor="absolute">Absolute fee</Label>
+        <RadioGroupItem id="radio-absolute" value="absolute" />
+        <Label htmlFor="radio-absolute">Absolute fee</Label>
       </div>
       <div className="flex items-center gap-2">
-        <RadioGroupItem id="relative" value="relative" />
-        <Label htmlFor="relative">Relative fee</Label>
+        <RadioGroupItem id="radio-relative" value="relative" />
+        <Label htmlFor="radio-relative">Relative fee</Label>
       </div>
     </RadioGroup>
   ),
@@ -30,12 +30,12 @@ export const DisabledOption: Story = {
   render: () => (
     <RadioGroup defaultValue="one">
       <div className="flex items-center gap-2">
-        <RadioGroupItem id="jar-one" value="one" />
-        <Label htmlFor="jar-one">Jar 1</Label>
+        <RadioGroupItem id="radio-jar-one" value="one" />
+        <Label htmlFor="radio-jar-one">Jar 1</Label>
       </div>
       <div className="flex items-center gap-2">
-        <RadioGroupItem id="jar-two" value="two" disabled />
-        <Label htmlFor="jar-two" className="text-muted-foreground">
+        <RadioGroupItem id="radio-jar-two" value="two" disabled />
+        <Label htmlFor="radio-jar-two" className="text-muted-foreground">
           Jar 2 disabled
         </Label>
       </div>
@@ -47,8 +47,8 @@ export const Invalid: Story = {
   render: () => (
     <RadioGroup aria-invalid="true">
       <div className="flex items-center gap-2">
-        <RadioGroupItem id="invalid-option" value="invalid" aria-invalid="true" />
-        <Label htmlFor="invalid-option">Needs attention</Label>
+        <RadioGroupItem id="radio-invalid-option" value="invalid" aria-invalid="true" />
+        <Label htmlFor="radio-invalid-option">Needs attention</Label>
       </div>
     </RadioGroup>
   ),

--- a/src/stories/RadioGroup.stories.tsx
+++ b/src/stories/RadioGroup.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Core/RadioGroup',
+  component: RadioGroup,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof RadioGroup>
+
+export const Default: Story = {
+  render: () => (
+    <RadioGroup defaultValue="absolute">
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="absolute" value="absolute" />
+        <Label htmlFor="absolute">Absolute fee</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="relative" value="relative" />
+        <Label htmlFor="relative">Relative fee</Label>
+      </div>
+    </RadioGroup>
+  ),
+}
+
+export const DisabledOption: Story = {
+  render: () => (
+    <RadioGroup defaultValue="one">
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="jar-one" value="one" />
+        <Label htmlFor="jar-one">Jar 1</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="jar-two" value="two" disabled />
+        <Label htmlFor="jar-two" className="text-muted-foreground">
+          Jar 2 disabled
+        </Label>
+      </div>
+    </RadioGroup>
+  ),
+}
+
+export const Invalid: Story = {
+  render: () => (
+    <RadioGroup aria-invalid="true">
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="invalid-option" value="invalid" aria-invalid="true" />
+        <Label htmlFor="invalid-option">Needs attention</Label>
+      </div>
+    </RadioGroup>
+  ),
+}

--- a/src/stories/Sheet.stories.tsx
+++ b/src/stories/Sheet.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Core/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Sheet>
+
+export const Default: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Wallet details</SheetTitle>
+          <SheetDescription>Review wallet status without leaving the current page.</SheetDescription>
+        </SheetHeader>
+        <div className="grid gap-3 px-4 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Confirmed balance</span>
+            <span>1,250,000 sats</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Maker status</span>
+            <span>Idle</span>
+          </div>
+        </div>
+        <SheetFooter>
+          <Button>Open wallet</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+}
+
+export const LeftSide: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open left sheet</Button>
+      </SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>Navigation</SheetTitle>
+          <SheetDescription>Small-screen sidebar style sheet.</SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  ),
+}

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+const meta: Meta<typeof Table> = {
+  title: 'Core/Table',
+  component: Table,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Table>
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <TableCaption>Recent wallet activity</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Type</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>Receive</TableCell>
+          <TableCell>
+            <Badge variant="secondary">Confirmed</Badge>
+          </TableCell>
+          <TableCell className="text-right">250,000 sats</TableCell>
+        </TableRow>
+        <TableRow data-state="selected">
+          <TableCell>Send</TableCell>
+          <TableCell>
+            <Badge variant="outline">Pending</Badge>
+          </TableCell>
+          <TableCell className="text-right">120,000 sats</TableCell>
+        </TableRow>
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={2}>Total</TableCell>
+          <TableCell className="text-right">370,000 sats</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+}
+
+export const Empty: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Jar</TableHead>
+          <TableHead>Balance</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell colSpan={2} className="text-muted-foreground text-center">
+            No jars found.
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+}

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Core/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Tabs>
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue="receive" className="w-[360px]">
+      <TabsList>
+        <TabsTrigger value="receive">Receive</TabsTrigger>
+        <TabsTrigger value="send">Send</TabsTrigger>
+        <TabsTrigger value="earn">Earn</TabsTrigger>
+      </TabsList>
+      <TabsContent value="receive" className="rounded-lg border p-4">
+        Receive funds into a wallet jar.
+      </TabsContent>
+      <TabsContent value="send" className="rounded-lg border p-4">
+        Send funds using a direct or collaborative transaction.
+      </TabsContent>
+      <TabsContent value="earn" className="rounded-lg border p-4">
+        Earn sats by providing liquidity.
+      </TabsContent>
+    </Tabs>
+  ),
+}
+
+export const DisabledTab: Story = {
+  render: () => (
+    <Tabs defaultValue="active" className="w-[360px]">
+      <TabsList>
+        <TabsTrigger value="active">Active</TabsTrigger>
+        <TabsTrigger value="disabled" disabled>
+          Disabled
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="active" className="rounded-lg border p-4">
+        Only active tabs can be selected.
+      </TabsContent>
+      <TabsContent value="disabled" className="rounded-lg border p-4">
+        Disabled content.
+      </TabsContent>
+    </Tabs>
+  ),
+}

--- a/src/stories/Textarea.stories.tsx
+++ b/src/stories/Textarea.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+const meta: Meta<typeof Textarea> = {
+  title: 'Core/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof Textarea>
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Write a note...',
+  },
+}
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="grid w-full max-w-sm gap-2">
+      <Label htmlFor="message">Message</Label>
+      <Textarea id="message" placeholder="Write your message..." />
+    </div>
+  ),
+}
+
+export const WithValue: Story = {
+  args: {
+    defaultValue: 'This is a longer value that shows how multiline content looks inside the textarea.',
+  },
+}
+
+export const Invalid: Story = {
+  args: {
+    placeholder: 'This field has an error',
+    'aria-invalid': true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disabled textarea',
+    disabled: true,
+  },
+}

--- a/src/stories/jam/Cheatsheet.stories.tsx
+++ b/src/stories/jam/Cheatsheet.stories.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Button } from '@/components/ui/button'
 import { Cheatsheet } from '@/components/ui/jam/Cheatsheet'
 
 const meta: Meta<typeof Cheatsheet> = {
   title: 'Jam/Cheatsheet',
   component: Cheatsheet,
   tags: ['autodocs'],
-  parameters: {
-    layout: 'fullscreen',
-  },
+  parameters: {},
 }
 export default meta
 
@@ -17,16 +16,14 @@ type Story = StoryObj<typeof Cheatsheet>
 const OpenCheatsheetStory = () => {
   const [open, setOpen] = useState(true)
 
-  return <Cheatsheet open={open} onOpenChange={setOpen} />
+  return (
+    <div className="h-screen">
+      <Button onClick={() => setOpen(true)}>Open</Button>
+      <Cheatsheet open={open} onOpenChange={setOpen} />
+    </div>
+  )
 }
 
 export const Open: Story = {
   render: () => <OpenCheatsheetStory />,
-}
-
-export const Closed: Story = {
-  args: {
-    open: false,
-    onOpenChange: () => undefined,
-  },
 }

--- a/src/stories/jam/Cheatsheet.stories.tsx
+++ b/src/stories/jam/Cheatsheet.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router-dom'
+import { Cheatsheet } from '@/components/ui/jam/Cheatsheet'
+
+const meta: Meta<typeof Cheatsheet> = {
+  title: 'Jam/Cheatsheet',
+  component: Cheatsheet,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <div className="min-h-[640px]">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof Cheatsheet>
+
+export const Open: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => undefined,
+  },
+}
+
+export const Closed: Story = {
+  args: {
+    ...Open.args,
+    open: false,
+  },
+}

--- a/src/stories/jam/Cheatsheet.stories.tsx
+++ b/src/stories/jam/Cheatsheet.stories.tsx
@@ -1,20 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { MemoryRouter } from 'react-router-dom'
 import { Cheatsheet } from '@/components/ui/jam/Cheatsheet'
 
 const meta: Meta<typeof Cheatsheet> = {
   title: 'Jam/Cheatsheet',
   component: Cheatsheet,
   tags: ['autodocs'],
-  decorators: [
-    (Story) => (
-      <MemoryRouter>
-        <div className="min-h-[640px]">
-          <Story />
-        </div>
-      </MemoryRouter>
-    ),
-  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
 }
 export default meta
 

--- a/src/stories/jam/Cheatsheet.stories.tsx
+++ b/src/stories/jam/Cheatsheet.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Cheatsheet } from '@/components/ui/jam/Cheatsheet'
 
@@ -13,16 +14,19 @@ export default meta
 
 type Story = StoryObj<typeof Cheatsheet>
 
+const OpenCheatsheetStory = () => {
+  const [open, setOpen] = useState(true)
+
+  return <Cheatsheet open={open} onOpenChange={setOpen} />
+}
+
 export const Open: Story = {
-  args: {
-    open: true,
-    onOpenChange: () => undefined,
-  },
+  render: () => <OpenCheatsheetStory />,
 }
 
 export const Closed: Story = {
   args: {
-    ...Open.args,
     open: false,
+    onOpenChange: () => undefined,
   },
 }

--- a/src/stories/jam/ClickableJar.stories.tsx
+++ b/src/stories/jam/ClickableJar.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ClickableJar } from '@/components/ui/jam/ClickableJar'
+
+const meta: Meta<typeof ClickableJar> = {
+  title: 'Jam/ClickableJar',
+  component: ClickableJar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof ClickableJar>
+
+export const Default: Story = {
+  args: {
+    name: 'Spending',
+    color: '#3498db',
+    totalBalance: 210_000,
+    availableBalance: 190_000,
+    frozenOrLockedBalance: 20_000,
+    totalWalletBalance: 500_000,
+    onClick: () => alert('Jar clicked'),
+  },
+}
+
+export const Selected: Story = {
+  args: {
+    ...Default.args,
+    name: 'Savings',
+    color: '#27ae60',
+    isSelected: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    name: 'Archive',
+    color: '#f39c12',
+    disabled: true,
+  },
+}

--- a/src/stories/jam/ClickableJar.stories.tsx
+++ b/src/stories/jam/ClickableJar.stories.tsx
@@ -40,5 +40,6 @@ export const Disabled: Story = {
     name: 'Archive',
     color: '#f39c12',
     disabled: true,
+    onClick: undefined,
   },
 }

--- a/src/stories/jam/CopyButton.stories.tsx
+++ b/src/stories/jam/CopyButton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { CopyIcon } from 'lucide-react'
+import { CheckIcon, CopyIcon } from 'lucide-react'
+import { buttonVariants } from '@/components/ui/button-variants'
 import { CopyButton } from '@/components/ui/jam/CopyButton'
 
 const meta: Meta<typeof CopyButton> = {
@@ -7,25 +8,69 @@ const meta: Meta<typeof CopyButton> = {
   component: CopyButton,
   tags: ['autodocs'],
   args: {
-    value: 'bc1qexampleaddress000000000000000000000000000',
-    text: (
-      <span className="inline-flex items-center gap-2">
-        <CopyIcon className="h-4 w-4" />
-        Copy address
-      </span>
-    ),
+    value: 'value',
+    text: 'Copy',
     successText: 'Copied',
-    className: 'rounded-md border px-3 py-2 text-sm hover:bg-accent',
   },
 }
 export default meta
 
 type Story = StoryObj<typeof CopyButton>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {},
+}
+
+export const ButtonStyle: Story = {
+  args: {
+    text: (
+      <>
+        <CopyIcon className="size-4" />
+        Copy
+      </>
+    ),
+    successText: (
+      <>
+        <CheckIcon className="size-4 text-green-500" />
+        Copied
+      </>
+    ),
+    className: buttonVariants({
+      size: 'lg',
+      variant: 'outline',
+    }),
+  },
+}
+
+export const Callbacks: Story = {
+  args: {
+    text: (
+      <>
+        <CopyIcon className="size-4" />
+        Copy
+      </>
+    ),
+    successText: (
+      <>
+        <CheckIcon className="size-4 text-green-500" />
+        Copied
+      </>
+    ),
+    onSuccess: () => alert('onSuccess'),
+    onError: () => alert('onError'),
+    className: buttonVariants({
+      size: 'sm',
+      variant: 'default',
+    }),
+  },
+}
 
 export const Disabled: Story = {
   args: {
     disabled: true,
+    className: buttonVariants({
+      size: 'xs',
+      variant: 'outline',
+    }),
   },
 }

--- a/src/stories/jam/CopyButton.stories.tsx
+++ b/src/stories/jam/CopyButton.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CopyIcon } from 'lucide-react'
+import { CopyButton } from '@/components/ui/jam/CopyButton'
+
+const meta: Meta<typeof CopyButton> = {
+  title: 'Jam/CopyButton',
+  component: CopyButton,
+  tags: ['autodocs'],
+  args: {
+    value: 'bc1qexampleaddress000000000000000000000000000',
+    text: (
+      <span className="inline-flex items-center gap-2">
+        <CopyIcon className="h-4 w-4" />
+        Copy address
+      </span>
+    ),
+    successText: 'Copied',
+    className: 'rounded-md border px-3 py-2 text-sm hover:bg-accent',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof CopyButton>
+
+export const Default: Story = {}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}

--- a/src/stories/jam/CurrencySymbol.stories.tsx
+++ b/src/stories/jam/CurrencySymbol.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CurrencySymbol } from '@/components/ui/jam/CurrencySymbol'
+
+const meta: Meta<typeof CurrencySymbol> = {
+  title: 'Jam/CurrencySymbol',
+  component: CurrencySymbol,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof CurrencySymbol>
+
+export const Bitcoin: Story = {
+  args: {
+    currency: 'btc',
+  },
+}
+
+export const Sats: Story = {
+  args: {
+    currency: 'sats',
+  },
+}
+
+export const Private: Story = {
+  args: {
+    currency: 'btc',
+    isPrivate: true,
+  },
+}
+
+export const Inline: Story = {
+  render: () => (
+    <div className="flex items-center gap-4 text-2xl">
+      <span>
+        <CurrencySymbol currency="btc" /> BTC
+      </span>
+      <span>
+        <CurrencySymbol currency="sats" /> sats
+      </span>
+      <span>
+        <CurrencySymbol currency="btc" isPrivate /> hidden
+      </span>
+    </div>
+  ),
+}

--- a/src/stories/jam/FeeConfigErrorAlert.stories.tsx
+++ b/src/stories/jam/FeeConfigErrorAlert.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
+
+const meta: Meta<typeof FeeConfigErrorAlert> = {
+  title: 'Jam/FeeConfigErrorAlert',
+  component: FeeConfigErrorAlert,
+  tags: ['autodocs'],
+  args: {
+    onOpenFeeConfig: () => alert('Open fee configuration'),
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof FeeConfigErrorAlert>
+
+export const Default: Story = {}
+
+export const WithSpacing: Story = {
+  args: {
+    className: 'max-w-2xl',
+  },
+}

--- a/src/stories/jam/JarIcon.stories.tsx
+++ b/src/stories/jam/JarIcon.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { JarIcon } from '@/components/ui/jam/JarIcon'
+
+const meta: Meta<typeof JarIcon> = {
+  title: 'Jam/JarIcon',
+  component: JarIcon,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof JarIcon>
+
+export const Empty: Story = {
+  args: {
+    color: '#e2b86a',
+    totalBalance: 0,
+    totalWalletBalance: 100_000,
+  },
+}
+
+export const HalfFull: Story = {
+  args: {
+    color: '#27ae60',
+    totalBalance: 50_000,
+    totalWalletBalance: 100_000,
+  },
+}
+
+export const Selected: Story = {
+  args: {
+    ...HalfFull.args,
+    isSelected: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    ...HalfFull.args,
+    disabled: true,
+  },
+}
+
+export const FillLevels: Story = {
+  render: () => (
+    <div className="flex items-end gap-6">
+      {[0, 10_000, 30_000, 60_000].map((totalBalance) => (
+        <JarIcon key={totalBalance} color="#3498db" totalBalance={totalBalance} totalWalletBalance={100_000} />
+      ))}
+    </div>
+  ),
+}

--- a/src/stories/jam/MaskedText.stories.tsx
+++ b/src/stories/jam/MaskedText.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MaskedText } from '@/components/ui/jam/MaskedText'
+
+const meta: Meta<typeof MaskedText> = {
+  title: 'Jam/MaskedText',
+  component: MaskedText,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof MaskedText>
+
+export const Revealed: Story = {
+  args: {
+    masked: false,
+    children: 'correct horse battery staple',
+  },
+}
+
+export const Masked: Story = {
+  args: {
+    masked: true,
+    children: 'correct horse battery staple',
+  },
+}
+
+export const CustomMaskedText: Story = {
+  args: {
+    masked: true,
+    maskedText: '•••• •••• •••• ••••',
+    children: 'correct horse battery staple',
+  },
+}
+
+export const Comparison: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2 font-mono">
+      <MaskedText masked={false}>visible wallet seed word</MaskedText>
+      <MaskedText masked>hidden wallet seed word</MaskedText>
+    </div>
+  ),
+}

--- a/src/stories/jam/PageLoading.stories.tsx
+++ b/src/stories/jam/PageLoading.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PageLoading } from '@/components/ui/jam/PageLoading'
+
+const meta: Meta<typeof PageLoading> = {
+  title: 'Jam/PageLoading',
+  component: PageLoading,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof PageLoading>
+
+export const Default: Story = {}

--- a/src/stories/jam/PageTitle.stories.tsx
+++ b/src/stories/jam/PageTitle.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import PageTitle from '@/components/ui/jam/PageTitle'
+
+const meta: Meta<typeof PageTitle> = {
+  title: 'Jam/PageTitle',
+  component: PageTitle,
+  tags: ['autodocs'],
+  args: {
+    title: 'Earn',
+    subtitle: 'Offer liquidity to the market while keeping your sats under your control.',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof PageTitle>
+
+export const Default: Story = {}
+
+export const Centered: Story = {
+  args: {
+    title: 'Wallet ready',
+    subtitle: 'Your wallet is loaded and ready to use.',
+    center: true,
+  },
+}
+
+export const Error: Story = {
+  args: {
+    title: 'Wallet could not load',
+    subtitle: 'Check your connection and try again.',
+    variant: 'error',
+  },
+}

--- a/src/stories/jam/SortIcon.stories.tsx
+++ b/src/stories/jam/SortIcon.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Column } from '@tanstack/react-table'
+import { SortIcon } from '@/components/ui/jam/SortIcon'
+
+type SortDirection = false | 'asc' | 'desc'
+
+const createColumn = (direction: SortDirection, meta?: Record<string, boolean>) =>
+  ({
+    getIsSorted: () => direction,
+    columnDef: {
+      meta,
+    },
+  }) as Column<unknown, unknown>
+
+const meta: Meta<typeof SortIcon> = {
+  title: 'Jam/SortIcon',
+  component: SortIcon,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof SortIcon>
+
+export const Unsorted: Story = {
+  args: {
+    column: createColumn(false),
+    className: 'size-5',
+  },
+}
+
+export const GenericAscending: Story = {
+  args: {
+    column: createColumn('asc'),
+    className: 'size-5',
+  },
+}
+
+export const NumericDescending: Story = {
+  args: {
+    column: createColumn('desc', { numeric: true }),
+    className: 'size-5',
+  },
+}
+
+export const AlphabeticAscending: Story = {
+  args: {
+    column: createColumn('asc', { alphabetic: true }),
+    className: 'size-5',
+  },
+}
+
+export const All: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      <SortIcon column={createColumn(false)} className="size-5" />
+      <SortIcon column={createColumn('asc')} className="size-5" />
+      <SortIcon column={createColumn('desc')} className="size-5" />
+      <SortIcon column={createColumn('asc', { numeric: true })} className="size-5" />
+      <SortIcon column={createColumn('desc', { alphabetic: true })} className="size-5" />
+    </div>
+  ),
+}

--- a/src/stories/jam/TablePagination.stories.tsx
+++ b/src/stories/jam/TablePagination.stories.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TablePagination } from '@/components/ui/jam/TablePagination'
+
+const meta: Meta<typeof TablePagination> = {
+  title: 'Jam/TablePagination',
+  component: TablePagination,
+  tags: ['autodocs'],
+}
+export default meta
+
+type Story = StoryObj<typeof TablePagination>
+
+export const Default: Story = {
+  args: {
+    currentPage: 2,
+    totalPages: 8,
+    itemsPerPage: 25,
+    totalItems: 183,
+    onPageChange: () => undefined,
+    onItemsPerPageChange: () => undefined,
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    ...Default.args,
+    currentPage: 1,
+    totalPages: 1,
+    totalItems: 0,
+  },
+}
+
+export const Interactive: Story = {
+  render: () => {
+    const [currentPage, setCurrentPage] = useState(1)
+    const [itemsPerPage, setItemsPerPage] = useState(25)
+
+    return (
+      <TablePagination
+        currentPage={currentPage}
+        totalPages={8}
+        itemsPerPage={itemsPerPage}
+        totalItems={183}
+        onPageChange={setCurrentPage}
+        onItemsPerPageChange={(newItemsPerPage) => {
+          setItemsPerPage(newItemsPerPage)
+          setCurrentPage(1)
+        }}
+      />
+    )
+  },
+}

--- a/src/stories/jam/TablePagination.stories.tsx
+++ b/src/stories/jam/TablePagination.stories.tsx
@@ -35,13 +35,15 @@ export const Interactive: Story = {
   render: () => {
     const [currentPage, setCurrentPage] = useState(1)
     const [itemsPerPage, setItemsPerPage] = useState(25)
+    const totalItems = 183
+    const totalPages = itemsPerPage === -1 ? 1 : Math.max(1, Math.ceil(totalItems / itemsPerPage))
 
     return (
       <TablePagination
         currentPage={currentPage}
-        totalPages={8}
+        totalPages={totalPages}
         itemsPerPage={itemsPerPage}
-        totalItems={183}
+        totalItems={totalItems}
         onPageChange={setCurrentPage}
         onItemsPerPageChange={(newItemsPerPage) => {
           setItemsPerPage(newItemsPerPage)

--- a/src/stories/jam/WalletLoadErrorAlert.stories.tsx
+++ b/src/stories/jam/WalletLoadErrorAlert.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { WalletLoadErrorAlert } from '@/components/ui/jam/WalletLoadErrorAlert'
+
+const meta: Meta<typeof WalletLoadErrorAlert> = {
+  title: 'Jam/WalletLoadErrorAlert',
+  component: WalletLoadErrorAlert,
+  tags: ['autodocs'],
+  args: {
+    reason: 'Connection refused while loading wallet data.',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof WalletLoadErrorAlert>
+
+export const Default: Story = {}
+
+export const UnknownReason: Story = {
+  args: {
+    reason: undefined,
+  },
+}


### PR DESCRIPTION
Adds Storybook coverage for reusable Jam and core UI components so they can be inspected in isolation across common states and layouts.

This PR keeps the scope focused on component stories only:
- Adds stories for reusable Jam UI pieces like page title, loading/error alerts, copy/masked text, jar helpers, cheatsheet, sorting, and table pagination.
- Adds stories for core primitives like checkbox, radio group, tabs, textarea, dialog, field, input group, dropdown menu, popover, sheet, table, and pagination.
- Keeps stories small and useful for reviewing component states, variants, and responsive behavior.
- Avoids full page-flow stories for now, since those are broader and can be handled later if needed.
- Leaves GitHub Pages deployment as a separate follow-up task/PR.

This follows the direction we discussed :
- Do not split this too fine-grained per component; one Storybook coverage pass is enough.
- Think from a UI/design review perspective and cover components that are useful to inspect.
- Use Storybook as a base for future mobile/small-screen UI checks and iterative improvements.

fixes a part of #1246 
