### PR TITLE
fix: handle locale-specific decimal separators in BTC balance

### DIFF
--- a/src/components/ui/jam/Balance.tsx
+++ b/src/components/ui/jam/Balance.tsx
@@ -67,10 +67,16 @@ const BitcoinBalance = ({
   ...props
 }: BitcoinBalanceProps) => {
   const numberString = formatBtc(satsToBtc(String(value)))
-  // Normalise locale-specific decimal separators (e.g. "," in it-IT) to "."
+  // Normalise locale-specific decimal separators to "." and strip
+  // thousands separators (e.g. it-IT "12.345,67890123" → "12345.67890123").
   const normalizedString = numberString.replace(
-    /^([^.,]*)[.,](\d+)$/,
-    (_m, intPart, fracPart) => `${intPart}.${fracPart}`
+    /^([\d.,]*[.,])?([^.,]*)[.,](\d+)$|^([^.,]+)$/,
+    (_m, _preamble, intPart, fracPart, _whole) => {
+      if (intPart !== undefined) {
+        return `${intPart.replace(/[.,]/g, "")}.${fracPart}`
+      }
+      return _m  // no decimal separator, leave as-is
+    }
   )
   const [rawIntegerPart, fractionalPart] = normalizedString.split(DECIMAL_POINT_CHAR)
 

--- a/src/components/ui/jam/Balance.tsx
+++ b/src/components/ui/jam/Balance.tsx
@@ -67,7 +67,12 @@ const BitcoinBalance = ({
   ...props
 }: BitcoinBalanceProps) => {
   const numberString = formatBtc(satsToBtc(String(value)))
-  const [rawIntegerPart, fractionalPart] = numberString.split(DECIMAL_POINT_CHAR)
+  // Normalise locale-specific decimal separators (e.g. "," in it-IT) to "."
+  const normalizedString = numberString.replace(
+    /^([^.,]*)[.,](\d+)$/,
+    (_m, intPart, fracPart) => `${intPart}.${fracPart}`
+  )
+  const [rawIntegerPart, fractionalPart] = normalizedString.split(DECIMAL_POINT_CHAR)
 
   const fractionPartArray = [...fractionalPart]
   const sign = ['-', '+'].includes(rawIntegerPart[0]) ? rawIntegerPart[0] : undefined

--- a/src/components/ui/jam/Balance.tsx
+++ b/src/components/ui/jam/Balance.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState, type MouseEvent, type MouseEventHandler, 
 import { SnowflakeIcon } from 'lucide-react'
 import { CurrencySymbol } from '@/components/ui/jam/CurrencySymbol'
 import { useJamDisplayContext } from '@/context/JamDisplayContext'
-import { cn, satsToBtc, tryBtcToSat, isValidNumber, formatBtc, formatSats } from '@/lib/utils'
+import { cn, satsToBtc, tryBtcToSat, isValidNumber, getBtcParts, formatSats } from '@/lib/utils'
 import type { AmountSats, Currency } from '@/types/global'
 import styles from './Balance.module.css'
 
@@ -66,23 +66,10 @@ const BitcoinBalance = ({
   highlightSignificantDigits = true,
   ...props
 }: BitcoinBalanceProps) => {
-  const numberString = formatBtc(satsToBtc(String(value)))
-  // Normalise locale-specific decimal separators to "." and strip
-  // thousands separators (e.g. it-IT "12.345,67890123" → "12345.67890123").
-  const normalizedString = numberString.replace(
-    /^([\d.,]*[.,])?([^.,]*)[.,](\d+)$|^([^.,]+)$/,
-    (_m, _preamble, intPart, fracPart, _whole) => {
-      if (intPart !== undefined) {
-        return `${intPart.replace(/[.,]/g, "")}.${fracPart}`
-      }
-      return _m  // no decimal separator, leave as-is
-    }
-  )
-  const [rawIntegerPart, fractionalPart] = normalizedString.split(DECIMAL_POINT_CHAR)
+  const btcValue = satsToBtc(String(value))
+  const { sign, integerPart, fractionalPart, formatted } = getBtcParts(btcValue)
 
   const fractionPartArray = [...fractionalPart]
-  const sign = ['-', '+'].includes(rawIntegerPart[0]) ? rawIntegerPart[0] : undefined
-  const integerPart = sign !== undefined ? rawIntegerPart.slice(1) : rawIntegerPart
   const integerPartIsZero = integerPart === '0'
   const fractionalPartStartsWithZero = fractionPartArray[0] === '0'
 
@@ -97,7 +84,7 @@ const BitcoinBalance = ({
         data-integer-part-is-zero={integerPartIsZero}
         data-fractional-part-starts-with-zero={fractionalPartStartsWithZero}
         data-raw-value={value}
-        data-formatted-value={numberString}
+        data-formatted-value={formatted}
       >
         {sign && <span>{sign}</span>}
         <span className={styles.integerPart}>{integerPart}</span>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -37,7 +37,7 @@ import {
 import type { WalletFileName } from './utils'
 
 const withRuntimeLocale = (locale: string, callback: () => void) => {
-  const toLocaleStringMock = vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
+  const numberToLocaleStringMock = vi.spyOn(Number.prototype, 'toLocaleString').mockImplementation(function (
     this: number,
     locales,
     options,
@@ -48,7 +48,7 @@ const withRuntimeLocale = (locale: string, callback: () => void) => {
   try {
     callback()
   } finally {
-    toLocaleStringMock.mockRestore()
+    numberToLocaleStringMock.mockRestore()
   }
 }
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -579,6 +579,14 @@ describe('formatSats', () => {
       expect(formatBtc(21000000)).toBe('2,10,00,000.00000000')
       expect(formatSats(2100000000000000)).toBe('2,10,00,00,00,00,00,000')
     })
+    withRuntimeLocale('it-IT', () => {
+      expect(formatBtc(21000000)).toBe('21.000.000,00000000')
+      expect(formatSats(2100000000000000)).toBe('2.100.000.000.000.000')
+    })
+    withRuntimeLocale('ar-EG', () => {
+      expect(formatBtc(21000000)).toBe('٢١٬٠٠٠٬٠٠٠٫٠٠٠٠٠٠٠٠')
+      expect(formatSats(2100000000000000)).toBe('٢٬١٠٠٬٠٠٠٬٠٠٠٬٠٠٠٬٠٠٠')
+    })
   })
 })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -18,6 +18,7 @@ import {
   parseSemanticVersion,
   UNKNOWN_VERSION,
   formatBtc,
+  getBtcParts,
   formatSats,
   BTC,
   SATS,
@@ -510,6 +511,42 @@ describe('formatBtc', () => {
   it('should handle negative BTC values', () => {
     expect(formatBtc(-1)).toBe('-1.00000000')
     expect(formatBtc(-0.12345678)).toBe('-0.12345678')
+  })
+})
+
+describe('getBtcParts', () => {
+  it('should decompose a BTC value into semantic parts', () => {
+    const parts = getBtcParts(1.5)
+    expect(parts.integerPart).toBe('1')
+    expect(parts.fractionalPart).toBe('50000000')
+    expect(parts.sign).toBeUndefined()
+    expect(parts.formatted).toBe('1.50000000')
+  })
+
+  it('should handle negative values', () => {
+    const parts = getBtcParts(-0.12345678)
+    expect(parts.sign).toBe('-')
+    expect(parts.integerPart).toBe('0')
+    expect(parts.fractionalPart).toBe('12345678')
+  })
+
+  it('should handle zero', () => {
+    const parts = getBtcParts(0)
+    expect(parts.integerPart).toBe('0')
+    expect(parts.fractionalPart).toBe('00000000')
+    expect(parts.sign).toBeUndefined()
+  })
+
+  it('should handle large values with grouping', () => {
+    const parts = getBtcParts(21000000)
+    expect(parts.integerPart).toBe('21000000')
+    expect(parts.fractionalPart).toBe('00000000')
+  })
+
+  it('should handle very small values', () => {
+    const parts = getBtcParts(0.00000001)
+    expect(parts.integerPart).toBe('0')
+    expect(parts.fractionalPart).toBe('00000001')
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -157,12 +157,14 @@ export const isValidInteger = (val: unknown): val is number => {
   return Number.isSafeInteger(val)
 }
 
+const BTC_NUMBER_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  minimumFractionDigits: 8,
+  maximumFractionDigits: 8,
+  roundingMode: 'trunc',
+}
+
 export const formatBtc = (value: number) => {
-  return value.toLocaleString(undefined, {
-    minimumFractionDigits: 8,
-    maximumFractionDigits: 8,
-    roundingMode: 'trunc',
-  })
+  return value.toLocaleString(undefined, BTC_NUMBER_FORMAT_OPTIONS)
 }
 
 export interface BtcParts {
@@ -181,11 +183,7 @@ export interface BtcParts {
  * Handles all locales including it-IT (12.345,67890123) and ar-EG (١٢٬٣٤٥٫٦٧٨٩٠١٢٣).
  */
 export const getBtcParts = (value: number): BtcParts => {
-  const parts = new Intl.NumberFormat(undefined, {
-    minimumFractionDigits: 8,
-    maximumFractionDigits: 8,
-    roundingMode: 'trunc',
-  }).formatToParts(value)
+  const parts = new Intl.NumberFormat(undefined, BTC_NUMBER_FORMAT_OPTIONS).formatToParts(value)
 
   const sign = parts.find((p) => p.type === 'minusSign')?.value
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -165,6 +165,45 @@ export const formatBtc = (value: number) => {
   })
 }
 
+export interface BtcParts {
+  /** The sign character ('-') or undefined for positive */
+  sign: string | undefined
+  /** Integer digits without grouping (e.g. "12345") */
+  integerPart: string
+  /** Fraction digits (e.g. "67890123") */
+  fractionalPart: string
+  /** Full locale-formatted string for display attributes */
+  formatted: string
+}
+
+/**
+ * Decompose a BTC value into semantic parts using Intl.NumberFormat.formatToParts().
+ * Handles all locales including it-IT (12.345,67890123) and ar-EG (١٢٬٣٤٥٫٦٧٨٩٠١٢٣).
+ */
+export const getBtcParts = (value: number): BtcParts => {
+  const parts = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 8,
+    maximumFractionDigits: 8,
+    roundingMode: 'trunc',
+  }).formatToParts(value)
+
+  const sign = parts.find((p) => p.type === 'minusSign')?.value
+
+  const integerPart = parts
+    .filter((p) => p.type === 'integer')
+    .map((p) => p.value)
+    .join('') || '0'
+
+  const fractionalPart = parts
+    .filter((p) => p.type === 'fraction')
+    .map((p) => p.value)
+    .join('')
+
+  const formatted = parts.map((p) => p.value).join('')
+
+  return { sign, integerPart, fractionalPart, formatted }
+}
+
 export const formatSats = (value: number) => {
   return value.toLocaleString(undefined, {
     minimumFractionDigits: 0,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -189,10 +189,11 @@ export const getBtcParts = (value: number): BtcParts => {
 
   const sign = parts.find((p) => p.type === 'minusSign')?.value
 
-  const integerPart = parts
-    .filter((p) => p.type === 'integer')
-    .map((p) => p.value)
-    .join('') || '0'
+  const integerPart =
+    parts
+      .filter((p) => p.type === 'integer')
+      .map((p) => p.value)
+      .join('') || '0'
 
   const fractionalPart = parts
     .filter((p) => p.type === 'fraction')


### PR DESCRIPTION
Locale-formatted BTC values (e.g. '0,26120925' for it-IT) caused a crash when splitting on '.' because the comma decimal separator left fractionalPart undefined.

Normalize the formatted number string to replace locale decimal separators with '.' before splitting.

Fixes #1289