### PR TITLE
fix(send): make utxo selection table scrollable

### DIFF
--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -50,7 +50,7 @@ export const UtxoSelectionDialog = ({
           placeholder={t('jar_details.utxo_list.placeholder_search')}
           disabled={isSubmitting}
         />
-        <div className="max-h-[55dvh] min-h-0 overflow-y-auto">
+        <div className="flex max-h-[55dvh] min-h-0 flex-col">
           <JarUtxosTable
             globalFilter={filter}
             tableEntries={tableEntries}

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -36,7 +36,7 @@ export const UtxoSelectionDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-6xl">
+      <DialogContent className="flex max-w-6xl flex-col overflow-hidden">
         <DialogHeader>
           <DialogTitle>{t('show_utxos.title')}</DialogTitle>
           <DialogDescription>
@@ -45,12 +45,13 @@ export const UtxoSelectionDialog = ({
         </DialogHeader>
 
         <Input
+          className="shrink-0"
           value={filter}
           onChange={(event) => onFilterChange(event.target.value)}
           placeholder={t('jar_details.utxo_list.placeholder_search')}
           disabled={isSubmitting}
         />
-        <div className="flex max-h-[55dvh] min-h-0 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <JarUtxosTable
             globalFilter={filter}
             tableEntries={tableEntries}
@@ -61,7 +62,7 @@ export const UtxoSelectionDialog = ({
           />
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
             {t('modal.confirm_button_reject')}
           </Button>

--- a/src/components/send/UtxoSelectionDialog.tsx
+++ b/src/components/send/UtxoSelectionDialog.tsx
@@ -50,7 +50,7 @@ export const UtxoSelectionDialog = ({
           placeholder={t('jar_details.utxo_list.placeholder_search')}
           disabled={isSubmitting}
         />
-        <div className="max-h-[55dvh] min-h-0 overflow-hidden">
+        <div className="max-h-[55dvh] min-h-0 overflow-y-auto">
           <JarUtxosTable
             globalFilter={filter}
             tableEntries={tableEntries}

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -351,7 +351,7 @@ export const WalletJarsDetailsContent = ({
         </TabsList>
       </Tabs>
 
-      <Tabs defaultValue="utxos" className="flex flex-1 flex-col gap-4">
+      <Tabs defaultValue="utxos" className="flex min-h-0 flex-1 flex-col gap-4">
         <TabsList className="mx-auto flex items-center gap-2">
           <TabsTrigger value="utxos" className="cursor-pointer" disabled={!enabled}>
             {t('jar_details.title_tab_utxos')}
@@ -366,7 +366,7 @@ export const WalletJarsDetailsContent = ({
           )}
         </TabsList>
 
-        <TabsContent value="utxos" className="flex flex-col gap-2">
+        <TabsContent value="utxos" className="flex min-h-0 flex-1 flex-col gap-2">
           <UtxosContent
             key={activeJar.jarIndex}
             enabled={enabled}

--- a/src/components/wallet/WalletJarsDetailsOverlay.tsx
+++ b/src/components/wallet/WalletJarsDetailsOverlay.tsx
@@ -34,7 +34,7 @@ export function WalletJarsDetailsOverlay({
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <WalletJarsDetailsContent
             enabled={open}
-            className="flex h-full flex-col overflow-auto p-2 pt-0"
+            className="flex h-full min-h-0 flex-col overflow-hidden p-2 pt-0"
             debug={isDeveloperMode}
             selectedJarIndex={selectedJarIndex}
             walletFileName={walletFileName}


### PR DESCRIPTION
Closes #1324

Changed `overflow-hidden` to `overflow-y-auto` on the wrapper so the table region scrolls within the dialog while the search input and footer buttons stay visible.


@theborakompanioni 