### PR TITLE
fix(login): wallet preselection

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -61,7 +61,7 @@ export const LoginFormComponent = ({
   className,
   wallets,
   activeWallet,
-  preselectedWallet = activeWallet,
+  preselectedWallet = activeWallet ?? (wallets.length === 1 ? wallets[0] : undefined),
   makerRunning,
   coinjoinInProgress,
   onSubmit,
@@ -85,7 +85,7 @@ export const LoginFormComponent = ({
     mode: 'onSubmit',
     reValidateMode: 'onSubmit',
     defaultValues: {
-      walletFileName: preselectedWallet ?? (wallets.length === 1 ? wallets[0] : undefined),
+      walletFileName: preselectedWallet,
     },
     resolver: yupResolver(schema),
   })

--- a/src/components/login/LoginPage.tsx
+++ b/src/components/login/LoginPage.tsx
@@ -9,7 +9,7 @@ import { useApiClient } from '@/hooks/useApiClient'
 import { getErrorReason } from '@/lib/errorReason'
 import { hashPassword } from '@/lib/hash'
 import { withQueryDelay } from '@/lib/queryClient'
-import { sortWallets } from '@/lib/utils'
+import { isWalletFileName, sortWallets } from '@/lib/utils'
 import type { WalletFileName } from '@/lib/utils'
 import { authStore, type AuthState } from '@/store/authStore'
 import { jmSessionStore } from '@/store/jmSessionStore'
@@ -46,10 +46,8 @@ const LoginPage = () => {
     }),
   })
 
-  const activeWalletOrNull =
-    jmSession?.wallet_name !== undefined && jmSession.wallet_name !== 'None'
-      ? (jmSession?.wallet_name as WalletFileName)
-      : null
+  const activeWalletOrNull: WalletFileName | null =
+    jmSession?.session === true && isWalletFileName(jmSession.wallet_name) ? jmSession.wallet_name : null
   const wallets = sortWallets((listWalletsData?.wallets || []) as WalletFileName[], activeWalletOrNull)
 
   const unlockWallet = useMutation({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,7 +22,11 @@ export const isRelativeOffer = (offertype: OfferType) => offertype.includes('rel
 // can be any of ['sw0absoffer', 'swabsoffer', 'absoffer']
 export const isAbsoluteOffer = (offertype: OfferType) => offertype.includes('absoffer')
 
-export type WalletFileName = `${string}.jmdat`
+export type WalletFileName = `${string}${typeof JM_WALLET_FILE_EXTENSION}`
+
+export function isWalletFileName(val: unknown): val is WalletFileName {
+  return typeof val === 'string' && val.endsWith(JM_WALLET_FILE_EXTENSION)
+}
 
 /**
  * Formats a wallet name by removing the .jmdat extension


### PR DESCRIPTION
Fixes wallet preselection (for joinmarket-ng backend).
joinmarket-clientserver provides 'None' as `wallet_name` in session responses, whereas joinmarket-ng returns `''` (empty string).
This PR ensures that either the active wallet is preselected or a single wallet ending with `.jmdat` if present.