### PR TITLE
feat: display alert and reload balance on tx message via websocket

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,6 +67,10 @@ vi.mock('./store/jmSessionStore', () => ({
   jmSessionStore: { getState: () => ({ state: holders.jmSession }) },
 }))
 
+vi.mock('./store/jmTxStore', () => ({
+  jmTxStore: { getState: () => ({ state: {} }) },
+}))
+
 vi.mock('@/store/jamSettingsStore', () => ({
   jamSettingsStore: { getState: () => ({ state: { developerMode: holders.developerMode } }) },
   useDeveloperMode: () => ({ enabled: holders.developerMode }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import { useJamWalletInfoContext } from './context/JamWalletInfoContext'
 import { JmWebsocketContextProvider } from './context/JmWebsocketContextProvider'
 import { getErrorReason } from './lib/errorReason'
 import { jmSessionStore } from './store/jmSessionStore'
+import { jmTxStore, type JmTxInfos } from './store/jmTxStore'
 import type { Milliseconds } from './types/global'
 
 const DevSetupPage = lazy(() => import('@/components/dev/DevSetupPage'))
@@ -387,6 +388,7 @@ const RELOAD_WALLET_INFO_DELAY: {
   AFTER_UTXO_CHANGE: Milliseconds
   AFTER_BLOCK_HEIGHT_CHANGE: Milliseconds
   AFTER_TAKER_STOPPED: Milliseconds
+  AFTER_TX_MESSAGE: Milliseconds
 } = {
   // After rescanning, it is necessary to give the JM backend some time to synchronize.
   // A couple of seconds should be enough, however, this depends on the user hardware
@@ -404,6 +406,9 @@ const RELOAD_WALLET_INFO_DELAY: {
 
   // Small delay is sufficient after block height change
   AFTER_TAKER_STOPPED: 210,
+
+  // Small delay is sufficient after an incoming tx message via websocket
+  AFTER_TX_MESSAGE: 210,
 }
 
 /**
@@ -424,6 +429,9 @@ const WalletInfoAutoReload = () => {
   const previousRescanningRef = useRef<boolean>(currentRescanInfo.rescanning)
   const previousBlockHeightRef = useRef<number | undefined>(currentBlockHeight)
   const previousTakerRunningRef = useRef<boolean>(currentTakerRunning)
+
+  const jmTxs = useStore(jmTxStore, (state) => state.state)
+  const previousJmTxsRef = useRef<JmTxInfos>(jmTxs)
 
   const { refetch: refetchWalletBalance, utxosHashHex } = useJamWalletInfoContext()
 
@@ -492,6 +500,26 @@ const WalletInfoAutoReload = () => {
       return () => abortCtrl.abort('useEffect(AFTER_UTXO_CHANGE) ended')
     },
     [refetchWalletBalance, utxosHashHex],
+  )
+
+  useEffect(
+    function refetchWalletInfoAfterTxMessage() {
+      const txsChanged = previousJmTxsRef.current !== jmTxs
+      previousJmTxsRef.current = jmTxs
+      if (!txsChanged) {
+        return
+      }
+
+      const delayBefore = RELOAD_WALLET_INFO_DELAY.AFTER_TX_MESSAGE
+      console.debug('Trigger refetch looking for funds AFTER_TX_MESSAGE with delay %d...', delayBefore)
+
+      const abortCtrl = new AbortController()
+      refetchWalletBalance({ delayBefore, signal: abortCtrl.signal }).catch((error: unknown) => {
+        console.warn('Error while auto-reloading wallet info AFTER_TX_MESSAGE finished', error)
+      })
+      return () => abortCtrl.abort('useEffect(AFTER_TX_MESSAGE) ended')
+    },
+    [refetchWalletBalance, jmTxs],
   )
 
   useEffect(

--- a/src/context/JmWebsocketContextProvider.test.tsx
+++ b/src/context/JmWebsocketContextProvider.test.tsx
@@ -6,6 +6,7 @@ import { JmWebsocketContextProvider } from './JmWebsocketContextProvider'
 
 const mocks = vi.hoisted(() => ({
   useJmWebsocket: vi.fn(),
+  toastInfo: vi.fn(),
   websocket: {
     isOpen: true,
     isAuthenticated: true,
@@ -20,6 +21,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/hooks/useJmWebsocket', () => ({
   useJmWebsocket: mocks.useJmWebsocket,
+}))
+
+vi.mock('sonner', () => ({
+  toast: { info: mocks.toastInfo },
 }))
 
 const Consumer = () => {
@@ -82,6 +87,53 @@ describe('<JmWebsocketContextProvider />', () => {
 
     expect(jmTxStore.getState().get(txid)).toEqual({ txid, outs: [] })
     expect(jmTxStore.getState().get('short')).toBeUndefined()
+  })
+
+  it('shows an info toast for unknown transactions from websocket messages', () => {
+    render(
+      <JmWebsocketContextProvider>
+        <Consumer />
+      </JmWebsocketContextProvider>,
+    )
+
+    const onMessage = lastOnMessage()
+    const txid = 'b'.repeat(64)
+
+    onMessage(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          txid,
+          txdetails: { txid, outs: [] },
+        }),
+      }),
+    )
+
+    expect(mocks.toastInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show a toast for transactions already known (e.g. made via the ui)', () => {
+    const txid = 'c'.repeat(64)
+    jmTxStore.getState().add({ txid })
+
+    render(
+      <JmWebsocketContextProvider>
+        <Consumer />
+      </JmWebsocketContextProvider>,
+    )
+
+    const onMessage = lastOnMessage()
+
+    onMessage(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          txid,
+          txdetails: { txid, outs: [] },
+        }),
+      }),
+    )
+
+    expect(mocks.toastInfo).not.toHaveBeenCalled()
+    expect(jmTxStore.getState().get(txid)).toEqual({ txid, outs: [] })
   })
 
   it('ignores malformed websocket payloads', () => {

--- a/src/context/JmWebsocketContextProvider.test.tsx
+++ b/src/context/JmWebsocketContextProvider.test.tsx
@@ -113,7 +113,7 @@ describe('<JmWebsocketContextProvider />', () => {
 
   it('does not show a toast for transactions already known (e.g. made via the ui)', () => {
     const txid = 'c'.repeat(64)
-    jmTxStore.getState().add({ txid })
+    jmTxStore.getState().add({ txid, hex: '00' })
 
     render(
       <JmWebsocketContextProvider>

--- a/src/context/JmWebsocketContextProvider.tsx
+++ b/src/context/JmWebsocketContextProvider.tsx
@@ -1,5 +1,8 @@
 import type { PropsWithChildren } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { useJmWebsocket } from '@/hooks/useJmWebsocket'
+import { shortenStringMiddle } from '@/lib/utils'
 import { jmTxStore, type JmTxInfo } from '@/store/jmTxStore'
 import { JmWebsocketContext } from './JmWebsocketContext'
 
@@ -21,9 +24,15 @@ function isJmTxWebsocketMessage(val: unknown): val is JmTxWebsocketMessage {
   )
 }
 
-const onWebsocketMessage = (message: unknown) => {
+const onWebsocketMessage = (message: unknown, onNewTx: (tx: JmTxInfo) => void) => {
   if (isJmTxWebsocketMessage(message)) {
+    // txs made via the ui are added to the store before the websocket
+    // echoes them, so an unknown txid means an external tx (e.g. earn, deposit)
+    const isKnownTx = jmTxStore.getState().get(message.txid) !== undefined
     jmTxStore.getState().add(message.txdetails)
+    if (!isKnownTx) {
+      onNewTx(message.txdetails)
+    }
   }
 }
 
@@ -32,6 +41,7 @@ interface JmWebsocketContextType {
 }
 
 export const JmWebsocketContextProvider = ({ children }: PropsWithChildren<JmWebsocketContextType>) => {
+  const { t } = useTranslation()
   const websocket = useJmWebsocket({
     config: {
       enableHeartbeat: true,
@@ -49,7 +59,9 @@ export const JmWebsocketContextProvider = ({ children }: PropsWithChildren<JmWeb
         })()
 
         if (message !== undefined && message !== null) {
-          onWebsocketMessage(message)
+          onWebsocketMessage(message, (tx) => {
+            toast.info(t('app.alert_new_transaction', { txid: shortenStringMiddle(tx.txid) }))
+          })
         }
       },
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -41,6 +41,7 @@
     "next": "Next"
   },
   "app": {
+    "alert_new_transaction": "New transaction: {{ txid }}",
     "alert_rescan_in_progress": "Rescanning in progress...",
     "alert_rescan_in_progress_with_progress": "Rescanning in progress ({{progress}}%)..."
   },


### PR DESCRIPTION
Closes [#1307](https://github.com/joinmarket-webui/jam/issues/1307)

On incoming tx messages via websocket, the wallet info is now reloaded (new AFTER_TX_MESSAGE trigger in WalletInfoAutoReload, same pattern as the existing triggers) and a brief info toast "New transaction: xxxx…xxxx" is shown.

The toast is only shown for txids not already present in jmTxStore transactions made via the UI are added to the store before the websocket echoes them, so they don't produce a duplicate alert. This also dedupes repeated notifications for the same tx.

Verified on regtest by triggering a direct-send via the API (outside the UI): toast appears and balance updates without user interaction. 

Note: the backend currently only emits tx messages from the coinjoin/direct-send paths, not for external deposits the frontend handles those messages whenever the backend starts sending them.
<img width="800" height="1046" alt="image" src="https://github.com/user-attachments/assets/f20c9357-bf86-4abf-ac62-79008a28533d" />