### PR TITLE
fix(fb): re-freeze fidelity bond utxo when renew/move sweep fails after unfreezing it

### DIFF
--- a/src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts
+++ b/src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
 // `useFidelityBondSweep` only talks to the network through these two hooks —
 // mock at that boundary and let the hook's own orchestration logic run for real.
 vi.mock('@tanstack/react-query', () => ({
-  useMutation: vi.fn((options: { mutationFn: (vars: unknown) => Promise<unknown> }) => ({
+  useMutation: vi.fn((options: { mutationFn: (variables: unknown) => Promise<unknown> }) => ({
     mutateAsync: options.mutationFn,
     isPending: false,
   })),
@@ -62,11 +62,10 @@ const utxo = (overrides: Partial<Utxo>): Utxo => ({
   ...overrides,
 })
 
-const bondUtxo = (overrides: Partial<FidelityBondUtxo>): FidelityBondUtxo =>
-  ({
-    ...utxo({ utxo: 'bond:0', frozen: true, ...overrides }),
-    locktime: '2999-01-01 00:00:00',
-  }) as FidelityBondUtxo
+const bondUtxo = (overrides: Partial<FidelityBondUtxo>): FidelityBondUtxo => ({
+  ...utxo({ utxo: 'bond:0', frozen: true, ...overrides }),
+  locktime: '2999-01-01 00:00:00',
+})
 
 const jar = (jarIndex: number, utxos: Utxo[]): Jar =>
   ({

--- a/src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts
+++ b/src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts
@@ -179,4 +179,30 @@ describe('useFidelityBondSweep', () => {
     )
     expect(mocks.walletInfoRefetch).toHaveBeenCalled()
   })
+
+  it('does not re-freeze the bond if the sweep broadcast but the refetch after it fails', async () => {
+    const bond = bondUtxo({ mixdepth: 0 })
+    mocks.walletInfo.jars = [jar(0, [bond])]
+    mocks.directSendMutateAsync.mockResolvedValue({ txinfo: { txid: 'renewed-tx' } })
+    mocks.walletInfoRefetch.mockRejectedValue(new Error('refetch failed'))
+
+    const { result } = renderHook(() =>
+      useFidelityBondSweep({
+        walletFileName: 'wallet.jmdat',
+        utxo: bond,
+        unfreezeErrorKey: 'earn.fidelity_bond.error_unfreezing_utxos',
+        sendErrorKey: 'earn.fidelity_bond.renew.error_renewing_fidelity_bond',
+      }),
+    )
+
+    const txResult = await result.current.sweep({
+      destination: 'bcrt1qdestination',
+      tryFreezeAfterBroadcast: false,
+    })
+
+    expect(txResult).toEqual({ txinfo: { txid: 'renewed-tx' } })
+    expect(mocks.freezeMutateAsync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ body: { 'utxo-string': 'bond:0', freeze: true } }),
+    )
+  })
 })

--- a/src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts
+++ b/src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts
@@ -1,0 +1,183 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Jar } from '@/context/JamWalletInfoContext'
+import type { FidelityBondUtxo, Utxo } from '@/hooks/useQueryUtxos'
+import { BALANCE_SUMMARY_EMPTY } from '@/lib/balanceSummary'
+import { useFidelityBondSweep } from './useFidelityBondSweep'
+
+const mocks = vi.hoisted(() => ({
+  freezeMutateAsync: vi.fn(),
+  unfreezeMutateAsync: vi.fn(),
+  directSendMutateAsync: vi.fn(),
+  setError: vi.fn(),
+  walletInfoRefetch: vi.fn(),
+  walletInfo: {
+    jars: [] as Jar[],
+    refetch: vi.fn(),
+  },
+}))
+
+// `useFidelityBondSweep` only talks to the network through these two hooks —
+// mock at that boundary and let the hook's own orchestration logic run for real.
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: vi.fn((options: { mutationFn: (vars: unknown) => Promise<unknown> }) => ({
+    mutateAsync: options.mutationFn,
+    isPending: false,
+  })),
+}))
+
+vi.mock('./useFidelityBondMutations', () => ({
+  useFidelityBondMutations: () => ({
+    freezeUtxo: { mutateAsync: mocks.freezeMutateAsync },
+    unfreezeUtxo: { mutateAsync: mocks.unfreezeMutateAsync },
+    directSend: { mutateAsync: mocks.directSendMutateAsync },
+    error: undefined,
+    setError: mocks.setError,
+  }),
+}))
+
+vi.mock('@/context/JamWalletInfoContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/context/JamWalletInfoContext')>()),
+  useJamWalletInfoContext: () => mocks.walletInfo,
+}))
+
+vi.mock('@/lib/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/utils')>()),
+  delayedPromise: vi.fn(() => Promise.resolve()),
+}))
+
+const utxo = (overrides: Partial<Utxo>): Utxo => ({
+  utxo: 'tx:0',
+  address: 'bcrt1qsource',
+  path: "m/84'/1'/0'/0/0",
+  label: '',
+  value: 100_000,
+  tries: 0,
+  tries_remaining: 3,
+  external: false,
+  mixdepth: 0,
+  confirmations: 6,
+  frozen: false,
+  locktime: undefined,
+  ...overrides,
+})
+
+const bondUtxo = (overrides: Partial<FidelityBondUtxo>): FidelityBondUtxo =>
+  ({
+    ...utxo({ utxo: 'bond:0', frozen: true, ...overrides }),
+    locktime: '2999-01-01 00:00:00',
+  }) as FidelityBondUtxo
+
+const jar = (jarIndex: number, utxos: Utxo[]): Jar =>
+  ({
+    jarIndex,
+    name: `Jar ${jarIndex}`,
+    color: '#808080',
+    balanceSummary: BALANCE_SUMMARY_EMPTY,
+    utxos,
+  }) as unknown as Jar
+
+describe('useFidelityBondSweep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.freezeMutateAsync.mockResolvedValue(undefined)
+    mocks.unfreezeMutateAsync.mockResolvedValue(undefined)
+    mocks.walletInfoRefetch.mockResolvedValue(undefined)
+    mocks.walletInfo.refetch = mocks.walletInfoRefetch
+  })
+
+  it('re-freezes the fidelity bond after a failed sweep that had unfrozen it', async () => {
+    const bond = bondUtxo({ mixdepth: 0 })
+    const other = utxo({ utxo: 'other:0', mixdepth: 0, frozen: false })
+    mocks.walletInfo.jars = [jar(0, [bond, other])]
+    mocks.directSendMutateAsync.mockRejectedValue(new Error('broadcast failed'))
+
+    const { result } = renderHook(() =>
+      useFidelityBondSweep({
+        walletFileName: 'wallet.jmdat',
+        utxo: bond,
+        unfreezeErrorKey: 'earn.fidelity_bond.error_unfreezing_utxos',
+        sendErrorKey: 'earn.fidelity_bond.renew.error_renewing_fidelity_bond',
+      }),
+    )
+
+    const txResult = await result.current.sweep({
+      destination: 'bcrt1qdestination',
+      tryFreezeAfterBroadcast: false,
+    })
+
+    expect(txResult).toBeUndefined()
+
+    // the other jar utxo was frozen then correctly rolled back
+    expect(mocks.freezeMutateAsync).toHaveBeenCalledWith({
+      path: { walletname: 'wallet.jmdat' },
+      body: { 'utxo-string': 'other:0', freeze: true },
+    })
+    expect(mocks.unfreezeMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { 'utxo-string': 'other:0', freeze: false } }),
+    )
+
+    // the bond itself was unfrozen before the failed send, and MUST be re-frozen in rollback
+    expect(mocks.unfreezeMutateAsync).toHaveBeenCalledWith({
+      path: { walletname: 'wallet.jmdat' },
+      body: { 'utxo-string': 'bond:0', freeze: false },
+    })
+    expect(mocks.freezeMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { 'utxo-string': 'bond:0', freeze: true } }),
+    )
+  })
+
+  it('does not attempt to re-freeze the bond on failure when it was never unfrozen', async () => {
+    const bond = bondUtxo({ mixdepth: 0, frozen: false })
+    mocks.walletInfo.jars = [jar(0, [bond])]
+    mocks.directSendMutateAsync.mockRejectedValue(new Error('broadcast failed'))
+
+    const { result } = renderHook(() =>
+      useFidelityBondSweep({
+        walletFileName: 'wallet.jmdat',
+        utxo: bond,
+        unfreezeErrorKey: 'earn.fidelity_bond.error_unfreezing_utxos',
+        sendErrorKey: 'earn.fidelity_bond.renew.error_renewing_fidelity_bond',
+      }),
+    )
+
+    await result.current.sweep({ destination: 'bcrt1qdestination', tryFreezeAfterBroadcast: false })
+
+    expect(mocks.unfreezeMutateAsync).not.toHaveBeenCalled()
+    expect(mocks.freezeMutateAsync).not.toHaveBeenCalledWith(
+      expect.objectContaining({ body: { 'utxo-string': 'bond:0', freeze: true } }),
+    )
+  })
+
+  it('sweeps successfully: freezes other utxos, unfreezes the bond, then restores the others', async () => {
+    const bond = bondUtxo({ mixdepth: 0 })
+    const other = utxo({ utxo: 'other:0', mixdepth: 0, frozen: false })
+    mocks.walletInfo.jars = [jar(0, [bond, other])]
+    mocks.directSendMutateAsync.mockResolvedValue({ txinfo: { txid: 'renewed-tx' } })
+
+    const { result } = renderHook(() =>
+      useFidelityBondSweep({
+        walletFileName: 'wallet.jmdat',
+        utxo: bond,
+        unfreezeErrorKey: 'earn.fidelity_bond.error_unfreezing_utxos',
+        sendErrorKey: 'earn.fidelity_bond.renew.error_renewing_fidelity_bond',
+      }),
+    )
+
+    const txResult = await result.current.sweep({
+      destination: 'bcrt1qdestination',
+      tryFreezeAfterBroadcast: false,
+    })
+
+    expect(txResult).toEqual({ txinfo: { txid: 'renewed-tx' } })
+    expect(mocks.directSendMutateAsync).toHaveBeenCalledWith({
+      path: { walletname: 'wallet.jmdat' },
+      body: { mixdepth: 0, amount_sats: 0, destination: 'bcrt1qdestination' },
+    })
+    // the other utxo ends up unfrozen again post-broadcast
+    expect(mocks.unfreezeMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { 'utxo-string': 'other:0', freeze: false } }),
+    )
+    expect(mocks.walletInfoRefetch).toHaveBeenCalled()
+  })
+})

