### PR TITLE
dev(regtest): fix regtest init of standalone-ng containers

### DIFF
--- a/docker/regtest/docker-compose-common.yml
+++ b/docker/regtest/docker-compose-common.yml
@@ -59,6 +59,16 @@ services:
       context: ./dockerfile-deps/joinmarket/webui-standalone-ng
       dockerfile: Dockerfile
     restart: unless-stopped
+    environment:
+      JMWALLETD_HOST: 0.0.0.0
+      BITCOIN__BACKEND_TYPE: descriptor_wallet
+      BITCOIN__RPC_URL: http://bitcoind:43782
+      BITCOIN__RPC_USER: regtest
+      BITCOIN__RPC_PASSWORD: tegtest
+      LOGGING__LEVEL: DEBUG
+      NETWORK_CONFIG__NETWORK: testnet
+      NETWORK_CONFIG__BITCOIN_NETWORK: regtest
+      NETWORK_CONFIG__DIRECTORY_SERVERS: ${JM_ALL_DIRECTORY_NODES:?You must set the directory node addresses in generated env file}
     expose:
       - 80 # nginx
       - 28183 # jmwalletd api
@@ -69,7 +79,6 @@ services:
     environment:
       JOINMARKET_DATA_DIR: /root/.joinmarket-ng
       JMWALLETD_HOST: 0.0.0.0
-      JMWALLETD_NO_TLS: ${JMWALLETD_NO_TLS:-false}
       BITCOIN__BACKEND_TYPE: descriptor_wallet
       BITCOIN__RPC_URL: http://bitcoind:43782
       BITCOIN__RPC_USER: regtest
@@ -88,7 +97,6 @@ services:
     expose:
       - 8000 # obwatch
       - 28183 # jmwalletd api
