### PR TITLE
fix(validation): distinguish testnet and regtest for bech32 addresses

### DIFF
--- a/src/lib/formValidation.test.ts
+++ b/src/lib/formValidation.test.ts
@@ -13,6 +13,9 @@ const mainnetAddress = '1BitcoinEaterAddressDontSend8MUo1T'
 const testnetAddress = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
 const regtestBech32Address = 'bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk'
 const testnetBech32Address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
+// bech32m/taproot pair - same witness program, differing only by HRP (tb1p vs bcrt1p)
+const testnetTaprootAddress = 'tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47zagq'
+const regtestTaprootAddress = 'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6'
 const regtestLegacyAddressLabeledTestnet = 'mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV'
 
 const addressSummary = {
@@ -40,16 +43,24 @@ describe('isAddressOnNetwork', () => {
     expect(isAddressOnNetwork('not-an-address', Network.mainnet)).toBe(false)
   })
 
-  it('distinguishes testnet and regtest for bech32 addresses via their distinct HRP', () => {
-    // bech32 addresses carry a network-specific prefix (tb1 vs bcrt1), so each is only
+  it('distinguishes testnet and regtest for bech32 and bech32m addresses via their distinct HRP', () => {
+    // bech32/bech32m addresses carry a network-specific prefix (tb1 vs bcrt1), so each is only
     // valid on its own network - a regtest address must not pass on a testnet wallet, nor vice versa.
+    // bech32 (segwit v0):
     expect(isAddressOnNetwork(regtestBech32Address, Network.regtest)).toBe(true)
     expect(isAddressOnNetwork(regtestBech32Address, Network.testnet)).toBe(false)
     expect(isAddressOnNetwork(testnetBech32Address, Network.testnet)).toBe(true)
     expect(isAddressOnNetwork(testnetBech32Address, Network.regtest)).toBe(false)
-    // ...and neither passes on mainnet.
+    // bech32m (taproot):
+    expect(isAddressOnNetwork(regtestTaprootAddress, Network.regtest)).toBe(true)
+    expect(isAddressOnNetwork(regtestTaprootAddress, Network.testnet)).toBe(false)
+    expect(isAddressOnNetwork(testnetTaprootAddress, Network.testnet)).toBe(true)
+    expect(isAddressOnNetwork(testnetTaprootAddress, Network.regtest)).toBe(false)
+    // ...and none pass on mainnet.
     expect(isAddressOnNetwork(regtestBech32Address, Network.mainnet)).toBe(false)
     expect(isAddressOnNetwork(testnetBech32Address, Network.mainnet)).toBe(false)
+    expect(isAddressOnNetwork(regtestTaprootAddress, Network.mainnet)).toBe(false)
+    expect(isAddressOnNetwork(testnetTaprootAddress, Network.mainnet)).toBe(false)
   })
 
   it('treats testnet and regtest as interchangeable for ambiguous base58 addresses', () => {

--- a/src/lib/formValidation.test.ts
+++ b/src/lib/formValidation.test.ts
@@ -53,8 +53,8 @@ describe('isAddressOnNetwork', () => {
   })
 
   it('treats testnet and regtest as interchangeable for ambiguous base58 addresses', () => {
-    // A base58 (legacy/p2sh) address on a regtest wallet is labeled "testnet" by the library
-    // because the two share version bytes, so it must still be accepted on regtest.
+    // A base58 (P2PKH here; P2SH shares the trait) address on a regtest wallet is labeled "testnet"
+    // by the library because the two share version bytes, so it must still be accepted on regtest.
     expect(isAddressOnNetwork(regtestLegacyAddressLabeledTestnet, Network.regtest)).toBe(true)
     expect(isAddressOnNetwork(regtestLegacyAddressLabeledTestnet, Network.testnet)).toBe(true)
     // mainnet is never ambiguous with testnet/regtest.

--- a/src/lib/formValidation.test.ts
+++ b/src/lib/formValidation.test.ts
@@ -12,6 +12,7 @@ import {
 const mainnetAddress = '1BitcoinEaterAddressDontSend8MUo1T'
 const testnetAddress = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
 const regtestBech32Address = 'bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk'
+const testnetBech32Address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
 const regtestLegacyAddressLabeledTestnet = 'mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV'
 
 const addressSummary = {
@@ -39,17 +40,26 @@ describe('isAddressOnNetwork', () => {
     expect(isAddressOnNetwork('not-an-address', Network.mainnet)).toBe(false)
   })
 
-  it('treats testnet and regtest as interchangeable for base58 addresses ambiguous between the two', () => {
-    // bech32 regtest addresses are unambiguous and match regtest directly...
+  it('distinguishes testnet and regtest for bech32 addresses via their distinct HRP', () => {
+    // bech32 addresses carry a network-specific prefix (tb1 vs bcrt1), so each is only
+    // valid on its own network - a regtest address must not pass on a testnet wallet, nor vice versa.
     expect(isAddressOnNetwork(regtestBech32Address, Network.regtest)).toBe(true)
-    expect(isAddressOnNetwork(regtestBech32Address, Network.testnet)).toBe(true) // TODO: can be detected and differentiated for `p2wpkh`
-    // ...but a legacy address on a regtest wallet is labeled "testnet" by the library, so it
-    // must still be accepted when the wallet's detected network is regtest.
+    expect(isAddressOnNetwork(regtestBech32Address, Network.testnet)).toBe(false)
+    expect(isAddressOnNetwork(testnetBech32Address, Network.testnet)).toBe(true)
+    expect(isAddressOnNetwork(testnetBech32Address, Network.regtest)).toBe(false)
+    // ...and neither passes on mainnet.
+    expect(isAddressOnNetwork(regtestBech32Address, Network.mainnet)).toBe(false)
+    expect(isAddressOnNetwork(testnetBech32Address, Network.mainnet)).toBe(false)
+  })
+
+  it('treats testnet and regtest as interchangeable for ambiguous base58 addresses', () => {
+    // A base58 (legacy/p2sh) address on a regtest wallet is labeled "testnet" by the library
+    // because the two share version bytes, so it must still be accepted on regtest.
     expect(isAddressOnNetwork(regtestLegacyAddressLabeledTestnet, Network.regtest)).toBe(true)
     expect(isAddressOnNetwork(regtestLegacyAddressLabeledTestnet, Network.testnet)).toBe(true)
     // mainnet is never ambiguous with testnet/regtest.
     expect(isAddressOnNetwork(mainnetAddress, Network.regtest)).toBe(false)
-    expect(isAddressOnNetwork(regtestBech32Address, Network.mainnet)).toBe(false)
+    expect(isAddressOnNetwork(mainnetAddress, Network.testnet)).toBe(false)
   })
 })
 

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -11,16 +11,21 @@ import { isValidInteger } from './utils'
 export const isValidAddress = (value: unknown): value is BitcoinAddress =>
   typeof value === 'string' && isValidBitcoinAddress(value)
 
-// Legacy (base58) addresses share the same version bytes on testnet and regtest, so
-// bitcoin-address-validation can't tell them apart and always labels them "testnet" -
-// only bech32 addresses carry a distinct "bcrt1" prefix. Treat the two as interchangeable
-// so a regtest wallet doesn't reject its own legacy-style addresses as "wrong network".
+// Base58 addresses (p2pkh/p2sh) share the same version bytes on testnet and regtest, so
+// bitcoin-address-validation can't tell them apart and always labels them "testnet".
+// Treat the two as interchangeable for those so a regtest wallet doesn't reject its own
+// legacy-style addresses as "wrong network". Bech32 addresses are excluded below because
+// their distinct HRP (tb1 vs bcrt1) already identifies the network unambiguously.
 const AMBIGUOUS_TESTNET_REGTEST_NETWORKS: ReadonlySet<Network> = new Set([Network.testnet, Network.regtest])
 
 export const isAddressOnNetwork = (value: string, network: Network): boolean => {
   try {
-    const addressNetwork = getAddressInfo(value).network
+    const { network: addressNetwork, bech32 } = getAddressInfo(value)
     if (addressNetwork === network) return true
+    // Bech32/bech32m addresses carry a distinct HRP per network (tb1 vs bcrt1), so they are
+    // already identified correctly - don't relax them, or a bcrt1… (regtest) address would
+    // wrongly pass on a testnet wallet and vice versa. Only base58 addresses are ambiguous.
+    if (bech32) return false
     return AMBIGUOUS_TESTNET_REGTEST_NETWORKS.has(addressNetwork) && AMBIGUOUS_TESTNET_REGTEST_NETWORKS.has(network)
   } catch (_ignoredOnPurpose) {
     return false


### PR DESCRIPTION
## What does this PR do?

Follow-up to #1355. That PR added wallet-network validation for destination addresses, and to avoid a regtest wallet rejecting its own legacy (base58) addresses, isAddressOnNetwork treated testnet and regtest as interchangeable. As flagged in review, that fallback was too broad: it also relaxed bech32 addresses, so a bcrt1… (regtest) address wrongly passed on a testnet wallet, and vice versa.

This tightens the fallback to only the ambiguous case:

Base58 (p2pkh/p2sh): testnet and regtest share version bytes, so bitcoin-address-validation always labels them testnet, these stay interchangeable.
Bech32/bech32m (tb1… vs bcrt1…): the HRP already identifies the network, so getAddressInfo returns the correct distinct network and these are now validated strictly (gated on !bech32).
Net effect: mainnet validation is unchanged (never ambiguous); only the wrong test-network variant of a segwit/taproot address is now correctly rejected. 



