### PR TITLE
fix(wallet): keep jars visible and clickable during background refetch

### DIFF
--- a/src/components/MainWalletPage.test.tsx
+++ b/src/components/MainWalletPage.test.tsx
@@ -125,10 +125,10 @@ describe('MainWalletPage', () => {
     expect(refetch).toHaveBeenCalled()
   })
 
-  it('shows a jars spinner while fetching and refreshes on click', () => {
+  it('keeps jars visible and clickable while fetching in the background', () => {
     walletInfo = { ...walletInfo, isFetching: true }
     render(<MainWalletPage walletFileName={walletFileName} />)
-    expect(screen.getByTestId('spinner')).toBeInTheDocument()
+    expect(screen.getByText(jars[0].name)).toBeInTheDocument()
     fireEvent.click(screen.getByText('global.refresh'))
     expect(refetch).toHaveBeenCalled()
   })

--- a/src/components/MainWalletPage.test.tsx
+++ b/src/components/MainWalletPage.test.tsx
@@ -129,6 +129,10 @@ describe('MainWalletPage', () => {
     walletInfo = { ...walletInfo, isFetching: true }
     render(<MainWalletPage walletFileName={walletFileName} />)
     expect(screen.getByText(jars[0].name)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText(jars[0].name))
+    expect(screen.getByTestId('WalletJarsDetailsOverlay#open')).toHaveTextContent('open')
+    expect(screen.getByTestId('WalletJarsDetailsOverlay#selectedJarIndex')).toHaveTextContent(String(jars[0].jarIndex))
     fireEvent.click(screen.getByText('global.refresh'))
     expect(refetch).toHaveBeenCalled()
   })

--- a/src/components/MainWalletPage.tsx
+++ b/src/components/MainWalletPage.tsx
@@ -116,7 +116,7 @@ export default function MainWalletPage({ walletFileName }: MainWalletPageProps) 
             </Tooltip>
           </div>
           <div className="flex min-h-[128px] items-center justify-center gap-4">
-            {isFetching ? (
+            {isLoading ? (
               <div className="flex flex-1 items-center justify-center gap-2 py-8">
                 <Spinner className="motion-reduce:hidden" />
                 {t('global.loading')}


### PR DESCRIPTION
The jars section in MainWalletPage was gated on isFetching, which is true on every background refetch, not just the initial load. That meant any time wallet data refreshed in the background, the jars grid, and the Jar Details overlay it opens, would get replaced by a spinner even though the previously loaded jars were still valid to show and click. The balance display right above it already used isLoading for this same purpose, so this brings the jars section in line with that pattern.

I also updated the test that covered the old spinner behavior. It now asserts that a jar stays visible and clickable while isFetching is true, and that clicking refresh still triggers a refetch, instead of asserting a spinner appears.

Closes #1382.