### PR TITLE
feat(navbar): toggle lock wallet/logout button based on running services

### DIFF
--- a/src/components/layout/AppNavbar.test.tsx
+++ b/src/components/layout/AppNavbar.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/components/ui/jam/Balance', () => ({
 }))
 
 const LOCK_WALLET_LABEL = 'settings.button_lock_wallet'
-const LOGOUT_LABEL = 'Logout'
+const LOGOUT_LABEL = 'navbar.button_logout'
 
 const defaults: ComponentProps<typeof AppNavbar> = {
   theme: 'dark',

--- a/src/components/layout/AppNavbar.test.tsx
+++ b/src/components/layout/AppNavbar.test.tsx
@@ -1,0 +1,91 @@
+import type { ComponentProps, ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AppNavbar } from './AppNavbar'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => key + (options ? ' ' + JSON.stringify(options) : ''),
+  }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  Link: ({ children, to }: { children?: ReactNode; to: string }) => <a href={String(to)}>{children}</a>,
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false }),
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/jam/Balance', () => ({
+  Balance: ({ valueString }: { valueString?: string }) => <span data-testid="balance">{valueString}</span>,
+}))
+
+const LOCK_WALLET_LABEL = 'settings.button_lock_wallet'
+const LOGOUT_LABEL = 'Logout'
+
+const defaults: ComponentProps<typeof AppNavbar> = {
+  theme: 'dark',
+  toggleTheme: vi.fn(),
+  onLogout: vi.fn().mockResolvedValue(undefined),
+  onLockWallet: vi.fn().mockResolvedValue(undefined),
+  walletName: 'Satoshi',
+  totalBalance: 21_000_000,
+}
+
+const queryLockWalletButton = () => screen.queryByRole('button', { name: LOCK_WALLET_LABEL })
+const queryLogoutButton = () => screen.queryByRole('button', { name: LOGOUT_LABEL })
+
+describe('AppNavbar lock/logout toggle', () => {
+  it('shows "lock wallet" and hides "logout" when idle', () => {
+    render(<AppNavbar {...defaults} />)
+
+    expect(queryLockWalletButton()).toBeInTheDocument()
+    expect(queryLogoutButton()).not.toBeInTheDocument()
+  })
+
+  it('shows "logout" and hides "lock wallet" while the maker is running', () => {
+    render(
+      <AppNavbar
+        {...defaults}
+        sessionInfo={{ maker_running: true, coinjoin_in_process: false, schedule: undefined }}
+      />,
+    )
+
+    expect(queryLogoutButton()).toBeInTheDocument()
+    expect(queryLockWalletButton()).not.toBeInTheDocument()
+  })
+
+  it('shows "logout" and hides "lock wallet" while a taker coinjoin is running', () => {
+    render(
+      <AppNavbar
+        {...defaults}
+        sessionInfo={{ maker_running: false, coinjoin_in_process: true, schedule: undefined }}
+      />,
+    )
+
+    expect(queryLogoutButton()).toBeInTheDocument()
+    expect(queryLockWalletButton()).not.toBeInTheDocument()
+  })
+
+  it('shows "logout" and hides "lock wallet" while the scheduler is running', () => {
+    render(<AppNavbar {...defaults} sessionInfo={{ maker_running: false, coinjoin_in_process: true, schedule: [] }} />)
+
+    expect(queryLogoutButton()).toBeInTheDocument()
+    expect(queryLockWalletButton()).not.toBeInTheDocument()
+  })
+
+  it('shows "logout" and hides "lock wallet" while a rescan is in progress', () => {
+    render(<AppNavbar {...defaults} rescanInfo={{ rescanning: true, progress: undefined, updatedAt: Date.now() }} />)
+
+    expect(queryLogoutButton()).toBeInTheDocument()
+    expect(queryLockWalletButton()).not.toBeInTheDocument()
+  })
+})

--- a/src/components/layout/AppNavbar.tsx
+++ b/src/components/layout/AppNavbar.tsx
@@ -259,12 +259,13 @@ export function AppNavbar({
                 variant="ghost-navbar"
                 size="icon"
                 onClick={() => void logoutMutation.mutateAsync({ navigate })}
-                aria-label={/* TODO: i18n */ 'Logout'}
+                aria-label={t('navbar.button_logout')}
+                disabled={logoutMutation.isPending}
               >
-                <LogOutIcon />
+                {logoutMutation.isPending ? <Spinner /> : <LogOutIcon />}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{/* TODO: i18n */ 'Logout'}</TooltipContent>
+            <TooltipContent>{t('navbar.button_logout')}</TooltipContent>
           </Tooltip>
         )}
         {sidebarTrigger}

