### PR TITLE
fix(receive): save sourceJarIndex before async operation

### DIFF
--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -67,17 +67,18 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
     mutationKey: ['receive', ...getaddressQueryKey(getAddressOptions)],
     mutationFn: withMutationDelay(
       async () => {
+        const sourceJarIndex = Number.parseInt(getAddressOptions.path.mixdepth, 10)
         const { data } = await getaddress({
           ...getAddressOptions,
           throwOnError: true,
         })
         return {
           address: data.address,
-          sourceJarIndex: Number.parseInt(getAddressOptions.path.mixdepth, 10),
+          sourceJarIndex,
         }
       },
       {
-        delayAfter: 21,
+        throttle: 210,
       },
     ),
     retry: false,

--- a/src/components/send/SendForm.test.tsx
+++ b/src/components/send/SendForm.test.tsx
@@ -286,7 +286,7 @@ describe('SendForm', () => {
     await waitFor(() => expect(h.toastError).toHaveBeenCalledWith('global.errors.error_loading_address_failed'))
   })
 
-  it('applies a pasted bip21 uri', async () => {
+  it('applies a pasted bip21 uri and shows success toast', async () => {
     renderForm()
 
     const inputBefore = document.querySelector('#send-destination') as HTMLInputElement
@@ -303,11 +303,23 @@ describe('SendForm', () => {
     await flushActUpdates()
   })
 
-  it('ignores a non-bitcoin paste', () => {
+  it('ignores a non-bitcoin-uri paste', () => {
     renderForm()
     const input = document.querySelector('#send-destination') as HTMLInputElement
 
     fireEvent.paste(input, { clipboardData: { getData: () => 'just some text' } })
+
+    expect(h.toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('applies pasted address and does show success toast', () => {
+    renderForm()
+    const inputBefore = document.querySelector('#send-destination') as HTMLInputElement
+
+    fireEvent.paste(inputBefore, { clipboardData: { getData: () => h.DEFAULT_SCAN_DUMMY_ADDRESS_1 } })
+
+    const inputAfter = document.querySelector('#send-destination') as HTMLInputElement
+    expect(inputAfter).toHaveValue(h.DEFAULT_SCAN_DUMMY_ADDRESS_1)
 
     expect(h.toastSuccess).not.toHaveBeenCalled()
   })

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -259,7 +259,9 @@ export function SendForm({
 
       event.preventDefault()
       applyBip21Result(parsed)
-      toast.success(t('send.qr_scan_bip21_applied'))
+      if (parsed.fromUri) {
+        toast.success(t('send.qr_scan_bip21_applied'))
+      }
     },
     [applyBip21Result, t],
   )

--- a/src/components/sweep/SweepDestinationInputs.test.tsx
+++ b/src/components/sweep/SweepDestinationInputs.test.tsx
@@ -1,17 +1,33 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { FieldArrayWithId, UseFormReturn } from 'react-hook-form'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SweepDestinationInputs } from './SweepDestinationInputs'
 import type { SweepFormValues } from './SweepFormSchema'
 
 type SweepForm = UseFormReturn<SweepFormValues, unknown, SweepFormValues>
 type SweepFields = Array<FieldArrayWithId<SweepFormValues, 'destinations', 'id'>>
 
+const h = vi.hoisted(() => {
+  const DEFAULT_NEW_DUMMY_ADDRESS_0 = 'bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk'
+  return {
+    DEFAULT_NEW_DUMMY_ADDRESS_0,
+    toastSuccess: vi.fn<(message: string) => void>(),
+  }
+})
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, options?: Record<string, unknown>) => (options ? `${key} ${JSON.stringify(options)}` : key),
   }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (message: string) => {
+      h.toastSuccess(message)
+    },
+  },
 }))
 
 describe('SweepDestinationInputs', () => {
@@ -29,6 +45,11 @@ describe('SweepDestinationInputs', () => {
     { id: '1', address: '' },
     { id: '2', address: '' },
   ] as unknown as SweepFields
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.toastSuccess = vi.fn<(message: string) => void>()
+  })
 
   it('renders input fields correctly', async () => {
     render(
@@ -118,6 +139,7 @@ describe('SweepDestinationInputs', () => {
     )
 
     const inputs = screen.getAllByRole('textbox')
+    expect(inputs).toHaveLength(fields.length)
     await act(async () => {
       await userEvent.click(inputs[0])
       await userEvent.paste('anything')
@@ -128,7 +150,19 @@ describe('SweepDestinationInputs', () => {
       await userEvent.click(inputs[0])
       await userEvent.paste('bitcoin:')
     })
+
     expect(defaultFormMock.setValue).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await userEvent.click(inputs[0])
+      await userEvent.paste(h.DEFAULT_NEW_DUMMY_ADDRESS_0)
+    })
+
+    expect(defaultFormMock.setValue).toHaveBeenCalledWith(`destinations.0.address`, h.DEFAULT_NEW_DUMMY_ADDRESS_0, {
+      shouldValidate: true,
+    })
+
+    expect(h.toastSuccess).not.toHaveBeenCalled()
 
     await act(async () => {
       await userEvent.click(inputs[1])
@@ -136,11 +170,13 @@ describe('SweepDestinationInputs', () => {
         'bitcoin:bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk?amount=0.0021&label=order%20123&message=regtest',
       )
     })
+
     expect(defaultFormMock.setValue).toHaveBeenCalledWith(
       `destinations.1.address`,
       'bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk',
       { shouldValidate: true },
     )
+    expect(h.toastSuccess).toHaveBeenCalledWith('send.qr_scan_bip21_applied')
   })
 
   it('adds additional destination inputs', () => {

--- a/src/components/sweep/SweepDestinationInputs.tsx
+++ b/src/components/sweep/SweepDestinationInputs.tsx
@@ -55,7 +55,9 @@ export const SweepDestinationInputs = ({
 
       event.preventDefault()
       applyBip21Result(parsed, index)
-      toast.success(t('send.qr_scan_bip21_applied'))
+      if (parsed.fromUri) {
+        toast.success(t('send.qr_scan_bip21_applied'))
+      }
     },
     [applyBip21Result, t],
   )

--- a/src/lib/bip21.test.ts
+++ b/src/lib/bip21.test.ts
@@ -10,17 +10,17 @@ describe('parseBip21Uri', () => {
   describe('raw addresses', () => {
     it('parses a valid mainnet address', () => {
       const result = parseBip21Uri(VALID_ADDRESS)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: false })
     })
 
     it('parses a valid testnet address', () => {
       const result = parseBip21Uri(VALID_TESTNET_ADDRESS)
-      expect(result).toEqual({ address: VALID_TESTNET_ADDRESS })
+      expect(result).toEqual({ address: VALID_TESTNET_ADDRESS, fromUri: false })
     })
 
     it('trims whitespace around address', () => {
       const result = parseBip21Uri(`  ${VALID_ADDRESS}  `)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: false })
     })
 
     it('returns undefined for invalid address', () => {
@@ -35,32 +35,38 @@ describe('parseBip21Uri', () => {
   describe('BIP21 URIs', () => {
     it('parses bitcoin: URI with address only', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}`)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true })
     })
 
     it('parses bitcoin: URI with amount', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0.5`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 50_000_000 })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 50_000_000 })
     })
 
     it('parses bitcoin: URI with 1 BTC amount', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=1`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 100_000_000 })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 100_000_000 })
     })
 
     it('parses bitcoin: URI with small amount (1 sat)', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0.00000001`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 1 })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 1 })
     })
 
     it('handles case-insensitive scheme', () => {
-      const result = parseBip21Uri(`BITCOIN:${VALID_ADDRESS}?amount=0.1`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 10_000_000 })
+      const result = parseBip21Uri(`BiTcOiN:${VALID_ADDRESS}?amount=0.1`)
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 10_000_000 })
     })
 
     it('ignores extra query parameters', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0.01&label=test&message=hello`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 1_000_000, label: 'test', message: 'hello' })
+      expect(result).toEqual({
+        address: VALID_ADDRESS,
+        fromUri: true,
+        amount: 1_000_000,
+        label: 'test',
+        message: 'hello',
+      })
     })
 
     it('returns undefined for invalid address in URI', () => {
@@ -73,48 +79,48 @@ describe('parseBip21Uri', () => {
 
     it('ignores zero amount', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0`)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true })
     })
 
     it('ignores negative amount', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=-1`)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true })
     })
 
     it('ignores non-numeric amount', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=abc`)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true })
     })
 
     it('returns undefined for non-bitcoin URI scheme', () => {
-      expect(parseBip21Uri(`ethereum:${VALID_ADDRESS}`)).toBeUndefined()
+      expect(parseBip21Uri(`lnurl:${VALID_ADDRESS}`)).toBeUndefined()
     })
   })
 
   describe('label parameter', () => {
     it('parses label from BIP21 URI', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?label=Donation`)
-      expect(result).toEqual({ address: VALID_ADDRESS, label: 'Donation' })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, label: 'Donation' })
     })
 
     it('parses label with amount', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0.01&label=Payment`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 1_000_000, label: 'Payment' })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 1_000_000, label: 'Payment' })
     })
 
     it('ignores empty label', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?label=`)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true })
     })
 
     it('decodes URL-encoded label', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?label=My%20Wallet`)
