### PR TITLE
fix(receive): block new addresses during rescan

### DIFF
--- a/src/components/receive/ReceivePage.test.tsx
+++ b/src/components/receive/ReceivePage.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     developerMode: false,
+    rescanning: false,
     getAddress: vi.fn(),
     defaultJars,
     jars: defaultJars,
@@ -107,6 +108,12 @@ vi.mock('@/context/JamWalletInfoContext', () => ({
   }),
 }))
 
+vi.mock('@/context/JamSessionInfoContext', () => ({
+  useRescanStatus: () => ({
+    rescanInfo: { rescanning: mocks.rescanning },
+  }),
+}))
+
 vi.mock('@/hooks/useApiClient', () => ({
   useApiClient: () => ({}),
 }))
@@ -148,6 +155,7 @@ vi.mock('./ReceiveForm', () => ({
 describe('ReceivePage', () => {
   beforeEach(() => {
     mocks.developerMode = false
+    mocks.rescanning = false
     mocks.jars = mocks.defaultJars
     mocks.getAddress.mockReset()
     mocks.getAddress.mockResolvedValue({ data: { address: 'bc1qexample' } })
@@ -173,6 +181,16 @@ describe('ReceivePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'receive.button_new_address' }))
     expect(mocks.getAddress).toHaveBeenCalledTimes(2)
     await flushActUpdates()
+  })
+
+  it('prevents loading addresses while rescanning', () => {
+    mocks.rescanning = true
+
+    render(<ReceivePage walletFileName="wallet.jmdat" />)
+
+    expect(screen.getByRole('button', { name: 'receive.button_reveal_address' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'receive.button_new_address' })).toBeDisabled()
+    expect(mocks.getAddress).not.toHaveBeenCalled()
   })
 
   it('uses a secondary jar badge when no jar is available', () => {

--- a/src/components/receive/ReceivePage.test.tsx
+++ b/src/components/receive/ReceivePage.test.tsx
@@ -190,6 +190,7 @@ describe('ReceivePage', () => {
 
     expect(screen.getByRole('button', { name: 'receive.button_reveal_address' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'receive.button_new_address' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'receive.button_new_address' }))
     expect(mocks.getAddress).not.toHaveBeenCalled()
   })
 

--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import PageTitle from '@/components/ui/jam/PageTitle'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useRescanStatus } from '@/context/JamSessionInfoContext'
 import { useJars } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import { withMutationDelay } from '@/lib/queryClient'
@@ -34,6 +35,7 @@ interface ReceivePageProps {
 export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
   const { t } = useTranslation()
   const { jars } = useJars()
+  const { rescanInfo } = useRescanStatus()
 
   const [selectedSourceJarIndex, setSelectedSourceJarIndex] = useState(jars.length > 0 ? jars[0].jarIndex : undefined)
   const [amount, setAmount] = useState<AmountSats>()
@@ -107,6 +109,7 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
   }
 
   const fetchNewAddress = async () => {
+    if (rescanInfo.rescanning) return
     await getAddressMutation.mutateAsync()
   }
 
@@ -132,7 +135,7 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
                   variant={jarButtonVariant(selectedSourceJarIndex)}
                   size="lg"
                   onClick={() => void fetchNewAddress()}
-                  disabled={getAddressMutation.isPending}
+                  disabled={getAddressMutation.isPending || rescanInfo.rescanning}
                 >
                   <HatGlassesIcon />
                   {t('receive.button_reveal_address')}
@@ -189,7 +192,11 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
           </div>
 
           <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
-            <Button variant="outline" onClick={() => void fetchNewAddress()} disabled={getAddressMutation.isPending}>
+            <Button
+              variant="outline"
+              onClick={() => void fetchNewAddress()}
+              disabled={getAddressMutation.isPending || rescanInfo.rescanning}
+            >
               {getAddressMutation.isPending ? (
                 <>
                   <RefreshCwIcon className="animate-spin motion-reduce:hidden" />


### PR DESCRIPTION
### Summary

- Prevent new address requests while a wallet rescan is active.
- Disable the reveal and refresh address buttons during rescanning.
- Add regression coverage for the rescan state.

Closes #1361