### PR TITLE
refactor(send): standardize jar selector form handling

### DIFF
--- a/src/components/send/JarSelectorDialog.schema.test.ts
+++ b/src/components/send/JarSelectorDialog.schema.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { createJarSelectorDialogFormSchema } from './JarSelectorDialog.schema'
+
+describe('createJarSelectorDialogFormSchema', () => {
+  const schema = createJarSelectorDialogFormSchema([0, 2])
+
+  it('accepts a selectable jar index', async () => {
+    await expect(schema.validate({ jarIndex: 2 })).resolves.toEqual({ jarIndex: 2 })
+  })
+
+  it.each([{ jarIndex: 1 }, { jarIndex: undefined }])('rejects an unavailable jar index', async (values) => {
+    await expect(schema.isValid(values)).resolves.toBe(false)
+  })
+})

--- a/src/components/send/JarSelectorDialog.schema.ts
+++ b/src/components/send/JarSelectorDialog.schema.ts
@@ -1,0 +1,15 @@
+import * as yup from 'yup'
+import type { JarIndex } from '@/types/global'
+
+export type JarSelectorDialogFormValues = {
+  jarIndex: JarIndex
+}
+
+export const createJarSelectorDialogFormSchema = (
+  selectableJarIndexes: JarIndex[],
+): yup.ObjectSchema<JarSelectorDialogFormValues> =>
+  yup
+    .object({
+      jarIndex: yup.number().oneOf(selectableJarIndexes).required(),
+    })
+    .required()

--- a/src/components/send/JarSelectorDialog.test.tsx
+++ b/src/components/send/JarSelectorDialog.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../ui/jam/SelectableJar', () => ({
     disabled?: boolean
     isSelected?: boolean
   }) => (
-    <button onClick={onClick} disabled={disabled} data-selected={isSelected}>
+    <button type="button" onClick={onClick} disabled={disabled} data-selected={isSelected}>
       {name}
     </button>
   ),
@@ -94,20 +94,23 @@ describe('JarSelectorDialog', () => {
     expect(screen.queryByText('Pick a jar')).not.toBeInTheDocument()
   })
 
