### PR TITLE
chore(ui): improve activity indicators

### DIFF
--- a/src/components/layout/AppNavbar.tsx
+++ b/src/components/layout/AppNavbar.tsx
@@ -1,4 +1,3 @@
-import { type PropsWithChildren } from 'react'
 import type { SessionResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { useMutation } from '@tanstack/react-query'
 import type { TFunction } from 'i18next'
@@ -15,24 +14,10 @@ import { routes } from '@/constants/routes'
 import type { RescanInfo } from '@/context/JamSessionInfoContext'
 import { cn, shortenStringMiddle } from '@/lib/utils'
 import type { AmountSats } from '@/types/global'
+import { WithActivityIndicator } from '../ui/jam/ActivityIndicator'
 import { Balance } from '../ui/jam/Balance'
 import { Spinner } from '../ui/spinner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
-
-const WithActivityIndicator = ({ active, children }: PropsWithChildren<{ active: boolean }>) => {
-  return (
-    <span className="relative">
-      {children}
-      <span
-        className={cn('absolute -top-1 -right-2 text-[8px]', {
-          'light:text-green-600 text-green-300 motion-safe:animate-pulse': active,
-        })}
-      >
-        ●
-      </span>
-    </span>
-  )
-}
 
 type WalletPreviewProps = {
   isLoading?: boolean

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -13,6 +13,7 @@ import { cn, shortenStringMiddle, walletDisplayName } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { Field, FieldLabel } from '../ui/field'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
+import { ActivityIndicator } from '../ui/jam/ActivityIndicator'
 
 const LoginFormSkeleton = () => {
   return (
@@ -120,9 +121,7 @@ export const LoginFormComponent = ({
                   {shortenStringMiddle(walletDisplayName(wallet), 32)}
                   {activeWallet === wallet ? (
                     <span className="text-muted-foreground/50 inline-flex items-center gap-1.5 py-1 text-xs">
-                      {(makerRunning || coinjoinInProgress) && (
-                        <span className="light:bg-green-600 h-2 w-2 rounded-full bg-green-300/90 motion-safe:animate-pulse" />
-                      )}
+                      <ActivityIndicator active={makerRunning || coinjoinInProgress} />
                       {t('wallets.wallet_preview.wallet_active')}
                     </span>
                   ) : undefined}

--- a/src/components/ui/jam/ActivityIndicator.tsx
+++ b/src/components/ui/jam/ActivityIndicator.tsx
@@ -1,0 +1,31 @@
+import type { PropsWithChildren } from 'react'
+import { cn } from '@/lib/utils'
+
+type ActivityIndicatorProps = {
+  active?: boolean
+  animateEnter?: boolean
+  className?: string
+}
+
+export const ActivityIndicator = ({ active = true, animateEnter = false, className }: ActivityIndicatorProps) => {
+  return (
+    <span
+      className={cn('relative flex size-2', className, {
+        hidden: !active,
+        'animate-in fade-in-0 zoom-in-0 duration-2000': animateEnter,
+      })}
+    >
+      <span className="light:bg-green-500 absolute inline-flex h-full w-full animate-ping rounded-full bg-green-200 opacity-75 [animation-duration:_2.1s]" />
+      <span className="light:bg-green-600 relative inline-flex size-2 rounded-full bg-green-300" />
+    </span>
+  )
+}
+
+export const WithActivityIndicator = ({ children, ...props }: PropsWithChildren<ActivityIndicatorProps>) => {
+  return (
+    <span className="relative">
+      {children}
+      <ActivityIndicator animateEnter {...props} className={cn('absolute -top-0.5 -right-3', props.className)} />
+    </span>
+  )
+}

--- a/src/stories/jam/ActivityIndicator.stories.tsx
+++ b/src/stories/jam/ActivityIndicator.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ActivityIndicator, WithActivityIndicator } from '@/components/ui/jam/ActivityIndicator'
+
+const meta: Meta<typeof ActivityIndicator> = {
+  title: 'Jam/ActivityIndicator',
+  component: ActivityIndicator,
+  tags: ['autodocs'],
+  args: {
+    animateEnter: true,
+  },
+  argTypes: {
+    animateEnter: {
+      description: 'Enable enter animation',
+      control: 'boolean',
+    },
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof ActivityIndicator>
+
+export const Default: Story = {
+  args: {},
+}
+
+export const ElementWithActivityIndicator: Story = {
+  render: () => <WithActivityIndicator>Acitivty Text</WithActivityIndicator>,
+}

--- a/src/stories/jam/ActivityIndicator.stories.tsx
+++ b/src/stories/jam/ActivityIndicator.stories.tsx
@@ -24,5 +24,5 @@ export const Default: Story = {
 }
 
 export const ElementWithActivityIndicator: Story = {
-  render: () => <WithActivityIndicator>Acitivty Text</WithActivityIndicator>,
+  render: () => <WithActivityIndicator>Activity Text</WithActivityIndicator>,
 }


### PR DESCRIPTION
Improve activity indicators on navbar items and login wallet select.
Use `animate-ping` with a slowed down animation duration.

## Test
Run `npm run storybook:up` and see http://localhost:6006/?path=/docs/jam-activityindicator--docs