### PR TITLE
chore(storybook): deploy Storybook preview to GitHub Pages

### DIFF
--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -1,0 +1,77 @@
+name: Storybook Pages
+
+on:
+  push:
+    branches: [devel]
+    paths:
+      - '.github/workflows/storybook-pages.yml'
+      - '.storybook/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+  pull_request:
+    branches: [devel]
+    paths:
+      - '.github/workflows/storybook-pages.yml'
+      - '.storybook/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: storybook-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['v24.11.1']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup (Node.js ${{ matrix.node-version }})
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: npm clean-install --no-audit --no-fund
+
+      - name: Build Storybook
+        run: npm run storybook:build:pages
+
+      - name: Prepare Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+        run: touch storybook-static/.nojekyll
+
+      - name: Configure Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: storybook-static
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -1,22 +1,10 @@
-name: Storybook Pages
+name: Deploy Storybook
 
 on:
   push:
-    branches: [devel]
-    paths:
-      - '.github/workflows/storybook-pages.yml'
-      - '.storybook/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'src/**'
-  pull_request:
-    branches: [devel]
-    paths:
-      - '.github/workflows/storybook-pages.yml'
-      - '.storybook/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'src/**'
+    branches:
+      - devel
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -24,54 +12,39 @@ permissions:
   id-token: write
 
 concurrency:
-  group: storybook-pages-${{ github.ref }}
-  cancel-in-progress: true
+  group: storybook-pages
+  cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['v24.11.1']
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup (Node.js ${{ matrix.node-version }})
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install
-        run: npm clean-install --no-audit --no-fund
-
-      - name: Build Storybook
-        run: npm run storybook:build:pages
-
-      - name: Prepare Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
-        run: touch storybook-static/.nojekyll
-
-      - name: Configure Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
-        uses: actions/configure-pages@v5
-
-      - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: storybook-static
-
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
-    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install
+        run: npm clean-install --no-audit --no-fund
+
+      - name: Build Storybook
+        run: npm run storybook:build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: storybook-static
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -24,7 +24,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: storybook-pages
+  group: storybook-pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -43,10 +43,10 @@ npm run storybook:up
 Build the static Storybook preview with:
 
 ```bash
-npm run storybook:build:pages
+npm run storybook:build
 ```
 
-The Storybook Pages workflow builds Storybook on pull requests and publishes the latest `devel` version through GitHub Pages once Pages is configured to use GitHub Actions as its source.
+The Storybook Pages workflow publishes the latest `devel` version through GitHub Pages once Pages is configured to use GitHub Actions as its source.
 
 Hosted preview:
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -30,6 +30,30 @@ JMOBWATCH_PORT=8080 \
 npm run dev
 ```
 
+## Storybook
+
+Storybook is used to inspect reusable UI and Jam components in isolation without running a full wallet flow.
+
+Run it locally with:
+
+```bash
+npm run storybook:up
+```
+
+Build the static Storybook preview with:
+
+```bash
+npm run storybook:build:pages
+```
+
+The Storybook Pages workflow builds Storybook on pull requests and publishes the latest `devel` version through GitHub Pages once Pages is configured to use GitHub Actions as its source.
+
+Hosted preview:
+
+```text
+https://joinmarket-webui.github.io/jam/
+```
+
 ## Linting
 
 We use Create React App's [default ESLint integration](https://create-react-app.dev/docs/setting-up-your-editor/#displaying-lint-output-in-the-editor).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "preview": "vite preview",
     "storybook:up": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "storybook:build:pages": "storybook build --output-dir storybook-static",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:storybook": "vitest run --project storybook",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "preview": "vite preview",
     "storybook:up": "storybook dev -p 6006",
     "storybook:build": "storybook build",
+    "storybook:build:pages": "storybook build --output-dir storybook-static",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:storybook": "vitest run --project storybook",


### PR DESCRIPTION
summary
add a Storybook static build script
add a GitHub Pages workflow that builds Storybook on PRs and deploys latest devel
document the local Storybook build command and hosted preview URL

note
It's a deployment-only follow-up to #1247 !!
