### PR TITLE
docs: replace joinmarket-clientserver references to joinmarket-ng

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ The aim of this document is to help you get setup for participating in all areas
 
 ## Understanding the Components Involved
 
-Jam is a web UI for [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver/) with focus on user-friendliness.
+Jam is a web UI for [JoinMarket-NG](https://github.com/joinmarket-ng/joinmarket-ng) with focus on user-friendliness.
 The web UI's purpose is to be a rather lightweight front end for the JoinMarket API.
-To function, the web UI needs to connect to an instance of JoinMarket with [the API service](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/JSON-RPC-API-using-jmwalletd.md) running.
+To function, the web UI needs to connect to an instance of JoinMarket-NG with [the API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/) running.
 
 You don't need to worry about that, though.
-To ease development and testing, we provide a Docker setup that runs JoinMarket and its API service in a regtest setup.
+To ease development and testing, we provide a Docker setup that runs JoinMarket-NG and its API service in a regtest setup.
 
 ## Local setup (regtest and UI)
 
@@ -22,7 +22,7 @@ Install dependencies:
 npm install
 ```
 
-Start the JoinMarket HTTP API service in regtest.
+Start the JoinMarket-NG HTTP API service in regtest.
 It isn't needed to dig deeper into how it works to use it.
 However, if you want to find out more about it, see [docker/regtest/readme.md](docker/regtest/readme.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ The aim of this document is to help you get setup for participating in all areas
 
 ## Understanding the Components Involved
 
-Jam is a web UI for [JoinMarket-NG](https://github.com/joinmarket-ng/joinmarket-ng) with focus on user-friendliness.
-The web UI's purpose is to be a rather lightweight front end for the JoinMarket-NG API.
-To function, the web UI needs to connect to an instance of JoinMarket-NG with [the API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/) running.
+Jam is a web UI for [JoinMarket NG](https://github.com/joinmarket-ng/joinmarket-ng) with focus on user-friendliness.
+The web UI's purpose is to be a rather lightweight front end for the JoinMarket NG API.
+To function, the web UI needs to connect to an instance of JoinMarket NG with [the API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/) running.
 
 You don't need to worry about that, though.
-To ease development and testing, we provide a Docker setup that runs JoinMarket-NG and its API service in a regtest setup.
+To ease development and testing, we provide a Docker setup that runs JoinMarket NG and its API service in a regtest setup.
 
 ## Local setup (regtest and UI)
 
@@ -22,7 +22,7 @@ Install dependencies:
 npm install
 ```
 
-Start the JoinMarket-NG HTTP API service in regtest.
+Start the JoinMarket NG HTTP API service in regtest.
 It isn't needed to dig deeper into how it works to use it.
 However, if you want to find out more about it, see [docker/regtest/readme.md](docker/regtest/readme.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The aim of this document is to help you get setup for participating in all areas
 ## Understanding the Components Involved
 
 Jam is a web UI for [JoinMarket-NG](https://github.com/joinmarket-ng/joinmarket-ng) with focus on user-friendliness.
-The web UI's purpose is to be a rather lightweight front end for the JoinMarket API.
+The web UI's purpose is to be a rather lightweight front end for the JoinMarket-NG API.
 To function, the web UI needs to connect to an instance of JoinMarket-NG with [the API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/) running.
 
 You don't need to worry about that, though.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ---
 
-Jam is a web interface for [JoinMarket](https://github.com/JoinMarket-Org/joinmarket-clientserver/) focusing on user-friendliness and ease-of-use.
+Jam is a web interface for [JoinMarket-NG](https://github.com/joinmarket-ng/joinmarket-ng) focusing on user-friendliness and ease-of-use.
 It aims to provide sensible defaults and be easy to use for beginners while still having the features advanced users expect.
 
 - 💬 Join our [Matrix room](https://matrix.to/#/%23jam:bitcoin.kyoto) to get help and [contribute](https://joinmarket-webui.github.io/jamdocs/contribute/)!
@@ -88,4 +88,4 @@ Want to get your hands dirty with code? Great! [CONTRIBUTING.md](CONTRIBUTING.md
 
 This project builds upon the [jm-web-client](https://github.com/JoinMarket-Org/jm-web-client) which was developed by [Shobhitaa](https://github.com/shobhitaa), [Abhishek](https://github.com/abhishek0405), and [waxwing](https://github.com/AdamISZ) himself. Many people contributed over time, some of which are [listed here](https://github.com/joinmarket-webui/jam/graphs/contributors).
 
-Jam and JoinMarket are separate projects. For more information on JoinMarket, see the [JoinMarket GitHub Page](https://github.com/JoinMarket-Org/joinmarket-clientserver).
+Jam and JoinMarket-NG are separate projects. For more information on JoinMarket-NG, see the [JoinMarket-NG GitHub Page](https://github.com/joinmarket-ng/joinmarket-ng).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ---
 
-Jam is a web interface for [JoinMarket-NG](https://github.com/joinmarket-ng/joinmarket-ng) focusing on user-friendliness and ease-of-use.
+Jam is a web interface for [JoinMarket NG](https://github.com/joinmarket-ng/joinmarket-ng) focusing on user-friendliness and ease-of-use.
 It aims to provide sensible defaults and be easy to use for beginners while still having the features advanced users expect.
 
 - 💬 Join our [Matrix room](https://matrix.to/#/%23jam:bitcoin.kyoto) to get help and [contribute](https://joinmarket-webui.github.io/jamdocs/contribute/)!
@@ -88,4 +88,4 @@ Want to get your hands dirty with code? Great! [CONTRIBUTING.md](CONTRIBUTING.md
 
 This project builds upon the [jm-web-client](https://github.com/JoinMarket-Org/jm-web-client) which was developed by [Shobhitaa](https://github.com/shobhitaa), [Abhishek](https://github.com/abhishek0405), and [waxwing](https://github.com/AdamISZ) himself. Many people contributed over time, some of which are [listed here](https://github.com/joinmarket-webui/jam/graphs/contributors).
 
-Jam and JoinMarket-NG are separate projects. For more information on JoinMarket-NG, see the [JoinMarket-NG GitHub Page](https://github.com/joinmarket-ng/joinmarket-ng).
+Jam and JoinMarket NG are separate projects. For more information on JoinMarket NG, see the [JoinMarket NG GitHub Page](https://github.com/joinmarket-ng/joinmarket-ng).

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -6,7 +6,7 @@ A place to collect useful information for developers that doesn't really fit els
 
 ## JoinMarket Development Environment
 
-For a complete development environment you need a local JoinMarket instance that the web UI can interact with. We provide a regtest environment that should give you everything needed to get started developing with JoinMarket. You can find details here: [docker/regtest/readme.md](../docker/regtest/readme.md).
+For a complete development environment you need a local JoinMarket-NG instance that the web UI can interact with. We provide a regtest environment that should give you everything needed to get started developing with JoinMarket-NG. You can find details here: [docker/regtest/readme.md](../docker/regtest/readme.md).
 
 ## Running Jam Against JoinMarket-NG
 
@@ -86,17 +86,17 @@ By default, the hook will be installed automatically as an [NPM postinstall scri
 If you're having issues with Husky not using the correct `$PATH`, you may need to setup a `~/.huskyrc` which will let you set up your path before the hook is run.
 See [here](https://typicode.github.io/husky/#/?id=command-not-found) for more info.
 
-## Running the Web UI Locally and Connecting to a Remote JoinMarket Instance
+## Running the Web UI Locally and Connecting to a Remote JoinMarket-NG Instance
 
-These instructions assume you want to run the web UI locally and connect it to a JoinMarket instance on your RaspiBlitz.
+These instructions assume you want to run the web UI locally and connect it to a JoinMarket-NG instance on your RaspiBlitz.
 The process should be similar for other setups.
-If you run the Web UI and JoinMarket on the same system, simply skip the SSH tunnel step.
+If you run the Web UI and JoinMarket-NG on the same system, simply skip the SSH tunnel step.
 
-### 🚨 Prerequisite: JoinMarket
+### 🚨 Prerequisite: JoinMarket-NG
 
-To run the web UI locally you need to connect it to a running JoinMarket instance.
+To run the web UI locally you need to connect it to a running JoinMarket-NG instance.
 
-#### 1. Install JoinMarket
+#### 1. Install JoinMarket-NG
 
 Install [JoininBox](https://github.com/openoms/joininbox) on your [RaspiBlitz](https://github.com/rootzoll/raspiblitz):
 
@@ -104,38 +104,38 @@ Install [JoininBox](https://github.com/openoms/joininbox) on your [RaspiBlitz](h
 Services > j [BTC JoinMarket+JoininBox menu]
 ```
 
-Or follow the JoinMarket [installation guide](https://github.com/JoinMarket-Org/joinmarket-clientserver#quickstart---recommended-installation-method-linux-and-macos-only) if you're on another system.
+Or follow the JoinMarket-NG [installation guide](https://joinmarket-ng.github.io/joinmarket-ng/install/) if you're on another system.
 
-### 🚨 Prerequisite: JoinMarket API Service
+### 🚨 Prerequisite: JoinMarket-NG API Service
 
-This app makes use of the JoinMarket RPC API. For this, you will need JoinMarket version 0.9.3 or higher. If needed you can upgrade JoinMarket to the latest commit via the JoininBox menu on your RaspiBlitz: Type `jm` in the command line and select `UPDATE > ADVANCED > JMCOMMIT`. This will install the latest development version from JoinMarket's master branch.
+This app makes use of the JoinMarket-NG API.
 
 #### 2. SSL Certificate
 
-As the joinmarket user on your RaspiBlitz, generate a self-signed certificate for the JoinMarket API Service as described [here](https://linuxize.com/post/creating-a-self-signed-ssl-certificate/), and put the certificate and the key in the `~/.joinmarket/ssl/` directory.
+As the joinmarket user on your RaspiBlitz, generate a self-signed certificate for the JoinMarket-NG API Service as described [here](https://linuxize.com/post/creating-a-self-signed-ssl-certificate/), and put the certificate and the key in the `~/.joinmarket-ng/ssl/` directory.
 
 _Hint:_ To login as the JoinMarket user, you can ssh into your RaspiBlitz, type `jm`, and exit the JoininBox menu.
 
 Create the SSL directory:
 
 ```bash
-(jmvenv) joinmarket@raspberrypi:~ $ mkdir ~/.joinmarket/ssl/
+(jmvenv) joinmarket@raspberrypi:~ $ mkdir ~/.joinmarket-ng/ssl/
 ```
 
 Generate the certificate and associated key:
 
 ```bash
-openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out ~/.joinmarket/ssl/cert.pem -keyout ~/.joinmarket/ssl/key.pem
+openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out ~/.joinmarket-ng/ssl/cert.pem -keyout ~/.joinmarket-ng/ssl/key.pem
 ```
 
 _Hint:_ You don't have to enter anything meaningful, you can just hit the return key a couple of times.
 
 #### 3. API Service
 
-Start the JoinMarket [API service](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/JSON-RPC-API-using-jmwalletd.md):
+Start the JoinMarket-NG [API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/):
 
 ```bash
-(jmvenv) joinmarket@raspberrypi:~/joinmarket-clientserver/scripts $ python jmwalletd.py
+(jmvenv) joinmarket@raspberrypi:~/joinmarket-ng $ jmwalletd serve
 ```
 
 You should see the following:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -6,9 +6,9 @@ A place to collect useful information for developers that doesn't really fit els
 
 ## JoinMarket Development Environment
 
-For a complete development environment you need a local JoinMarket-NG instance that the web UI can interact with. We provide a regtest environment that should give you everything needed to get started developing with JoinMarket-NG. You can find details here: [docker/regtest/readme.md](../docker/regtest/readme.md).
+For a complete development environment you need a local JoinMarket NG instance that the web UI can interact with. We provide a regtest environment that should give you everything needed to get started developing with JoinMarket NG. You can find details here: [docker/regtest/readme.md](../docker/regtest/readme.md).
 
-## Running Jam Against JoinMarket-NG
+## Running Jam Against JoinMarket NG
 
 Jam v2 can talk directly to a separately running `jmwalletd` / orderbook watcher from `joinmarket-ng`. You do not need to run the Jam regtest compose or the reference implementation for this workflow.
 
@@ -86,17 +86,17 @@ By default, the hook will be installed automatically as an [NPM postinstall scri
 If you're having issues with Husky not using the correct `$PATH`, you may need to setup a `~/.huskyrc` which will let you set up your path before the hook is run.
 See [here](https://typicode.github.io/husky/#/?id=command-not-found) for more info.
 
-## Running the Web UI Locally and Connecting to a Remote JoinMarket-NG Instance
+## Running the Web UI Locally and Connecting to a Remote JoinMarket NG Instance
 
-These instructions assume you want to run the web UI locally and connect it to a JoinMarket-NG instance on your RaspiBlitz.
+These instructions assume you want to run the web UI locally and connect it to a JoinMarket NG instance on your RaspiBlitz.
 The process should be similar for other setups.
-If you run the Web UI and JoinMarket-NG on the same system, simply skip the SSH tunnel step.
+If you run the Web UI and JoinMarket NG on the same system, simply skip the SSH tunnel step.
 
-### 🚨 Prerequisite: JoinMarket-NG
+### 🚨 Prerequisite: JoinMarket NG
 
-To run the web UI locally you need to connect it to a running JoinMarket-NG instance.
+To run the web UI locally you need to connect it to a running JoinMarket NG instance.
 
-#### 1. Install JoinMarket-NG
+#### 1. Install JoinMarket NG
 
 Install [JoininBox](https://github.com/openoms/joininbox) on your [RaspiBlitz](https://github.com/rootzoll/raspiblitz):
 
@@ -104,15 +104,15 @@ Install [JoininBox](https://github.com/openoms/joininbox) on your [RaspiBlitz](h
 Services > j [BTC JoinMarket+JoininBox menu]
 ```
 
-Or follow the JoinMarket-NG [installation guide](https://joinmarket-ng.github.io/joinmarket-ng/install/) if you're on another system.
+Or follow the JoinMarket NG [installation guide](https://joinmarket-ng.github.io/joinmarket-ng/install/) if you're on another system.
 
-### 🚨 Prerequisite: JoinMarket-NG API Service
+### 🚨 Prerequisite: JoinMarket NG API Service
 
-This app makes use of the JoinMarket-NG API.
+This app makes use of the JoinMarket NG API.
 
 #### 2. SSL Certificate
 
-As the joinmarket user on your RaspiBlitz, generate a self-signed certificate for the JoinMarket-NG API Service as described [here](https://linuxize.com/post/creating-a-self-signed-ssl-certificate/), and put the certificate and the key in the `~/.joinmarket-ng/ssl/` directory.
+As the joinmarket user on your RaspiBlitz, generate a self-signed certificate for the JoinMarket NG API Service as described [here](https://linuxize.com/post/creating-a-self-signed-ssl-certificate/), and put the certificate and the key in the `~/.joinmarket-ng/ssl/` directory.
 
 _Hint:_ To login as the JoinMarket user, you can ssh into your RaspiBlitz, type `jm`, and exit the JoininBox menu.
 
@@ -132,7 +132,7 @@ _Hint:_ You don't have to enter anything meaningful, you can just hit the return
 
 #### 3. API Service
 
-Start the JoinMarket-NG [API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/):
+Start the JoinMarket NG [API service](https://joinmarket-ng.github.io/joinmarket-ng/README-jmwalletd/):
 
 ```bash
 (jmvenv) joinmarket@raspberrypi:~/joinmarket-ng $ jmwalletd serve


### PR DESCRIPTION
This PR replaces legacy `joinmarket-clientserver` documentation and repository references with available
`joinmarket-ng` equivalents.

> Note:
> no joinmarket-ng equivalents found for `src/components/send/SendCoinjoinPreconditionAlert.tsx:12` and `src/components/sweep/SweepPreconditionAlert.tsx:12`

Closes #1314 