--- a/src/components/earn/fidelity-bond/useFidelityBondSweep.ts
+++ b/src/components/earn/fidelity-bond/useFidelityBondSweep.ts
@@ -154,7 +154,8 @@ export function useFidelityBondSweep({
 
         return undefined
       } finally {
-        
+        // refetch only if the sweep broadcast, and don't let a refetch error
+        // get treated as a sweep failure
         if (sweepBroadcasted) {
           try {
             await walletInfoRefetch()

--- a/src/components/earn/fidelity-bond/useFidelityBondSweep.ts
+++ b/src/components/earn/fidelity-bond/useFidelityBondSweep.ts
@@ -56,6 +56,7 @@ export function useFidelityBondSweep({
       setError(undefined)
 
       const frozen: Utxo[] = []
+      let bondWasUnfrozen = false
       try {
         // Freeze other UTXOs in the source jar so only the FB gets swept
         for (const u of utxosToFreeze) {
@@ -71,6 +72,7 @@ export function useFidelityBondSweep({
             path: { walletname: walletFileName },
             body: { 'utxo-string': utxo.utxo, freeze: false },
           })
+          bondWasUnfrozen = true
         }
 
         const result = await directSend.mutateAsync({
@@ -133,6 +135,20 @@ export function useFidelityBondSweep({
             console.debug('Error while unfreezing previously frozen UTXO in error handling.')
           }
         }
+
+        // Best-effort rollback — re-freeze the bond if we unfroze it before the error
+        if (bondWasUnfrozen) {
+          try {
+            await freezeUtxo.mutateAsync({
+              path: { walletname: walletFileName },
+              body: { 'utxo-string': utxo.utxo, freeze: true },
+              throwOnError: true,
+            })
+          } catch (_ignoredOnPurpose: unknown) {
+            console.debug('Error while re-freezing fidelity bond UTXO in error handling.')
+          }
+        }
+
         return undefined
       }
     },

--- a/src/components/earn/fidelity-bond/useFidelityBondSweep.ts
+++ b/src/components/earn/fidelity-bond/useFidelityBondSweep.ts
@@ -57,6 +57,8 @@ export function useFidelityBondSweep({
 
       const frozen: Utxo[] = []
       let bondWasUnfrozen = false
+      let sweepBroadcasted = false
+
       try {
         // Freeze other UTXOs in the source jar so only the FB gets swept
         for (const u of utxosToFreeze) {
@@ -83,6 +85,7 @@ export function useFidelityBondSweep({
             destination,
           },
         })
+        sweepBroadcasted = true
 
         // Best-effort cleanup — tx already broadcast, don't throw on unfreeze failure
         for (const u of frozen) {
@@ -119,7 +122,6 @@ export function useFidelityBondSweep({
           console.warn('onBroadcastSuccess failed', error)
         }
 
-        await walletInfoRefetch()
         return result
       } catch (_ignoredOnPurpose: unknown) {
         // Best-effort rollback — unfreeze UTXOs that were frozen before the error
@@ -136,8 +138,9 @@ export function useFidelityBondSweep({
           }
         }
 
-        // Best-effort rollback — re-freeze the bond if we unfroze it before the error
-        if (bondWasUnfrozen) {
+        // re-freeze the bond if it was unfrozen before the error. skip once the
+        // sweep already broadcast, the bond utxo is spent by then
+        if (bondWasUnfrozen && !sweepBroadcasted) {
           try {
             await freezeUtxo.mutateAsync({
               path: { walletname: walletFileName },
@@ -150,6 +153,15 @@ export function useFidelityBondSweep({
         }
 
         return undefined
+      } finally {
+        
+        if (sweepBroadcasted) {
+          try {
+            await walletInfoRefetch()
+          } catch (error: unknown) {
+            console.warn('Error while refetching wallet info after sweep.', error)
+          }
+        }
       }
     },
     retry: false,


### PR DESCRIPTION
## Summary

`useFidelityBondSweep` — shared by the Renew Bond and Move to Jar dialogs freezes the jar's other UTXOs, unfreezes the target fidelity bond, then sweeps the whole jar. If the sweep fails *after* the bond was unfrozen, the error-handling rollback restored only the other, temporarily-frozen UTXOs , it never re-froze the bond UTXO itself. A failed renew/move could silently leave a matured fidelity bond permanently unfrozen and unprotected, with no indication to the user beyond a generic error toast.

This adds a `bondWasUnfrozen` flag, set only when the bond's unfreeze call actually succeeds, and refreezes the bond in the `catch` block when that flag is set mirroring the existing best-effort rollback pattern already used for the other UTXOs in this file.

## Why

This directly undermines the auto-freeze protections recently added for fidelity bonds, and the downstream mitigations that were built on top of them:

- #1394 disallows sending from a jar with an unfrozen bond
- #1387 blocks collaborative transactions with a non-frozen expired bond

Both react to a bond *already being* unfrozen but don't address how it can end up that way through this exact rollback gap. This PR fixes the root cause instead of relying solely on those downstream guards.

## Changes

- `src/components/earn/fidelity-bond/useFidelityBondSweep.ts`: track whether the bond was unfrozen during the sweep attempt and re-freeze it on failure.
- `src/components/earn/fidelity-bond/useFidelityBondSweep.test.ts` (new): this hook previously had no test coverage. Added three tests:
  - refreezes the bond when a failed sweep had unfrozen it (the regression case)
  - does not attempt to re-freeze the bond when it was never unfrozen (guards against over-eager rollback)
  - happy path: sweep succeeds, other jar UTXOs get frozen then restored

## Test plan

- [x] `npm run build` passes, no type errors
- [x] `npm run test:unit`  full suite passes for all fidelity-bond/renew/move-to-jar tests (the only 5 pre-existing failures are unrelated: locale dependent number formatting in `Balance.test.tsx`, unaffected by this change)
- [x] New tests specifically cover the failure path this PR fixes

solves #1397 

