### PR TITLE
fix(ui): wrap table pagination row instead of cutting off buttons

### DIFF
--- a/src/components/ui/jam/TablePagination.tsx
+++ b/src/components/ui/jam/TablePagination.tsx
@@ -54,7 +54,7 @@ const TablePagination = ({
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center gap-2 px-2 py-4 sm:flex-row sm:justify-between',
+        'flex flex-col items-center justify-center gap-2 px-2 py-4 sm:flex-row sm:flex-wrap sm:justify-between',
         className,
       )}
     >


### PR DESCRIPTION
Closes [#1334](https://github.com/joinmarket-webui/jam/issues/1334)


<img width="706" height="442" alt="image" src="https://github.com/user-attachments/assets/1395b509-d8e7-4e6b-8eaa-2cfa7a23ba4b" />
