### PR TITLE
chore(build): require min node level of v26.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,8 +97,8 @@
         "vitest": "4.1.9"
       },
       "engines": {
-        "node": ">=24.11.1",
-        "npm": ">=11.6.2"
+        "node": ">=26.3.0",
+        "npm": ">=11.16.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=24.11.1",
-    "npm": ">=11.6.2"
+    "node": ">=26.3.0",
+    "npm": ">=11.16.0"
   },
   "scripts": {
     "dev": "npm run dev:ng:native",


### PR DESCRIPTION
This is required in order to support `NODE_OPTIONS=--no-webstorage` (in tests)
