### PR TITLE
Fix orderbook own-offer pin/highlight with pagination

### DIFF
--- a/src/components/orderbook/OrderbookTable.tsx
+++ b/src/components/orderbook/OrderbookTable.tsx
@@ -254,14 +254,14 @@ export const OrderbookTable = ({
 
   useEffect(() => {
     table.resetRowPinning(true)
-    table.getRowModel().rows.forEach((row) => {
+    table.getPrePaginationRowModel().rows.forEach((row) => {
       row.pin(pinnedEntries.includes(row.original) ? 'top' : false)
     })
   }, [table, pinnedEntries])
 
   useEffect(() => {
     table.resetRowSelection(true)
-    table.getRowModel().rows.forEach((row) => {
+    table.getPrePaginationRowModel().rows.forEach((row) => {
       row.toggleSelected(highlightedEntries.includes(row.original))
     })
   }, [table, highlightedEntries])


### PR DESCRIPTION
## Summary

- apply own-offer row pinning against the pre-pagination row model
- apply own-offer row selection/highlighting against the pre-pagination row model
- keep the existing filtering/search behavior intact