### PR TITLE
fix: soft display query reloading

### DIFF
--- a/.github/workflows/storybook-build.yml
+++ b/.github/workflows/storybook-build.yml
@@ -7,11 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout

--- a/src/context/JamWalletInfoContext.ts
+++ b/src/context/JamWalletInfoContext.ts
@@ -1,8 +1,7 @@
 import { createContext, useContext, type Dispatch, type SetStateAction } from 'react'
 import type { ErrorMessage, WalletDisplayResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { Network, type AddressInfo } from 'bitcoin-address-validation'
-import type { UseQueryDisplayWalletResult } from '@/hooks/useQueryDisplayWallet'
-import type { FidelityBondUtxo, UseQueryUtxosResult, Utxo, UtxoId } from '@/hooks/useQueryUtxos'
+import type { FidelityBondUtxo, Utxo, UtxoId } from '@/hooks/useQueryUtxos'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import type { AmountSats, BitcoinAddress, HdPath, JarIndex, Milliseconds } from '@/types/global'
 
@@ -98,9 +97,6 @@ interface JamWalletInfoContextType {
   isFetching: boolean
   error: Error | ErrorMessage | null
   refetch: (options?: WalletRefetchOptions) => Promise<BalanceSummary>
-
-  utxosQueryResult: UseQueryUtxosResult['queryResult']
-  displayWalletQueryResult: UseQueryDisplayWalletResult['queryResult']
 }
 
 export const JamWalletInfoContext = createContext<JamWalletInfoContextType | undefined>(undefined)

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -264,8 +264,6 @@ export const JamWalletInfoContextProvider = ({
     isFetching: refetchIsPending || utxosQueryResult.isFetching || displayWalletQueryResult.isFetching,
     error: utxosQueryResult.error || displayWalletQueryResult.error,
     refetch: refetchMutateAsync,
-    utxosQueryResult: utxosQueryResult,
-    displayWalletQueryResult: displayWalletQueryResult,
   }
 
   return <JamWalletInfoContext.Provider value={value}>{children}</JamWalletInfoContext.Provider>

--- a/src/hooks/useQueryDisplayWallet.ts
+++ b/src/hooks/useQueryDisplayWallet.ts
@@ -29,11 +29,10 @@ export function useQueryDisplayWallet({
 
   const displaywalletQueryOptions = displaywalletOptions({
     client,
-    path: { walletname: walletFileName || '' },
-    query: {
-      // cache busting: reload whenever local utxos change
-      '#cb': utxosHashHex,
-    } as never,
+    path: { walletname: walletFileName },
+    meta: {
+      cacheBuster: utxosHashHex,
+    },
   })
 
   const queryResult = useQuery({


### PR DESCRIPTION
- Soft reload display query: does not change `isLoading` state when `utxoHashHex` is moved from "query" to "meta"
- Remove unused `utxosQueryResult` and `displayWalletQueryResult` from `JamWalletInfoContextType`
