### PR TITLE
chore(orderbook): improve bond and relative fee display value

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 VITE_JAM_DEFAULT_THEME=dark
-VITE_JAM_REPO_URL=https://github.com/joinmarket-webui
+VITE_JAM_REPO_URL=https://github.com/joinmarket-webui/jam
 VITE_JAM_DOCS_URL=https://jamdocs.org
 VITE_JAM_MATRIX_URL=https://matrix.to/#/%23jam:bitcoin.kyoto
 VITE_JAM_TELEGRAM_URL=https://t.me/JoinMarketWebUI

--- a/src/components/earn/FidelityBondCard.tsx
+++ b/src/components/earn/FidelityBondCard.tsx
@@ -5,15 +5,16 @@ import { Card, CardContent, CardAction, CardDescription, CardFooter, CardHeader,
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { FidelityBondUtxo } from '@/hooks/useQueryUtxos'
 import * as fb from '@/lib/fidelityBondUtils'
-import { time } from '@/lib/utils'
+import { cn, time } from '@/lib/utils'
 import { Address } from '../ui/jam/Address'
 import { Balance } from '../ui/jam/Balance'
 
 interface FidelityBondCardProps {
   value: FidelityBondUtxo
+  className?: string
 }
 
-export function FidelityBondCard({ value, children }: PropsWithChildren<FidelityBondCardProps>) {
+export function FidelityBondCard({ value, className, children }: PropsWithChildren<FidelityBondCardProps>) {
   const { t, i18n } = useTranslation()
 
   const isExpired = !fb.utxo.isLocked(value)
@@ -31,7 +32,7 @@ export function FidelityBondCard({ value, children }: PropsWithChildren<Fidelity
   }
 
   return (
-    <Card>
+    <Card className={cn('transition-all duration-300 hover:-translate-y-[2px] hover:shadow-md', className)}>
       <CardHeader>
         <CardTitle>
           {isExpired ? (

--- a/src/components/earn/OfferCard.tsx
+++ b/src/components/earn/OfferCard.tsx
@@ -42,7 +42,7 @@ export function OfferCard({ className, value, nickname, children }: PropsWithChi
   const { t } = useTranslation()
 
   return (
-    <Card className={cn('w-full', className)}>
+    <Card className={cn('transition-all duration-300 hover:-translate-y-[2px] hover:shadow-md', className)}>
       <CardHeader>
         <CardTitle>{t('earn.current.text_offer')}</CardTitle>
         <CardDescription></CardDescription>

--- a/src/components/orderbook/OrderbookContent.tsx
+++ b/src/components/orderbook/OrderbookContent.tsx
@@ -87,7 +87,7 @@ const offerToTableEntry = (
     maximumSize: String(offer.maxsize || 0),
     bondValue: {
       value: offer.fidelity_bond_value || 0,
-      displayValue: String((offer.fidelity_bond_value || 0).toFixed(0)),
+      displayValue: Math.floor(offer.fidelity_bond_value || 0).toLocaleString(),
       locktime: fidelityBond?.locktime,
       displayLocktime: fidelityBond?.locktime ? new Date(fidelityBond.locktime * 1_000).toDateString() : undefined,
       displayExpiresIn: fidelityBond?.locktime

--- a/src/components/orderbook/OrderbookTable.tsx
+++ b/src/components/orderbook/OrderbookTable.tsx
@@ -116,16 +116,19 @@ export const OrderbookTable = ({
       columnHelper.accessor<'type', OrderTableEntry['type']>('type', {
         header: () => <div className="flex items-center">{t('orderbook.table.heading_type')}</div>,
         sortingFn: (a, b) => a.original.type.displayValue.localeCompare(b.original.type.displayValue),
-        cell: (info) => (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Badge variant={info.getValue().badgeColor}>{info.getValue().displayValue}</Badge>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{info.getValue().tooltip}</p>
-            </TooltipContent>
-          </Tooltip>
-        ),
+        cell: (info) => {
+          const value = info.getValue()
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge variant={value.badgeColor}>{value.displayValue}</Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{value.tooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          )
+        },
         meta: {
           align: 'center',
           alphabetic: true,
@@ -140,12 +143,18 @@ export const OrderbookTable = ({
           }
           return a.original.fee.value - b.original.fee.value
         },
-        cell: (info) => {
-          const entry = info.row.original
-          return entry.fee.displayValue.includes('%') ? (
-            <span className="font-mono">{entry.fee.displayValue}</span>
+        cell: ({
+          row: {
+            original: {
+              type: { isAbsolute },
+              fee,
+            },
+          },
+        }) => {
+          return isAbsolute ? (
+            <span className="slashed-zero tabular-nums">{fee.displayValue}</span>
           ) : (
-            <Balance valueString={entry.fee.displayValue} />
+            <Balance valueString={fee.displayValue} />
           )
         },
         meta: {
@@ -184,26 +193,29 @@ export const OrderbookTable = ({
       columnHelper.accessor('bondValue', {
         header: () => <div className="flex items-center">{t('orderbook.table.heading_bond_value')}</div>,
         sortingFn: (a, b) => a.original.bondValue.value - b.original.bondValue.value,
-        cell: (info) => {
-          const entry = info.row.original
-          return entry.bondValue.value > 0 ? (
+        cell: ({
+          row: {
+            original: { bondValue },
+          },
+        }) => {
+          return bondValue.value > 0 ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="cursor-help">{entry.bondValue.displayValue}</span>
+                <span className="cursor-help slashed-zero tabular-nums">{bondValue.displayValue}</span>
               </TooltipTrigger>
               <TooltipContent>
                 <div>
-                  <Balance valueString={String(entry.bondValue.amount || 0)} convertToUnit="btc" />
-                  {entry.bondValue.displayLocktime && (
+                  <Balance valueString={String(bondValue.amount || 0)} convertToUnit="btc" />
+                  {bondValue.displayLocktime && (
                     <div className="mt-1 text-xs">
-                      {entry.bondValue.displayLocktime} ({entry.bondValue.displayExpiresIn})
+                      {bondValue.displayLocktime} ({bondValue.displayExpiresIn})
                     </div>
                   )}
                 </div>
               </TooltipContent>
             </Tooltip>
           ) : (
-            <>{entry.bondValue.displayValue}</>
+            <>{bondValue.displayValue}</>
           )
         },
         meta: {

--- a/src/components/wallet/JarUtxosTable.tsx
+++ b/src/components/wallet/JarUtxosTable.tsx
@@ -147,14 +147,12 @@ const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnD
       ),
     },
     columnHelper.accessor('utxo.frozen', {
-      header: () => <div className="flex items-center"></div>,
-      sortingFn: (a, b) => {
-        const val = (a.original.utxo.frozen ? 1 : 0) - (b.original.utxo.frozen ? 1 : 0)
+      header: () => <></>,
+      sortingFn: ({ original: { utxo: a } }, { original: { utxo: b } }) => {
+        const val = (a.frozen ? 1 : 0) - (b.frozen ? 1 : 0)
         if (val !== 0) return val
         // tie-break using confirmations
-        const aid = Number(a.original.utxo.confirmations)
-        const bid = Number(b.original.utxo.confirmations)
-        return aid - bid
+        return a.confirmations - b.confirmations
       },
       cell: (info) => {
         return (
@@ -172,14 +170,12 @@ const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnD
       },
     }),
     columnHelper.accessor('utxo.value', {
-      header: () => <div className="flex items-center">{t('jar_details.utxo_list.column_title_balance')}</div>,
-      sortingFn: (a, b) => {
-        const val = a.original.utxo.value - b.original.utxo.value
+      header: () => t('jar_details.utxo_list.column_title_balance'),
+      sortingFn: ({ original: { utxo: a } }, { original: { utxo: b } }) => {
+        const val = a.value - b.value
         if (val !== 0) return val
         // tie-break using confirmations
-        const aid = Number(a.original.utxo.confirmations)
-        const bid = Number(b.original.utxo.confirmations)
-        return aid - bid
+        return a.confirmations - b.confirmations
       },
       cell: (info) => <Balance valueString={String(info.getValue())} />,
       meta: {
@@ -189,17 +185,21 @@ const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnD
     }),
     columnHelper.accessor('utxo.confirmations', {
       header: () => t('jar_details.utxo_list.column_title_confirmations'),
-      cell: (info) => <>{info.getValue()}</>,
+      cell: (info) => <span className="slashed-zero tabular-nums">{info.getValue()}</span>,
       meta: {
         numeric: true,
-        align: 'center',
+        align: 'right',
       },
     }),
     columnHelper.accessor('tags', {
       header: () => t('jar_details.utxo_list.column_title_label_and_status'),
-      cell: (info) => (
+      cell: ({
+        row: {
+          original: { tags },
+        },
+      }) => (
         <div className="flex items-center gap-2">
-          {info.row.original.tags.map((it, index) => {
+          {tags.map((it, index) => {
             const tooltipKey = `jar_details.utxo_list.utxo_tag_tooltip_${it.value.replaceAll(':', '_')}`
             const tooltip = t(tooltipKey)
             const hasTooltip = tooltip !== tooltipKey
@@ -214,7 +214,7 @@ const utxoTableColumns = (enableSelectAllToggle: boolean, t: TFunction): ColumnD
       enableSorting: false,
     }),
     columnHelper.accessor<'utxo.address', UtxoTableEntry['utxo']['address']>('utxo.address', {
-      header: () => <div className="flex items-center">{t('jar_details.utxo_list.column_title_address')}</div>,
+      header: () => t('jar_details.utxo_list.column_title_address'),
       sortingFn: (a, b) => {
         const val = a.original.utxo.address.localeCompare(b.original.utxo.address)
         if (val !== 0) return val


### PR DESCRIPTION
See title.

Small improvements to the way numbers are displayed, adding classes `slashed-zero` and `tabular-nums` to relative fee and bond values.

Additionally:
- hover effect on bond and offer cards
- fix repo url in `.env`