-      expect(result).toEqual({ address: VALID_ADDRESS, label: 'My Wallet' })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, label: 'My Wallet' })
     })
 
     it('does not include label for raw address', () => {
       const result = parseBip21Uri(VALID_ADDRESS)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: false })
       expect(result).not.toHaveProperty('label')
     })
   })
@@ -122,21 +128,28 @@ describe('parseBip21Uri', () => {
   describe('message parameter', () => {
     it('parses message from BIP21 URI', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?message=Invoice%20%231234`)
-      expect(result).toEqual({ address: VALID_ADDRESS, message: 'Invoice #1234' })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, message: 'Invoice #1234' })
     })
 
     it('parses message with amount and label', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0.05&label=Shop&message=Order%20789`)
-      expect(result).toEqual({ address: VALID_ADDRESS, amount: 5_000_000, label: 'Shop', message: 'Order 789' })
+      expect(result).toEqual({
+        address: VALID_ADDRESS,
+        fromUri: true,
+        amount: 5_000_000,
+        label: 'Shop',
+        message: 'Order 789',
+      })
     })
 
     it('ignores empty message', () => {
       const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?message=`)
-      expect(result).toEqual({ address: VALID_ADDRESS })
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true })
     })
 
     it('does not include message for raw address', () => {
       const result = parseBip21Uri(VALID_ADDRESS)
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: false })
       expect(result).not.toHaveProperty('message')
     })
   })

--- a/src/lib/bip21.ts
+++ b/src/lib/bip21.ts
@@ -2,34 +2,36 @@ import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
 import { tryBtcToSat } from '@/lib/utils'
 import type { AmountSats, BitcoinAddress } from '@/types/global'
 
+const BITCOIN_URI_SCHEME = 'bitcoin:'
+
 export type Bip21ParseResult = {
   address: BitcoinAddress
   amount?: AmountSats
   label?: string
   message?: string
+  fromUri: boolean
 }
 
 export const parseBip21Uri = (raw: string): Bip21ParseResult | undefined => {
   const trimmed = raw.trim()
 
-  // raw address (no URI scheme)
-  if (isValidBitcoinAddress(trimmed)) {
-    return { address: trimmed }
-  }
-
   // BIP21: bitcoin:<address>?amount=<btc>&...
-  if (!trimmed.toLowerCase().startsWith('bitcoin:')) {
+  if (!trimmed.toLowerCase().startsWith(BITCOIN_URI_SCHEME)) {
+    // raw address (no URI scheme)
+    if (isValidBitcoinAddress(trimmed)) {
+      return { address: trimmed, fromUri: false }
+    }
     return undefined
   }
 
-  const withoutScheme = trimmed.slice('bitcoin:'.length)
+  const withoutScheme = trimmed.slice(BITCOIN_URI_SCHEME.length)
   const [addressPart, queryString] = withoutScheme.split('?', 2)
 
   if (!addressPart || !isValidBitcoinAddress(addressPart)) {
     return undefined
   }
 
-  const result: Bip21ParseResult = { address: addressPart }
+  const result: Bip21ParseResult = { address: addressPart, fromUri: true }
 
   if (queryString) {
     const parameters = new URLSearchParams(queryString)


### PR DESCRIPTION
See title. Since the mixdepth is not included in the response, this makes sure the `sourceIndexJar` is actually the one the address is requested from.