### PR TITLE
Add tooltip for jm:autofrozen:reuse label

### DIFF
--- a/src/components/wallet/BranchEntryTable.tsx
+++ b/src/components/wallet/BranchEntryTable.tsx
@@ -131,7 +131,7 @@ export const BranchEntryTable = ({
         cell: (info) => (
           <div className="flex items-center gap-2">
             {info.row.original.tags.map((it, index) => {
-              const tooltipKey = `jar_details.utxo_list.utxo_tag_tooltip_${it.value}`
+              const tooltipKey = `jar_details.utxo_list.utxo_tag_tooltip_${it.value.replaceAll(':', '_')}`
               const tooltip = t(tooltipKey)
               const hasTooltip = tooltip !== tooltipKey
               return (

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -207,7 +207,7 @@ const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnD
       cell: (info) => (
         <div className="flex items-center gap-2">
           {info.row.original.tags.map((it, index) => {
-            const tooltipKey = `jar_details.utxo_list.utxo_tag_tooltip_${it.value}`
+            const tooltipKey = `jar_details.utxo_list.utxo_tag_tooltip_${it.value.replaceAll(':', '_')}`
             const tooltip = t(tooltipKey)
             const hasTooltip = tooltip !== tooltipKey
             return (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -871,6 +871,7 @@
       "utxo_tag_tooltip_locked": "Time-locked by the Bitcoin protocol",
       "utxo_tag_tooltip_pending": "Part of a pending transaction",
       "utxo_tag_tooltip_bond": "Fidelity bond",
+      "utxo_tag_tooltip_jm_autofrozen_reuse": "Automatically frozen due to address reuse detected",
       "column_title_balance": "Value",
       "column_title_address": "Address",
       "column_title_confirmations": "Confs.",

--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -81,6 +81,26 @@ describe('tags', () => {
       ])
     })
 
+    it('should not apply status styling to free-form labels', () => {
+      expect(utxoTags({ address: 'bcrt1address', label: 'deposit' } as Utxo, {}, t)).toStrictEqual([
+        {
+          displayValue: 'deposit',
+          value: 'deposit',
+          variant: 'default',
+        },
+      ])
+    })
+
+    it('should apply reused styling to the JoinMarket autofrozen reuse label', () => {
+      expect(utxoTags({ address: 'bcrt1address', label: 'jm:autofrozen:reuse' } as Utxo, {}, t)).toStrictEqual([
+        {
+          displayValue: 'jm:autofrozen:reuse',
+          value: 'jm:autofrozen:reuse',
+          variant: 'reused',
+        },
+      ])
+    })
+
     it('should prefer fidelity-bond tag and ignore raw status for locked UTXOs', () => {
       expect(
         utxoTags(

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -44,6 +44,7 @@ export const UTXO_STATUS_TAG_VARIANTS: { [key in UtxoTagValue]: StatusBadgeVaria
   ...JM_PLAIN_STATUS_TAG_VARIANTS,
   ...ADDITIONAL_STATUS_TAG_VARIANTS,
   bond: 'fidelity-bond',
+  'jm:autofrozen:reuse': 'reused',
 }
 
 export type UtxoTag = { value: UtxoTagValue; displayValue: string; variant: StatusBadgeVariant }
@@ -88,7 +89,11 @@ export const utxoTags = (utxo: Utxo, addressSummary: AddressSummary, t: TFunctio
   __statusTags.forEach((it) => tags.push(it))
 
   if (utxo.label) {
-    tags.push({ value: utxo.label, displayValue: utxo.label, variant: 'default' })
+    tags.push({
+      value: utxo.label,
+      displayValue: utxo.label,
+      variant: UTXO_STATUS_TAG_VARIANTS[utxo.label] || 'default',
+    })
   }
   return tags
 }

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -89,10 +89,11 @@ export const utxoTags = (utxo: Utxo, addressSummary: AddressSummary, t: TFunctio
   __statusTags.forEach((it) => tags.push(it))
 
   if (utxo.label) {
+    const isJmLabel = utxo.label.startsWith('jm:')
     tags.push({
       value: utxo.label,
       displayValue: utxo.label,
-      variant: UTXO_STATUS_TAG_VARIANTS[utxo.label] || 'default',
+      variant: isJmLabel ? UTXO_STATUS_TAG_VARIANTS[utxo.label] || 'default' : 'default',
     })
   }
   return tags


### PR DESCRIPTION
Adds a tooltip description for the `jm:autofrozen:reuse` label in the UI.

**Tooltip:** Automatically frozen due to address reuse detected.

Closes #1284 