### PR TITLE
Apply Tailwind styling consistency and brand identity pass across app

### DIFF
--- a/src/components/create/CreateStepVerifyMnemonic.tsx
+++ b/src/components/create/CreateStepVerifyMnemonic.tsx
@@ -87,7 +87,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
           <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
             <div
               className={cn('h-full rounded-full transition-all duration-300 ease-out', {
-                'bg-green-300/50': isCorrect,
+                'bg-brand-success/40': isCorrect,
                 'bg-primary': !isCorrect,
               })}
               style={{ width: `${(progress / total) * 100}%` }}
@@ -100,7 +100,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
         className={cn('rounded-lg border-2 border-dashed p-2.5 transition-colors', {
           'border-destructive/50': wrongButtonIndex !== undefined,
           'border-muted-foreground/20': wrongButtonIndex === undefined,
-          'border-green-300/50 bg-green-600/5': allSelected && isCorrect,
+          'border-brand-success/50 bg-brand-success/10': allSelected && isCorrect,
         })}
       >
         <div className="grid grid-cols-3 gap-1.5 select-none">
@@ -135,7 +135,7 @@ export const CreateStepVerifyMnemonic = ({ mnemonicPhrase, onVerified, onBack }:
             })}
         </div>
         {allSelected && isCorrect && (
-          <div className="flex h-full items-center justify-center gap-1.5 text-sm font-medium text-green-300">
+          <div className="text-brand-success flex h-full items-center justify-center gap-1.5 text-sm font-medium">
             <CheckCircle2Icon className="size-4" />
             {t('create_wallet.verify_mnemonic.feedback_mnemonic_confirmed')}
           </div>

--- a/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondDialogSteps.tsx
+++ b/src/components/earn/CreateFidelityBondDialog/CreateFidelityBondDialogSteps.tsx
@@ -361,7 +361,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
           </div>
 
           <div className="space-y-4">
-            <div className="rounded-lg border border-green-500/20 bg-green-500/10 p-4">
+            <div className="border-brand-success/20 bg-brand-success/10 rounded-lg border p-4">
               <p className="mb-3 text-sm font-medium">
                 {t('earn.fidelity_bond.freeze_utxos.label_selected_utxos', { count: selectedUtxos.length })}
               </p>
@@ -376,7 +376,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
             </div>
 
             {utxosToFreeze.length > 0 && (
-              <div className="rounded-lg border border-orange-500/20 bg-orange-500/10 p-4">
+              <div className="border-brand-warning/20 bg-brand-warning/10 rounded-lg border p-4">
                 <p className="mb-1 text-sm font-medium">
                   {t('earn.fidelity_bond.freeze_utxos.label_utxos_to_freeze', { count: utxosToFreeze.length })}
                 </p>
@@ -445,7 +445,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                       key="copy-address-review"
                       value={address}
                       text={<CopyIcon className="h-4 w-4" />}
-                      successText={<CheckIcon className="h-4 w-4 text-green-500" />}
+                      successText={<CheckIcon className="text-brand-success h-4 w-4" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                       onSuccess={() => toast.success(t('receive.text_copy_address'))}
                       onError={() => toast.error(t('receive.error_copy_address_failed'))}
@@ -503,8 +503,8 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
       return (
         <div className="space-y-6">
           <div className="flex flex-col items-center py-6">
-            <div className="rounded-full bg-green-500/10 p-4">
-              <CheckCircle2Icon className="h-16 w-16 text-green-500" />
+            <div className="bg-brand-success/10 rounded-full p-4">
+              <CheckCircle2Icon className="text-brand-success h-16 w-16" />
             </div>
             <p className="mt-4 text-xl font-bold">{t('earn.fidelity_bond.create_fidelity_bond.success_text')}</p>
             <p className="text-muted-foreground mt-2 text-sm">
@@ -531,7 +531,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                     key="copy-address-success"
                     value={address}
                     text={<CopyIcon className="h-4 w-4" />}
-                    successText={<CheckIcon className="h-4 w-4 text-green-500" />}
+                    successText={<CheckIcon className="text-brand-success h-4 w-4" />}
                     className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                     onSuccess={() => toast.success(t('receive.text_copy_address'))}
                     onError={() => toast.error(t('receive.error_copy_address_failed'))}
@@ -553,7 +553,7 @@ export function CreateFidelityBondDialogSteps({ wizard }: CreateFidelityBondDial
                     key="copy-txid"
                     value={txResult.txinfo.txid}
                     text={<CopyIcon className="h-4 w-4" />}
-                    successText={<CheckIcon className="h-4 w-4 text-green-500" />}
+                    successText={<CheckIcon className="text-brand-success h-4 w-4" />}
                     className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                     onSuccess={() =>
                       toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))

--- a/src/components/earn/EarnForm.tsx
+++ b/src/components/earn/EarnForm.tsx
@@ -310,11 +310,11 @@ export function EarnForm({
           </CardHeader>
           <CardContent className="flex flex-col gap-2">
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">isValid:</code>
+              <code className="text-destructive">isValid:</code>
               <pre className="text-xs">{JSON.stringify(isValid, null, 2)}</pre>
             </div>
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">values:</code>
+              <code className="text-destructive">values:</code>
               <pre className="text-xs">{JSON.stringify(values, null, 2)}</pre>
             </div>
           </CardContent>

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -418,11 +418,11 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
           </CardHeader>
           <CardContent className="flex flex-col gap-2">
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">walletInfo.fidelityBondSummary.fbOutputs:</code>
+              <code className="text-destructive">walletInfo.fidelityBondSummary.fbOutputs:</code>
               <pre className="text-xs">{JSON.stringify(walletInfo.fidelityBondSummary.fbOutputs, null, 2)}</pre>
             </div>
             <div className="mt-8 overflow-scroll">
-              <code className="light:text-red-700 text-red-800">jmSessionState.offer_list:</code>
+              <code className="text-destructive">jmSessionState.offer_list:</code>
               <pre className="text-xs">{JSON.stringify(jmSession.offer_list, null, 2)}</pre>
             </div>
           </CardContent>

--- a/src/components/earn/MoveToJarDialog.tsx
+++ b/src/components/earn/MoveToJarDialog.tsx
@@ -349,8 +349,8 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
           {step === 'success' && (
             <div className="space-y-6">
               <div className="flex flex-col items-center py-6">
-                <div className="rounded-full bg-green-500/10 p-4">
-                  <CheckCircle2Icon className="h-16 w-16 text-green-500" />
+                <div className="bg-brand-success/10 rounded-full p-4">
+                  <CheckCircle2Icon className="text-brand-success h-16 w-16" />
                 </div>
                 <p className="mt-4 text-xl font-bold">{t('earn.fidelity_bond.move.success_text')}</p>
               </div>
@@ -368,7 +368,7 @@ export function MoveToJarDialog({ open, onOpenChange, walletFileName, utxo }: Mo
                       key="copy-txid-move"
                       value={txResult.txinfo.txid}
                       text={<CopyIcon className="h-4 w-4" />}
-                      successText={<CheckIcon className="h-4 w-4 text-green-500" />}
+                      successText={<CheckIcon className="text-brand-success h-4 w-4" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                       onSuccess={() =>
                         toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))

--- a/src/components/earn/RenewBondDialog.tsx
+++ b/src/components/earn/RenewBondDialog.tsx
@@ -402,8 +402,8 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
           {step === 'success' && (
             <div className="space-y-6">
               <div className="flex flex-col items-center py-6">
-                <div className="rounded-full bg-green-500/10 p-4">
-                  <CheckCircle2Icon className="h-16 w-16 text-green-500" />
+                <div className="bg-brand-success/10 rounded-full p-4">
+                  <CheckCircle2Icon className="text-brand-success h-16 w-16" />
                 </div>
                 <p className="mt-4 text-xl font-bold">{t('earn.fidelity_bond.renew.success_text')}</p>
               </div>
@@ -421,7 +421,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
                       key="copy-address-renew"
                       value={destinationAddress}
                       text={<CopyIcon className="h-4 w-4" />}
-                      successText={<CheckIcon className="h-4 w-4 text-green-500" />}
+                      successText={<CheckIcon className="text-brand-success h-4 w-4" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                       onSuccess={() => toast.success(t('receive.text_copy_address'))}
                       onError={() => toast.error(t('global.errors.reason_unknown'))}
@@ -443,7 +443,7 @@ export function RenewBondDialog({ open, onOpenChange, walletFileName, utxo }: Re
                       key="copy-txid-renew"
                       value={txResult.txinfo.txid}
                       text={<CopyIcon className="h-4 w-4" />}
-                      successText={<CheckIcon className="h-4 w-4 text-green-500" />}
+                      successText={<CheckIcon className="text-brand-success h-4 w-4" />}
                       className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-10 w-10 shrink-0')}
                       onSuccess={() =>
                         toast.success(t('earn.fidelity_bond.create_fidelity_bond.text_copy_transaction_id'))

--- a/src/components/import/ImportDetailsForm.tsx
+++ b/src/components/import/ImportDetailsForm.tsx
@@ -253,7 +253,8 @@ export const ImportDetailsForm = ({
           <AccordionTrigger
             className={cn({
               'text-destructive': hasImportDetailsSectionErrors,
-              'light:text-yellow-800 text-yellow-200/90': !hasImportDetailsSectionErrors && showGaplimitWarning,
+              'text-brand-warning light:text-brand-warning-foreground':
+                !hasImportDetailsSectionErrors && showGaplimitWarning,
             })}
           >
             <div className="flex items-center gap-2">

--- a/src/components/import/ImportStepConfirm.tsx
+++ b/src/components/import/ImportStepConfirm.tsx
@@ -113,7 +113,7 @@ export const ImportStepConfirm = ({
             <AccordionItem value="options">
               <AccordionTrigger
                 className={cn({
-                  'light:text-yellow-800 text-yellow-200/90': showGaplimitWarning,
+                  'text-brand-warning light:text-brand-warning-foreground': showGaplimitWarning,
                 })}
               >
                 <div className="flex items-center gap-2">

--- a/src/components/layout/AppNavbar.tsx
+++ b/src/components/layout/AppNavbar.tsx
@@ -69,7 +69,7 @@ const WalletPreview = ({
             ) : (
               <>
                 {isLoading ? (
-                  <Skeleton className="h-4 w-full bg-neutral-200 dark:bg-neutral-600" />
+                  <Skeleton className="bg-muted h-4 w-full" />
                 ) : (
                   <Balance valueString={String(totalBalance)} />
                 )}
@@ -172,7 +172,7 @@ export function AppNavbar({
         <Link to={rescanningRoute ? '#' : routes.earn} className="text-muted-foreground hover:text-foreground relative">
           <WithActivityIndicator active={makerRunning}>{t('navbar.tab_earn')}</WithActivityIndicator>
         </Link>
-        <span className="text-gray-400 dark:text-gray-600">|</span>
+        <span className="text-border">|</span>
         <Link
           to={rescanningRoute ? '#' : routes.sweep}
           className="text-muted-foreground hover:text-foreground relative"

--- a/src/components/layout/AppNavbar.tsx
+++ b/src/components/layout/AppNavbar.tsx
@@ -145,7 +145,7 @@ export function AppNavbar({
   })
 
   return (
-    <header className="light:bg-gray-100 light:text-black flex items-center justify-between bg-[#23262b] px-4 py-2 text-white transition-colors duration-300">
+    <header className="bg-brand-nav text-brand-nav-foreground flex items-center justify-between px-4 py-2 transition-colors duration-300">
       <WalletPreview
         isLoading={isLoading}
         isReloading={isReloading}
@@ -185,7 +185,7 @@ export function AppNavbar({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                className="light:text-green-600 text-green-300"
+                className="text-brand-success"
                 variant="ghost-navbar"
                 size="icon"
                 onClick={() => void navigate(rescanningRoute)}
@@ -201,7 +201,7 @@ export function AppNavbar({
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                className="light:text-green-600 text-green-300"
+                className="text-brand-success"
                 variant="ghost-navbar"
                 size="icon"
                 onClick={() => void navigate(joiningRoute)}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -72,7 +72,7 @@ export function LayoutInner({ onLogout, onLockWallet, children }: LayoutInnerPro
   }, [])
 
   return (
-    <div className="light:bg-white light:text-black flex min-h-screen flex-1 flex-col bg-[#181b20] text-white transition-colors duration-300">
+    <div className="bg-brand-shell text-brand-shell-foreground flex min-h-screen flex-1 flex-col transition-colors duration-300">
       <AppNavbar
         theme={resolvedTheme}
         isLoading={isLoading}

--- a/src/components/logging/LogViewer.tsx
+++ b/src/components/logging/LogViewer.tsx
@@ -126,10 +126,7 @@ export function LogViewer({ fileName, value, refresh }: LogViewerProps) {
         }
         const nextCursor = nextMatchIndex + queryLength
         fragments.push(
-          <mark
-            key={`${line}-${nextMatchIndex}`}
-            className="light:bg-yellow-400/80 rounded bg-yellow-500/40 px-0.5 text-current"
-          >
+          <mark key={`${line}-${nextMatchIndex}`} className="bg-brand-warning/40 rounded px-0.5 text-current">
             {line.slice(nextMatchIndex, nextCursor)}
           </mark>,
         )

--- a/src/components/orderbook/OrderbookTable.tsx
+++ b/src/components/orderbook/OrderbookTable.tsx
@@ -330,7 +330,7 @@ export const OrderbookTable = ({
           </TableHeader>
           <TableBody className=":bg-foreground [&>tr:nth-child(odd)]:bg-foreground/10 [&>tr]:hover:bg-foreground/20!">
             {tableTopRows().map((row) => (
-              <TableRow key={row.id} className={row.getIsSelected() ? 'light:bg-yellow-500/30! bg-yellow-950!' : ''}>
+              <TableRow key={row.id} className={row.getIsSelected() ? 'bg-brand-warning/25!' : ''}>
                 {row.getVisibleCells().map((cell) => {
                   const alignCenter = cell.column.columnDef.meta?.align === 'center'
                   const alignRight = cell.column.columnDef.meta?.align === 'right'
@@ -350,7 +350,7 @@ export const OrderbookTable = ({
             ))}
             {table.getCenterRows().map((row) => {
               return (
-                <TableRow key={row.id} className={row.getIsSelected() ? 'light:bg-yellow-500/30! bg-yellow-950!' : ''}>
+                <TableRow key={row.id} className={row.getIsSelected() ? 'bg-brand-warning/25!' : ''}>
                   {row.getVisibleCells().map((cell) => {
                     const alignCenter = cell.column.columnDef.meta?.align === 'center'
                     const alignRight = cell.column.columnDef.meta?.align === 'right'

--- a/src/components/receive/BitcoinAmountInput.tsx
+++ b/src/components/receive/BitcoinAmountInput.tsx
@@ -30,7 +30,7 @@ export const BitcoinAmountInput = ({
       <div className="flex w-full items-center gap-2">
         <div className="relative flex-1">
           <div onClick={toggleCurrencyUnit} className="absolute inset-y-0 left-0 flex items-center px-1">
-            <span className="px-1 text-gray-500">
+            <span className="text-muted-foreground px-1">
               <CurrencySymbol currency={currency} isPrivate={isPrivate} />
             </span>
           </div>

--- a/src/components/receive/ReceiveForm.tsx
+++ b/src/components/receive/ReceiveForm.tsx
@@ -149,11 +149,11 @@ export const ReceiveForm = ({ className, defaultValues, onSubmit, jars, disabled
           </CardHeader>
           <CardContent className="flex flex-col gap-2">
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">isValid:</code>
+              <code className="text-destructive">isValid:</code>
               <pre className="text-xs">{JSON.stringify(isValid, null, 2)}</pre>
             </div>
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">values:</code>
+              <code className="text-destructive">values:</code>
               <pre className="text-xs">{JSON.stringify(values, null, 2)}</pre>
             </div>
           </CardContent>

--- a/src/components/send/PaymentConfirmDialog.tsx
+++ b/src/components/send/PaymentConfirmDialog.tsx
@@ -200,11 +200,11 @@ export default function PaymentConfirmDialog({
             </CardHeader>
             <CardContent className="flex flex-col gap-2">
               <div className="overflow-scroll">
-                <code className="light:text-red-700 text-red-800">values:</code>
+                <code className="text-destructive">values:</code>
                 <pre className="text-xs">{JSON.stringify(values, null, 2)}</pre>
               </div>
               <div className="overflow-scroll">
-                <code className="light:text-red-700 text-red-800">meta:</code>
+                <code className="text-destructive">meta:</code>
                 <pre className="text-xs">{JSON.stringify(meta, null, 2)}</pre>
               </div>
             </CardContent>

--- a/src/components/send/PaymentConfirmDialog.tsx
+++ b/src/components/send/PaymentConfirmDialog.tsx
@@ -95,7 +95,7 @@ export default function PaymentConfirmDialog({
           </DialogTitle>
           <DialogDescription className="text-center">
             {values.isCoinJoin === true ? (
-              <span className="light:text-green-600/80 font-semibold text-green-700/80">
+              <span className="text-brand-success/80 font-semibold">
                 {t('send.confirm_send_modal.text_collaborative_tx_enabled')}
               </span>
             ) : (

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -668,15 +668,15 @@ export function SendForm({
               </CardHeader>
               <CardContent className="flex flex-col gap-2">
                 <div className="overflow-scroll">
-                  <code className="light:text-red-700 text-red-800">isValid:</code>
+                  <code className="text-destructive">isValid:</code>
                   <pre className="text-xs">{JSON.stringify(isValid, null, 2)}</pre>
                 </div>
                 <div className="overflow-scroll">
-                  <code className="light:text-red-700 text-red-800">values:</code>
+                  <code className="text-destructive">values:</code>
                   <pre className="text-xs">{JSON.stringify(values, null, 2)}</pre>
                 </div>
                 <div className="overflow-scroll">
-                  <code className="light:text-red-700 text-red-800">errors:</code>
+                  <code className="text-destructive">errors:</code>
                   <pre className="text-xs">{JSON.stringify(errors.source?.message, null, 2)}</pre>
                   <pre className="text-xs">{JSON.stringify(errors.source?.fromJar?.message, null, 2)}</pre>
 
@@ -689,7 +689,7 @@ export function SendForm({
                   <pre className="text-xs">{JSON.stringify(errors.amount?.isSweep?.message, null, 2)}</pre>
                 </div>
                 <div className="overflow-scroll">
-                  <code className="light:text-red-700 text-red-800">schema:</code>
+                  <code className="text-destructive">schema:</code>
                   <pre className="text-xs">{JSON.stringify(schema, null, 2)}</pre>
                 </div>
               </CardContent>

--- a/src/components/settings/AccountXpubsDialog.tsx
+++ b/src/components/settings/AccountXpubsDialog.tsx
@@ -117,7 +117,7 @@ const AccountXpubItem = ({ xpub, accountNameAndLabel }: AccountXpubItemProps) =>
           })}
           value={xpub.xpub}
           text={<CopyIcon className="h-3 w-3" />}
-          successText={<CheckIcon className="h-3 w-3 text-green-500" />}
+          successText={<CheckIcon className="text-brand-success h-3 w-3" />}
           title={t('settings.xpubs_modal.button_copy_title', {
             account: accountNameAndLabel,
           })}
@@ -326,7 +326,7 @@ export const AccountXpubsDialog = ({
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
-                <AlertTriangleIcon className="h-5 w-5 text-yellow-500" />
+                <AlertTriangleIcon className="text-brand-warning h-5 w-5" />
                 {t('settings.xpubs_modal.verification.title')}
               </DialogTitle>
               <DialogDescription>{t('settings.xpubs_modal.verification.subtitle')}</DialogDescription>

--- a/src/components/settings/SeedPhraseDialog.tsx
+++ b/src/components/settings/SeedPhraseDialog.tsx
@@ -112,7 +112,7 @@ export const SeedPhraseDialog = ({
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
-                <AlertTriangleIcon className="h-5 w-5 text-yellow-500" />
+                <AlertTriangleIcon className="text-brand-warning h-5 w-5" />
                 {t('settings.seed_modal.verification.title')}
               </DialogTitle>
               <DialogDescription>{t('settings.seed_modal.verification.subtitle')}</DialogDescription>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -9,9 +9,9 @@ const alertVariants = cva(
       variant: {
         default: 'bg-card text-card-foreground',
         success:
-          'text-green-200/90 light:text-green-800 light:border-green-800 light:bg-green-100/50 border-green-200/90 bg-green-900/10 *:data-[slot=alert-description]:text-green-200/90 *:data-[slot=alert-description]:light:text-green-800',
+          'border-brand-success/40 bg-brand-success/10 text-brand-success *:data-[slot=alert-description]:text-brand-success',
         warning:
-          'text-yellow-200/90 light:text-yellow-800 light:border-yellow-800 light:bg-yellow-100/40 border-yellow-200/90 bg-yellow-900/10 *:data-[slot=alert-description]:text-yellow-200/90 *:data-[slot=alert-description]:light:text-yellow-800',
+          'border-brand-warning/40 bg-brand-warning/10 text-brand-warning *:data-[slot=alert-description]:text-brand-warning',
         destructive:
           'border-destructive/90 text-destructive bg-destructive/5 *:data-[slot=alert-description]:text-destructive/90',
       },

--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -10,7 +10,7 @@ const badgeVariants = cva(
         destructive:
           'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
-        dev: 'border-transparent light:bg-yellow-300 bg-yellow-400 text-black',
+        dev: 'bg-brand-warning text-brand-warning-foreground border-transparent',
       },
     },
     defaultVariants: {

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -16,7 +16,7 @@ export const buttonVariants = cva(
           'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
         ghost:
           'hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground',
-        'ghost-navbar': 'hover:bg-zinc-700 light:hover:bg-zinc-200',
+        'ghost-navbar': 'hover:bg-brand-nav-hover',
         destructive:
           'bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/src/components/ui/jam/ActivityIndicator.tsx
+++ b/src/components/ui/jam/ActivityIndicator.tsx
@@ -15,8 +15,8 @@ export const ActivityIndicator = ({ active = true, animateEnter = false, classNa
         'animate-in fade-in-0 zoom-in-0 duration-2000': animateEnter,
       })}
     >
-      <span className="light:bg-green-500 absolute inline-flex h-full w-full animate-ping rounded-full bg-green-200 opacity-75 [animation-duration:_2.1s]" />
-      <span className="light:bg-green-600 relative inline-flex size-2 rounded-full bg-green-300" />
+      <span className="bg-brand-success/30 absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 [animation-duration:_2.1s]" />
+      <span className="bg-brand-success relative inline-flex size-2 rounded-full" />
     </span>
   )
 }

--- a/src/components/ui/jam/Address.tsx
+++ b/src/components/ui/jam/Address.tsx
@@ -35,7 +35,7 @@ const CopyableAddress = (props: CopyableAddressProps) => {
       <CopyButton
         value={props.value}
         text={<CopyIcon />}
-        successText={<CheckIcon className="text-green-500" />}
+        successText={<CheckIcon className="text-brand-success" />}
         className={cn(buttonVariants({ variant: 'outline', size: 'icon-xs' }), 'shrink-0')}
         onSuccess={() => toast.success(t(/*TODO: i18n - distinct key */ 'receive.text_copy_address'))}
         onError={() => toast.error(/*TODO: i18n - distinct key */ t('receive.error_copy_address_failed'))}

--- a/src/components/ui/jam/Balance.module.css
+++ b/src/components/ui/jam/Balance.module.css
@@ -1,9 +1,9 @@
 :root {
-  --jam-balance-deemphasize-color: #9eacba;
+  --jam-balance-deemphasize-color: var(--muted-foreground);
 }
 
 :root[data-theme='dark'] {
-  --jam-balance-deemphasize-color: #555c62;
+  --jam-balance-deemphasize-color: var(--muted-foreground);
 }
 
 .hideSymbol {

--- a/src/components/ui/jam/Balance.tsx
+++ b/src/components/ui/jam/Balance.tsx
@@ -39,7 +39,7 @@ const ElementWithSymbols = ({
       className={cn(
         'balance-hook inline-flex items-center',
         {
-          'light:text-blue-500/80 text-blue-500/80': frozen,
+          'text-brand-info': frozen,
         },
         className,
       )}

--- a/src/components/ui/jam/Cheatsheet.tsx
+++ b/src/components/ui/jam/Cheatsheet.tsx
@@ -59,7 +59,7 @@ export const Cheatsheet = ({ open, onOpenChange }: CheatsheetProps) => {
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-xs">
       <div className="fixed inset-0 z-0" onClick={handleClose} />
       <div
-        className={`bg-background relative z-10 flex max-h-[95vh] w-full max-w-[640px] flex-col rounded-t-2xl shadow-2xl transition-transform duration-200 ease-out dark:bg-[#181b20] ${
+        className={`bg-background dark:bg-brand-shell relative z-10 flex max-h-[95vh] w-full max-w-[640px] flex-col rounded-t-2xl shadow-2xl transition-transform duration-200 ease-out ${
           isClosing ? 'animate-slide-down' : 'animate-slide-up'
         }`}
       >

--- a/src/components/ui/jam/Jar.tsx
+++ b/src/components/ui/jam/Jar.tsx
@@ -51,7 +51,7 @@ export function Jar({
           <Balance valueString={String(availableBalance)} />
         </div>
         <div
-          className={cn('light:text-blue-500/80 flex min-w-[110px] items-center justify-center gap-1 text-xs', {
+          className={cn('text-brand-info flex min-w-[110px] items-center justify-center gap-1 text-xs', {
             hidden: frozenOrLockedBalance <= 0,
           })}
         >

--- a/src/components/ui/jam/JmWebsocketInfo.tsx
+++ b/src/components/ui/jam/JmWebsocketInfo.tsx
@@ -10,7 +10,7 @@ type JmWebsocketIconProps = Pick<JmWebsocket, 'isOpen' | 'isAuthenticated'> & {
 
 const JmWebsocketIcon = ({ className, isOpen, isAuthenticated }: JmWebsocketIconProps) => {
   if (isAuthenticated) {
-    return <MonitorCheckIcon className={cn('light:text-green-600 text-green-300', className)} />
+    return <MonitorCheckIcon className={cn('text-brand-success', className)} />
   }
   if (isOpen) {
     return <MonitorUpIcon className={cn('text-foreground', className)} />

--- a/src/components/ui/jam/StatusBadge-variants.ts
+++ b/src/components/ui/jam/StatusBadge-variants.ts
@@ -9,37 +9,37 @@ export const statusBadgeVariants = cva(
         default: badgeVariants({ variant: 'default' }),
         new: badgeVariants({
           variant: 'default',
-          className: 'border-green-900/50 light:border-transparent light:bg-green-900/60 bg-green-900/30 text-white/90',
+          className: 'bg-brand-success text-brand-success-foreground border-transparent',
         }),
         deposit: badgeVariants({ variant: 'default' }),
         used: badgeVariants({ variant: 'secondary' }),
         reused: badgeVariants({ variant: 'destructive', className: 'light:bg-destructive/70' }),
         'cj-out': badgeVariants({
           variant: 'default',
-          className: 'border-transparent light:bg-green-700 bg-green-700 text-white/90',
+          className: 'bg-brand-success text-brand-success-foreground border-transparent',
         }),
         'cj-change': badgeVariants({
           variant: 'default',
-          className: 'border-transparent light:bg-emerald-600 bg-emerald-700/70 text-white/90',
+          className: 'bg-brand-success/80 text-brand-success-foreground border-transparent',
         }),
         'change-out': badgeVariants({
           variant: 'default',
-          className: 'border-transparent light:bg-yellow-300 bg-yellow-400 text-black',
+          className: 'bg-brand-warning text-brand-warning-foreground border-transparent',
         }),
         'non-cj-change': badgeVariants({
           variant: 'default',
-          className: 'border-transparent light:bg-orange-600/70 bg-orange-500/70 text-white',
+          className: 'bg-brand-date text-white border-transparent',
         }),
         // TODO: style and verify "fidelity-bond, locked, pending and frozen" status tags
         'fidelity-bond': badgeVariants({ variant: 'outline' }),
         locked: badgeVariants({ variant: 'outline' }),
         pending: badgeVariants({
           variant: 'default',
-          className: 'border-transparent light:bg-yellow-100/90 bg-yellow-100/90 text-black',
+          className: 'bg-brand-warning/30 text-brand-warning-foreground border-transparent',
         }),
         frozen: badgeVariants({
           variant: 'outline',
-          className: 'border-blue-600/40 light:border-transparent light:bg-blue-900/90 bg-blue-900/50 text-white',
+          className: 'bg-brand-info text-brand-info-foreground border-transparent',
         }),
       },
     },

--- a/src/components/wallet/BranchEntryTable.tsx
+++ b/src/components/wallet/BranchEntryTable.tsx
@@ -263,7 +263,7 @@ export const BranchEntryTable = ({
           </TableHeader>
           <TableBody className=":bg-foreground [&>tr:nth-child(odd)]:bg-foreground/10 [&>tr]:hover:bg-foreground/20!">
             {tableTopRows().map((row) => (
-              <TableRow key={row.id} className={row.getIsSelected() ? 'light:bg-yellow-500/30! bg-yellow-950!' : ''}>
+              <TableRow key={row.id} className={row.getIsSelected() ? 'bg-brand-warning/25!' : ''}>
                 {row.getVisibleCells().map((cell) => {
                   const alignCenter = cell.column.columnDef.meta?.align === 'center'
                   const alignRight = cell.column.columnDef.meta?.align === 'right'
@@ -283,7 +283,7 @@ export const BranchEntryTable = ({
             ))}
             {table.getCenterRows().map((row) => {
               return (
-                <TableRow key={row.id} className={row.getIsSelected() ? 'light:bg-yellow-500/30! bg-yellow-950!' : ''}>
+                <TableRow key={row.id} className={row.getIsSelected() ? 'bg-brand-warning/25!' : ''}>
                   {row.getVisibleCells().map((cell) => {
                     const alignCenter = cell.column.columnDef.meta?.align === 'center'
                     const alignRight = cell.column.columnDef.meta?.align === 'right'

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -64,8 +64,8 @@ const UtxoTableRow = ({ row }: { row: Row<UtxoTableEntry> }) => {
       <TableRow
         key={row.id}
         className={cn({
-          'light:bg-blue-500/30! bg-blue-900/50!': row.original.utxo.frozen === true,
-          'light:bg-yellow-500/30! bg-yellow-950!': row.getIsSelected(),
+          'bg-brand-info/20!': row.original.utxo.frozen === true,
+          'bg-brand-warning/25!': row.getIsSelected(),
         })}
       >
         {row.getVisibleCells().map((cell) => {

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -389,15 +389,15 @@ export const WalletJarsDetailsContent = ({
         {debug && (
           <TabsContent value="dev">
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">activeJar:</code>
+              <code className="text-destructive">activeJar:</code>
               <pre className="text-xs">{JSON.stringify(activeJar, null, 2)}</pre>
             </div>
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">activeAccountMeta:</code>
+              <code className="text-destructive">activeAccountMeta:</code>
               <pre className="text-xs">{JSON.stringify(activeAccountMeta, null, 2)}</pre>
             </div>
             <div className="overflow-scroll">
-              <code className="light:text-red-700 text-red-800">addressSummary:</code>
+              <code className="text-destructive">addressSummary:</code>
               <pre className="text-xs">{JSON.stringify(addressSummary, null, 2)}</pre>
             </div>
           </TabsContent>

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,17 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-brand-apricot: var(--brand-apricot);
+  --color-brand-blueberry: var(--brand-blueberry);
+  --color-brand-cherry: var(--brand-cherry);
+  --color-brand-date: var(--brand-date);
+  --color-brand-elderberry: var(--brand-elderberry);
+  --color-brand-shell: var(--brand-shell);
+  --color-brand-shell-foreground: var(--brand-shell-foreground);
+  --color-brand-nav: var(--brand-nav);
+  --color-brand-nav-foreground: var(--brand-nav-foreground);
+  --color-brand-nav-hover: var(--brand-nav-hover);
+  --color-brand-success: var(--brand-success);
 }
 
 :root {
@@ -47,8 +58,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: #6f542e;
+  --primary-foreground: #fffaf0;
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -58,15 +69,26 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: #b58b45;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: #6f542e;
+  --sidebar-primary-foreground: #fffaf0;
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-ring: #b58b45;
+  --brand-apricot: #e2b86a;
+  --brand-blueberry: #3b5ba9;
+  --brand-cherry: #c94f7c;
+  --brand-date: #a67c52;
+  --brand-elderberry: #7c3fa6;
+  --brand-shell: #fffaf0;
+  --brand-shell-foreground: #24190f;
+  --brand-nav: #fff7e6;
+  --brand-nav-foreground: #24190f;
+  --brand-nav-hover: #f4e5c4;
+  --brand-success: #2f7d45;
 }
 
 [data-theme='dark'] {
@@ -76,8 +98,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: #e2b86a;
+  --primary-foreground: #181b20;
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -87,15 +109,26 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: #e2b86a;
   --sidebar: hsl(240 5.9% 10%);
   --sidebar-foreground: hsl(240 4.8% 95.9%);
-  --sidebar-primary: hsl(224.3 76.3% 48%);
-  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-primary: #e2b86a;
+  --sidebar-primary-foreground: #181b20;
   --sidebar-accent: hsl(240 3.7% 15.9%);
   --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
   --sidebar-border: hsl(240 3.7% 15.9%);
-  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+  --sidebar-ring: #e2b86a;
+  --brand-apricot: #e2b86a;
+  --brand-blueberry: #3b5ba9;
+  --brand-cherry: #c94f7c;
+  --brand-date: #a67c52;
+  --brand-elderberry: #7c3fa6;
+  --brand-shell: #181b20;
+  --brand-shell-foreground: #f6f1e8;
+  --brand-nav: #23262b;
+  --brand-nav-foreground: #f6f1e8;
+  --brand-nav-hover: #343138;
+  --brand-success: #8fdaa0;
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,11 @@
   --color-brand-nav-foreground: var(--brand-nav-foreground);
   --color-brand-nav-hover: var(--brand-nav-hover);
   --color-brand-success: var(--brand-success);
+  --color-brand-success-foreground: var(--brand-success-foreground);
+  --color-brand-warning: var(--brand-warning);
+  --color-brand-warning-foreground: var(--brand-warning-foreground);
+  --color-brand-info: var(--brand-info);
+  --color-brand-info-foreground: var(--brand-info-foreground);
 }
 
 :root {
@@ -89,6 +94,11 @@
   --brand-nav-foreground: #24190f;
   --brand-nav-hover: #f4e5c4;
   --brand-success: #2f7d45;
+  --brand-success-foreground: #fffaf0;
+  --brand-warning: #e2b86a;
+  --brand-warning-foreground: #24190f;
+  --brand-info: #3b5ba9;
+  --brand-info-foreground: #fffaf0;
 }
 
 [data-theme='dark'] {
@@ -129,6 +139,11 @@
   --brand-nav-foreground: #f6f1e8;
   --brand-nav-hover: #343138;
   --brand-success: #8fdaa0;
+  --brand-success-foreground: #181b20;
+  --brand-warning: #e2b86a;
+  --brand-warning-foreground: #181b20;
+  --brand-info: #7893d1;
+  --brand-info-foreground: #181b20;
 }
 
 @layer base {


### PR DESCRIPTION
### Summary

Refs #1260

Applies Tailwind styling consistency and brand identity pass across the app.

- Added Jam brand theme tokens based on the existing jar palette.
- Added semantic brand tokens for success, warning, info, shell, navbar, and hover states.
- Replaced repeated hardcoded Tailwind colors across shared UI surfaces with theme tokens.
- Normalized branded states for alerts, badges, selected/frozen table rows, copy success icons, and key flow screens.
- Kept intentional jar colors and dev-only styling mostly unchanged.

@theborakompanioni @kishore08-07 