### PR TITLE
chore(build): remove console.debug from prod build

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,19 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from '@/App.tsx'
 import '@/i18n/config'
+import { JAM_REPO_URL } from './constants/jam'
 import './index.css'
+
+console.debug(
+  `%c/${'*'.repeat(42)}
+* Thanks for testing! Please report anything that looks off.
+* Found a bug? Open an issue at ${JAM_REPO_URL}/issues/new?labels=bug&template=bug_report.md
+*
+* This message should be dropped from preview/prod builds.
+* Use the above link and open a bug report if you see this message outside development builds.
+${'*'.repeat(42)}/`,
+  'color:#e2b86a;font-size:14px;',
+)
 
 createRoot(document.querySelector('#root')!).render(
   <StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,6 +78,18 @@ export default defineConfig((config): UserConfig => {
         '@': path.resolve(import.meta.dirname, './src'),
       },
     },
+    build: {
+      rolldownOptions: {
+        output: {
+          minify: {
+            compress: {
+              dropConsole: buildOrPreview,
+              dropDebugger: buildOrPreview,
+            },
+          },
+        },
+      },
+    },
     server: {
       ...server,
       open: true,


### PR DESCRIPTION
Reverts regression in https://github.com/joinmarket-webui/jam/commit/945ece0df8b13741f39cfe6ab153ab5d6493fab9#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL83-L86 and drops console.debug and debugger statements from prod/preview builds.

## How to test
Run with `npm run dev` and see the debug message in the console.

<img width="350" alt="Image" src="https://github.com/user-attachments/assets/c573a037-ef5c-4514-9c7f-47dea1468257" />

Run with `npm run build && npm run preview` and verify that this message (and all other debug messages) is gone.