--- a/src/components/layout/AppNavbar.tsx
+++ b/src/components/layout/AppNavbar.tsx
@@ -120,6 +120,10 @@ export function AppNavbar({
   const singleCoinJoinRunning = sessionInfo?.coinjoin_in_process === true && !sessionInfo?.schedule
   const schedulerRunning = sessionInfo?.coinjoin_in_process === true && !!sessionInfo?.schedule
 
+  // While a maker/taker/rescan is in progress the wallet cannot be locked, so
+  // only offer "logout"; otherwise offer "lock wallet".
+  const serviceRunning = makerRunning || sessionInfo?.coinjoin_in_process === true || rescanInfo?.rescanning === true
+
   const joiningRoute = (() => {
     if (schedulerRunning) return routes.sweep
     if (singleCoinJoinRunning) return routes.send
@@ -230,35 +234,39 @@ export function AppNavbar({
           <TooltipContent>{t('navbar.menu_mobile_settings')}</TooltipContent>
         </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              className="hidden sm:flex"
-              variant="ghost-navbar"
-              size="icon"
-              onClick={() => void lockWalletMutation.mutateAsync({ navigate, t })}
-              aria-label={t('settings.button_lock_wallet')}
-              disabled={lockWalletMutation.isPending}
-            >
-              {lockWalletMutation.isPending ? <Spinner /> : <LockKeyholeIcon />}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{t('settings.button_lock_wallet')}</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              className="hidden sm:flex"
-              variant="ghost-navbar"
-              size="icon"
-              onClick={() => void logoutMutation.mutateAsync({ navigate })}
-              aria-label={/* TODO: i18n */ 'Logout'}
-            >
-              <LogOutIcon />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{/* TODO: i18n */ 'Logout'}</TooltipContent>
-        </Tooltip>
+        {!serviceRunning && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                className="hidden sm:flex"
+                variant="ghost-navbar"
+                size="icon"
+                onClick={() => void lockWalletMutation.mutateAsync({ navigate, t })}
+                aria-label={t('settings.button_lock_wallet')}
+                disabled={lockWalletMutation.isPending}
+              >
+                {lockWalletMutation.isPending ? <Spinner /> : <LockKeyholeIcon />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('settings.button_lock_wallet')}</TooltipContent>
+          </Tooltip>
+        )}
+        {serviceRunning && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                className="hidden sm:flex"
+                variant="ghost-navbar"
+                size="icon"
+                onClick={() => void logoutMutation.mutateAsync({ navigate })}
+                aria-label={/* TODO: i18n */ 'Logout'}
+              >
+                <LogOutIcon />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{/* TODO: i18n */ 'Logout'}</TooltipContent>
+          </Tooltip>
+        )}
         {sidebarTrigger}
       </div>
     </header>

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -43,7 +43,8 @@
     "tab_sweep": "Sweepen",
     "joining_in_progress": "Jamming",
     "menu_mobile": "Menü",
-    "menu_mobile_settings": "Einstellungen"
+    "menu_mobile_settings": "Einstellungen",
+    "button_logout": "Abmelden"
   },
   "footer": {
     "warning": "Jam ist Beta Software! <br /><1> Lies das, bevor du weitermachst.</1>",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -54,7 +54,8 @@
     "tab_sweep": "Sweep",
     "joining_in_progress": "Jamming",
     "menu_mobile": "Menu",
-    "menu_mobile_settings": "Settings"
+    "menu_mobile_settings": "Settings",
+    "button_logout": "Logout"
   },
   "footer": {
     "warning": "This is beta software.<br /><1>Read this before using.</1>",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -12,7 +12,8 @@
     "tab_earn": "Générer",
     "joining_in_progress": "Brouillage",
     "menu_mobile": "Menu",
-    "menu_mobile_settings": "Réglages"
+    "menu_mobile_settings": "Réglages",
+    "button_logout": "Se déconnecter"
   },
   "app": {
     "alert_no_connection": "Aucune connexion au backend: {{ connectionError }}"

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -40,7 +40,8 @@
     "tab_sweep": "Sweep",
     "joining_in_progress": "Mescolamento in corso",
     "menu_mobile": "Menu",
-    "menu_mobile_settings": "Impostazioni"
+    "menu_mobile_settings": "Impostazioni",
+    "button_logout": "Disconnetti"
   },
   "footer": {
     "warning": "Questo software è in beta.<br /><1>Leggi qui prima di usarlo.</1>",

--- a/src/i18n/locales/pt_BR/translation.json
+++ b/src/i18n/locales/pt_BR/translation.json
@@ -40,7 +40,8 @@
     "tab_sweep": "Limpar",
     "joining_in_progress": "Misturando",
     "menu_mobile": "Menu",
-    "menu_mobile_settings": "Configurações"
+    "menu_mobile_settings": "Configurações",
+    "button_logout": "Sair"
   },
   "footer": {
     "warning": "Este é um software em beta.<br /><1>Leia isso antes de utilizá-lo.</1>",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -46,7 +46,8 @@
     "tab_sweep": "Перенести",
     "joining_in_progress": "Перемешивание",
     "menu_mobile": "Меню",
-    "menu_mobile_settings": "Настройки"
+    "menu_mobile_settings": "Настройки",
+    "button_logout": "Выйти"
   },
   "footer": {
     "warning": "Это бета-версия ПО.<br /><1>Прочитайте перед использованием.</1>",

--- a/src/i18n/locales/zh_Hans/translation.json
+++ b/src/i18n/locales/zh_Hans/translation.json
@@ -43,7 +43,8 @@
     "tab_sweep": "扫空",
     "joining_in_progress": "Jamming",
     "menu_mobile": "菜单",
-    "menu_mobile_settings": "设置"
+    "menu_mobile_settings": "设置",
+    "button_logout": "退出登录"
   },
   "footer": {
     "warning": "这是测试版软件。<br /><1>使用前请先参阅。</1>",

--- a/src/i18n/locales/zh_Hant/translation.json
+++ b/src/i18n/locales/zh_Hant/translation.json
@@ -43,7 +43,8 @@
     "tab_sweep": "掃空",
     "joining_in_progress": "Jamming",
     "menu_mobile": "菜單",
-    "menu_mobile_settings": "設置"
+    "menu_mobile_settings": "設置",
+    "button_logout": "登出"
   },
   "footer": {
     "warning": "這是測試版軟件。<br /><1>使用前請先閱讀。</1>",


### PR DESCRIPTION
### Summary
Closes #1311.

When a maker/taker/rescan is in progress the wallet can't be locked, so the navbar now shows only the **logout** button in that state, and only the **lock wallet** button when idle (previously both always showed).