-      - 28283 # jmwalletd websocket
     healthcheck:
       test:
         [
@@ -109,7 +117,6 @@ services:
     environment:
       JOINMARKET_DATA_DIR: /root/.joinmarket-ng
       JMWALLETD_HOST: 0.0.0.0
-      JMWALLETD_NO_TLS: ${JMWALLETD_NO_TLS:-false}
       BITCOIN__BACKEND_TYPE: descriptor_wallet
       BITCOIN__RPC_URL: http://bitcoind:43782
       BITCOIN__RPC_USER: regtest
@@ -127,7 +134,6 @@ services:
     expose:
       - 8000 # obwatch
       - 28183 # jmwalletd api
-      - 28283 # jmwalletd websocket
     healthcheck:
       test:
         [

--- a/docker/regtest/docker-compose-common.yml
+++ b/docker/regtest/docker-compose-common.yml
@@ -64,7 +64,7 @@ services:
       BITCOIN__BACKEND_TYPE: descriptor_wallet
       BITCOIN__RPC_URL: http://bitcoind:43782
       BITCOIN__RPC_USER: regtest
-      BITCOIN__RPC_PASSWORD: tegtest
+      BITCOIN__RPC_PASSWORD: regtest
       LOGGING__LEVEL: DEBUG
       NETWORK_CONFIG__NETWORK: testnet
       NETWORK_CONFIG__BITCOIN_NETWORK: regtest

--- a/docker/regtest/docker-compose-common.yml
+++ b/docker/regtest/docker-compose-common.yml
@@ -77,7 +77,6 @@ services:
       NETWORK_CONFIG__NETWORK: testnet
       NETWORK_CONFIG__BITCOIN_NETWORK: regtest
       NETWORK_CONFIG__DIRECTORY_SERVERS: ${JM_ALL_DIRECTORY_NODES:?You must set the directory node addresses in generated env file}
-      DIRECTORY_NODES: ${JM_ALL_DIRECTORY_NODES:?You must set the directory node addresses in generated env file}
       OBWATCH_URL: http://joinmarket_ng_orderbook_watcher:8000
       TOR__SOCKS_HOST: tor
       TOR__SOCKS_PORT: 9050
@@ -118,7 +117,6 @@ services:
       NETWORK_CONFIG__NETWORK: testnet
       NETWORK_CONFIG__BITCOIN_NETWORK: regtest
       NETWORK_CONFIG__DIRECTORY_SERVERS: ${JM_ALL_DIRECTORY_NODES:?You must set the directory node addresses in generated env file}
-      DIRECTORY_NODES: ${JM_ALL_DIRECTORY_NODES:?You must set the directory node addresses in generated env file}
       OBWATCH_URL: http://joinmarket_ng_orderbook_watcher:8000
       TOR__SOCKS_HOST: tor
       TOR__SOCKS_PORT: 9050

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -9,8 +9,7 @@ services:
       BITCOIN__RPC_USER: joinmarket
       BITCOIN__RPC_PASSWORD: joinmarket
     ports:
-      - '28183:28183'  # jmwalletd api
-      - '28283:28283'  # jmwalletd websocket
+      - '28183:28183' # jmwalletd api (exposed for "init setup" routine)
     volumes:
       - 'joinmarket_datadir:/root/.joinmarket-ng'
       - 'initializer_datadir:/root/.regtest-initializer'
@@ -31,18 +30,13 @@ services:
       file: docker-compose-common.yml
       service: joinmarket_jam_standalone_ng
     environment:
-      BITCOIN__RPC_URL: http://bitcoind:43782
       BITCOIN__RPC_USER: joinmarket2
       BITCOIN__RPC_PASSWORD: joinmarket2
-      LOGGING__LEVEL: DEBUG
-      NETWORK_CONFIG__NETWORK: testnet
-      NETWORK_CONFIG__BITCOIN_NETWORK: regtest
-      NETWORK_CONFIG__DIRECTORY_SERVERS: ${JM_ALL_DIRECTORY_NODES:?You must set the directory node addresses in generated env file}
       TAKER__MINIMUM_MAKERS: 2 # necessary to do coinjoins with this regtest setup
       TAKER__MAKER_TIMEOUT_SEC: 30 # easier testing of maker timeouts on regtest
     ports:
       - '29080:80'     
-      - '29183:28183'  # exposed for "init setup" routine
+      - '29183:28183' # jmwalletd api (exposed for "init setup" routine)
     volumes:
       - 'joinmarket2_datadir:/root/.joinmarket-ng'
     depends_on:
@@ -63,9 +57,9 @@ services:
       jm_rpc_password: joinmarket3
       CREATE_WALLET_PARAMS_DESCRIPTORS: 'false'
     ports:
-      - '30601:62601'  # obwatch
-      - '30183:28183'  # jmwalletd api
-      - '30283:28283'  # jmwalletd websocket
+      - '30601:62601' # obwatch
+      - '30183:28183' # jmwalletd api (exposed for "init setup" routine)
+      - '30283:28283' # jmwalletd websocket
     volumes:
       - 'joinmarket3_datadir:/root/.joinmarket'
       - 'initializer_datadir:/root/.regtest-initializer'
@@ -91,7 +85,7 @@ services:
       jm_rpc_cookie_file: /root/.bitcoin_data/regtest/.cookie
     ports:
       - '31080:80'
-      - '31183:28183'  # exposed for "init setup" routine
+      - '31183:28183' # jmwalletd api (exposed for "init setup" routine)
     volumes:
       - 'joinmarket4_datadir:/root/.joinmarket'
       - 'bitcoin_datadir:/root/.bitcoin_data' # mount bitcoind dir to access .cookie file
@@ -111,11 +105,8 @@ services:
     extends:
       file: docker-compose-common.yml
       service: joinmarket_ng_peer
-    environment:
-      BITCOIN__RPC_USER: regtest
-      BITCOIN__RPC_PASSWORD: regtest
     ports:
-      - '32183:28183'
+      - '32183:28183' # jmwalletd api (exposed for "init setup" routine)
     volumes:
       - 'joinmarket5_datadir:/root/.joinmarket-ng'
       - 'tor_datadir:/var/lib/tor:ro'

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       file: docker-compose-common.yml
       service: joinmarket_jam_standalone_ng
     environment:
-      ENSURE_WALLET: 'false'
       BITCOIN__RPC_URL: http://bitcoind:43782
       BITCOIN__RPC_USER: joinmarket2
       BITCOIN__RPC_PASSWORD: joinmarket2
@@ -90,7 +89,6 @@ services:
       APP_PASSWORD: joinmarket
       jm_rpc_wallet_file: jm_quaternary
       jm_rpc_cookie_file: /root/.bitcoin_data/regtest/.cookie
-      CREATE_WALLET_PARAMS_DESCRIPTORS: 'false'
     ports:
       - '31080:80'
       - '31183:28183'  # exposed for "init setup" routine

--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -120,7 +120,7 @@ Port mapping overview:
 
 | Container                               | Ports                                          |
 | --------------------------------------- | ---------------------------------------------- |
-| `joinmarket` (ng native)                | `28183` (API), `28283` (WS), `62601` (obwatch) |
+| `joinmarket` (ng native)                | `28183` (API)                                  |
 | `joinmarket2` (ng standalone)           | `29080` (UI), `29183` (API)                    |
 | `joinmarket3` (clientserver native)     | `30183` (API), `30283` (WS), `30601` (obwatch) |
 | `joinmarket4` (clientserver standalone) | `31080` (UI, basic auth), `31183` (API)        |


### PR DESCRIPTION
Fixes regtest by exposing jmwalletd in standalone-ng containers for init routine (default host has been [previously changed in the image](https://github.com/joinmarket-webui/jam-docker/commit/b139be3b41ee965d9cedc06ab2d66eb725af5ea1)).

Also removes unnecessary env vars `DIRECTORY_NODES`, [`ENSURE_WALLET`](https://github.com/joinmarket-webui/jam-docker/commit/94a794ee175677616cc89f2e4f8aa5e38bf5eb52) and `CREATE_WALLET_PARAMS_DESCRIPTORS` are no longer needed.