-  it('disables the confirm button until a jar is selected', () => {
+  it('disables the confirm button until a jar is selected', async () => {
     renderDialog()
-    const confirm = screen.getByText('modal.confirm_button_accept').closest('button')
+    const confirm = screen.getByRole('button', { name: 'modal.confirm_button_accept' })
     expect(confirm).toBeDisabled()
     fireEvent.click(screen.getByText('Jar 0'))
-    expect(confirm).not.toBeDisabled()
+    await waitFor(() => expect(confirm).not.toBeDisabled())
   })
 
   it('confirms the selected jar', async () => {
     const onConfirm = vi.fn().mockResolvedValue(undefined)
     renderDialog({ onConfirm })
     fireEvent.click(screen.getByText('Jar 0'))
-    fireEvent.click(screen.getByText('modal.confirm_button_accept'))
+    const confirm = screen.getByRole('button', { name: 'modal.confirm_button_accept' })
+    await waitFor(() => expect(confirm).not.toBeDisabled())
+    fireEvent.click(confirm)
     await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(0))
+    await waitFor(() => expect(confirm).toBeDisabled())
   })
 
   it('closes and resets via the reject button', () => {

--- a/src/components/send/JarSelectorDialog.tsx
+++ b/src/components/send/JarSelectorDialog.tsx
@@ -1,4 +1,6 @@
-import { useState, type ComponentProps } from 'react'
+import { useMemo, type ComponentProps } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useForm, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { Jar } from '@/context/JamWalletInfoContext'
 import type { BalanceSummary } from '@/lib/balanceSummary'
@@ -7,6 +9,7 @@ import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogTitle, DialogDescription, DialogFooter, DialogHeader } from '../ui/dialog'
 import { SelectableJar } from '../ui/jam/SelectableJar'
 import { Spinner } from '../ui/spinner'
+import { createJarSelectorDialogFormSchema, type JarSelectorDialogFormValues } from './JarSelectorDialog.schema'
 
 type JarSelectorDialogProps = WithRequiredProperty<
   Omit<ComponentProps<typeof Dialog>, 'children'>,
@@ -33,73 +36,100 @@ export default function JarSelectorDialog({
 }: JarSelectorDialogProps) {
   const { t } = useTranslation()
 
-  const [isConfirming, setIsConfirming] = useState(false)
-  const [selectedJar, setSelectedJar] = useState<Jar>()
+  const selectableJarIndexes = useMemo(
+    () => jars.filter((jar) => !disabledJars.includes(jar)).map((jar) => jar.jarIndex),
+    [disabledJars, jars],
+  )
+  const schema = useMemo(() => createJarSelectorDialogFormSchema(selectableJarIndexes), [selectableJarIndexes])
+  const {
+    control,
+    handleSubmit,
+    reset,
+    setValue,
+    formState: { isSubmitting },
+  } = useForm<JarSelectorDialogFormValues>({
+    mode: 'onChange',
+    defaultValues: {
+      jarIndex: undefined,
+    },
+    resolver: yupResolver(schema),
+  })
+  const selectedJarIndex = useWatch({ control, name: 'jarIndex' })
+  const selectedJar = jars.find((jar) => jar.jarIndex === selectedJarIndex)
+  const canConfirm =
+    selectedJarIndex !== undefined && selectedJar !== undefined && selectableJarIndexes.includes(selectedJarIndex)
 
   const handleClose = () => {
-    setSelectedJar(undefined)
+    reset()
     onOpenChange(false)
   }
 
-  const confirm = async () => {
-    if (selectedJar === undefined) return
-
-    setIsConfirming(true)
-    try {
-      await onConfirm(selectedJar.jarIndex)
-      setSelectedJar(undefined)
-    } finally {
-      setIsConfirming(false)
-    }
-  }
+  const doOnSubmit = handleSubmit(async ({ jarIndex }) => {
+    await onConfirm(jarIndex)
+    reset()
+  })
 
   return (
     <Dialog open={open} onOpenChange={handleClose} {...dialogProps}>
       <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">{title}</DialogTitle>
-          {subtitle && <DialogDescription>{subtitle}</DialogDescription>}
-        </DialogHeader>
+        <form onSubmit={(event) => void doOnSubmit(event)} className="grid gap-4" noValidate>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">{title}</DialogTitle>
+            {subtitle && <DialogDescription>{subtitle}</DialogDescription>}
+          </DialogHeader>
 
-        <div className="py-4">
-          <div className="flex flex-1 flex-row flex-wrap items-center justify-center gap-2 gap-y-4">
-            {jars.map((jar, index) => (
-              <SelectableJar
-                key={index}
-                name={jar.name}
-                color={jar.color}
-                totalBalance={jar.balanceSummary.calculatedTotalBalanceInSats}
-                availableBalance={jar.balanceSummary.calculatedAvailableBalanceInSats}
-                frozenOrLockedBalance={jar.balanceSummary.calculatedFrozenOrLockedBalanceInSats}
-                totalWalletBalance={walletBalanceSummary.calculatedTotalBalanceInSats}
-                isSelected={selectedJar === jar}
-                onClick={() => setSelectedJar(jar)}
-                disabled={disabledJars.includes(jar)}
-              />
-            ))}
+          <div className="py-4">
+            <div className="flex flex-1 flex-row flex-wrap items-center justify-center gap-2 gap-y-4">
+              {jars.map((jar) => (
+                <SelectableJar
+                  key={jar.jarIndex}
+                  name={jar.name}
+                  color={jar.color}
+                  totalBalance={jar.balanceSummary.calculatedTotalBalanceInSats}
+                  availableBalance={jar.balanceSummary.calculatedAvailableBalanceInSats}
+                  frozenOrLockedBalance={jar.balanceSummary.calculatedFrozenOrLockedBalanceInSats}
+                  totalWalletBalance={walletBalanceSummary.calculatedTotalBalanceInSats}
+                  isSelected={selectedJarIndex === jar.jarIndex}
+                  onClick={() =>
+                    setValue('jarIndex', jar.jarIndex, {
+                      shouldDirty: true,
+                      shouldTouch: true,
+                      shouldValidate: true,
+                    })
+                  }
+                  disabled={disabledJars.includes(jar)}
+                />
+              ))}
+            </div>
           </div>
-        </div>
 
-        <DialogFooter className="gap-3 sm:justify-center">
-          <Button className="min-h-12 flex-1 text-base" variant="outline" size="xxl" onClick={handleClose}>
-            {t('modal.confirm_button_reject')}
-          </Button>
-          <Button
-            className="min-h-12 flex-1 text-base"
-            size="xxl"
-            onClick={() => void confirm()}
-            disabled={!selectedJar || isConfirming}
-          >
-            {isConfirming ? (
-              <>
-                <Spinner className="motion-reduce:hidden" />
-                {t('modal.confirm_button_accept')}
-              </>
-            ) : (
-              <>{t('modal.confirm_button_accept')}</>
-            )}
-          </Button>
-        </DialogFooter>
+          <DialogFooter className="gap-3 sm:justify-center">
+            <Button
+              type="button"
+              className="min-h-12 flex-1 text-base"
+              variant="outline"
+              size="xxl"
+              onClick={handleClose}
+            >
+              {t('modal.confirm_button_reject')}
+            </Button>
+            <Button
+              type="submit"
+              className="min-h-12 flex-1 text-base"
+              size="xxl"
+              disabled={!canConfirm || isSubmitting}
+            >
+              {isSubmitting ? (
+                <>
+                  <Spinner className="motion-reduce:hidden" />
+                  {t('modal.confirm_button_accept')}
+                </>
+              ) : (
+                <>{t('modal.confirm_button_accept')}</>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
### Summary

- migrate `JarSelectorDialog` from local state to `react-hook-form`
- add a Yup schema that accepts only selectable jar indexes
- submit through a native form and reset selection after closing or successful confirmation
- add focused schema and component tests

Partially addresses #1258.