### PR TITLE
fix(fb): explain missing eligible UTXOs

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -110,7 +110,6 @@ export function useCreateFidelityBondWizard(
 
   const jarsWithUtxos = useMemo(() => {
     return walletInfo.jars.filter((jar) => {
-      // TODO: let's allow selecting frozen utxos - unfreeze them before sending the transaction
       const availableUtxos = jar.utxos.filter((utxo) =>
         fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status),
       )
@@ -120,12 +119,9 @@ export function useCreateFidelityBondWizard(
 
   const availableUtxos = useMemo(() => {
     if (selectedJar === undefined) return []
-    return (
-      selectedJar.utxos
-        // TODO: let's allow selecting frozen utxos - unfreeze them before sending the transaction
-        .filter((utxo) => fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status))
-        .toSorted((a, b) => b.value - a.value)
-    )
+    return selectedJar.utxos
+      .filter((utxo) => fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status))
+      .toSorted((a, b) => b.value - a.value)
   }, [selectedJar, walletInfo.addressSummary])
 
   const selectedUtxos = useMemo(() => {

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -111,9 +111,8 @@ export function useCreateFidelityBondWizard(
   const jarsWithUtxos = useMemo(() => {
     return walletInfo.jars.filter((jar) => {
       // TODO: let's allow selecting frozen utxos - unfreeze them before sending the transaction
-      const availableUtxos = jar.utxos.filter(
-        (utxo) =>
-          !utxo.frozen && !fb.utxo.isFidelityBond(utxo) && walletInfo.addressSummary[utxo.address]?.status === 'cj-out',
+      const availableUtxos = jar.utxos.filter((utxo) =>
+        fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status),
       )
       return availableUtxos.length > 0
     })
@@ -124,12 +123,7 @@ export function useCreateFidelityBondWizard(
     return (
       selectedJar.utxos
         // TODO: let's allow selecting frozen utxos - unfreeze them before sending the transaction
-        .filter(
-          (utxo) =>
-            !utxo.frozen &&
-            !fb.utxo.isFidelityBond(utxo) &&
-            walletInfo.addressSummary[utxo.address]?.status === 'cj-out',
-        )
+        .filter((utxo) => fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status))
         .toSorted((a, b) => b.value - a.value)
     )
   }, [selectedJar, walletInfo.addressSummary])

--- a/src/components/earn/EarnPage.test.tsx
+++ b/src/components/earn/EarnPage.test.tsx
@@ -2,7 +2,8 @@ import type React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { FidelityBondUtxo } from '@/hooks/useQueryUtxos'
+import type { Jar } from '@/context/JamWalletInfoContext'
+import type { FidelityBondUtxo, Utxo } from '@/hooks/useQueryUtxos'
 import { jmSessionStore } from '@/store/jmSessionStore'
 import type { EarnFormValues } from './EarnForm'
 import { EarnPage } from './EarnPage'
@@ -26,17 +27,11 @@ const mocks = vi.hoisted(() => ({
   toastInfo: vi.fn(),
   toastSuccess: vi.fn(),
   walletInfo: {
+    addressSummary: {},
     fidelityBondSummary: { fbOutputs: [] as FidelityBondUtxo[] },
     isFetching: false,
     isLoading: false,
-    jars: [] as Array<{
-      balanceSummary: {
-        calculatedAvailableBalanceInSats: number
-        calculatedConfirmedAvailableBalanceInSats: number
-        calculatedFrozenOrLockedBalanceInSats: number
-        calculatedTotalBalanceInSats: number
-      }
-    }>,
+    jars: [] as Jar[],
     maxJarAvailableBalance: 100_000_000,
   },
 }))
@@ -212,10 +207,34 @@ vi.mock('./report/EarnReportOverlay', () => ({
 
 const balanceSummary = {
   calculatedAvailableBalanceInSats: 100_000_000,
+  calculatedAvailableFrozenBalanceInSats: 0,
   calculatedConfirmedAvailableBalanceInSats: 100_000_000,
   calculatedFrozenOrLockedBalanceInSats: 0,
   calculatedTotalBalanceInSats: 100_000_000,
 }
+
+const eligibleUtxo: Utxo = {
+  address: 'bcrt1qcj',
+  confirmations: 12,
+  external: false,
+  frozen: false,
+  label: '',
+  locktime: undefined,
+  mixdepth: 0,
+  path: "m/84'/1'/0'/0/0",
+  tries: 3,
+  tries_remaining: 3,
+  utxo: 'eligible:0',
+  value: 100_000,
+}
+
+const makeJar = (balanceOverrides = {}): Jar => ({
+  balanceSummary: { ...balanceSummary, ...balanceOverrides },
+  color: '#e2b86a',
+  jarIndex: 0,
+  name: 'Jar 0',
+  utxos: [eligibleUtxo],
+})
 
 const expiredBond: FidelityBondUtxo = {
   address: 'bc1qbond',
@@ -264,10 +283,13 @@ describe('EarnPage', () => {
     mocks.toastError.mockReset()
     mocks.toastInfo.mockReset()
     mocks.toastSuccess.mockReset()
+    mocks.walletInfo.addressSummary = {
+      [eligibleUtxo.address]: { status: 'cj-out' },
+    }
     mocks.walletInfo.fidelityBondSummary = { fbOutputs: [] }
     mocks.walletInfo.isFetching = false
     mocks.walletInfo.isLoading = false
-    mocks.walletInfo.jars = [{ balanceSummary }]
+    mocks.walletInfo.jars = [makeJar()]
     mocks.walletInfo.maxJarAvailableBalance = 100_000_000
     setSession()
   })
@@ -375,6 +397,26 @@ describe('EarnPage', () => {
 
     await user.click(createFidelityBondButton)
     expect(screen.getByText('create-bond-dialog:true')).toBeInTheDocument()
+  })
+
+  it('explains when no UTXO is eligible for fidelity-bond creation', async () => {
+    const user = userEvent.setup()
+    mocks.walletInfo.addressSummary = {
+      [eligibleUtxo.address]: { status: 'deposit' },
+    }
+
+    render(<EarnPage walletFileName="wallet.jmdat" />)
+
+    expect(screen.getByText('earn.fidelity_bond.create_form.alert_no_eligible_utxos_title')).toBeInTheDocument()
+    expect(screen.getByText('earn.fidelity_bond.create_form.alert_no_eligible_utxos_description')).toBeInTheDocument()
+
+    const createFidelityBondButton = screen.getByRole('button', {
+      name: 'earn.fidelity_bond.create_form.button_create',
+    })
+    expect(createFidelityBondButton).toBeDisabled()
+
+    await user.click(createFidelityBondButton)
+    expect(screen.getByText('create-bond-dialog:false')).toBeInTheDocument()
   })
 
   it('disables creating a fidelity bond while rescanning', async () => {
@@ -485,7 +527,7 @@ describe('EarnPage', () => {
   })
 
   it('warns when the spendable balance is only unconfirmed', () => {
-    mocks.walletInfo.jars = [{ balanceSummary: { ...balanceSummary, calculatedConfirmedAvailableBalanceInSats: 0 } }]
+    mocks.walletInfo.jars = [makeJar({ calculatedConfirmedAvailableBalanceInSats: 0 })]
     mocks.walletInfo.maxJarAvailableBalance = 100_000_000
 
     render(<EarnPage walletFileName="wallet.jmdat" />)
@@ -497,7 +539,7 @@ describe('EarnPage', () => {
   })
 
   it('warns when there is no spendable balance at all', () => {
-    mocks.walletInfo.jars = [{ balanceSummary: { ...balanceSummary, calculatedConfirmedAvailableBalanceInSats: 0 } }]
+    mocks.walletInfo.jars = [makeJar({ calculatedConfirmedAvailableBalanceInSats: 0 })]
     mocks.walletInfo.maxJarAvailableBalance = 0
 
     render(<EarnPage walletFileName="wallet.jmdat" />)

--- a/src/components/earn/EarnPage.test.tsx
+++ b/src/components/earn/EarnPage.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   walletInfo: {
     addressSummary: {},
     fidelityBondSummary: { fbOutputs: [] as FidelityBondUtxo[] },
+    hasEligibleFidelityBondUtxo: true,
     isFetching: false,
     isLoading: false,
     jars: [] as Jar[],
@@ -287,6 +288,7 @@ describe('EarnPage', () => {
       [eligibleUtxo.address]: { status: 'cj-out' },
     }
     mocks.walletInfo.fidelityBondSummary = { fbOutputs: [] }
+    mocks.walletInfo.hasEligibleFidelityBondUtxo = true
     mocks.walletInfo.isFetching = false
     mocks.walletInfo.isLoading = false
     mocks.walletInfo.jars = [makeJar()]
@@ -401,9 +403,7 @@ describe('EarnPage', () => {
 
   it('explains when no UTXO is eligible for fidelity-bond creation', async () => {
     const user = userEvent.setup()
-    mocks.walletInfo.addressSummary = {
-      [eligibleUtxo.address]: { status: 'deposit' },
-    }
+    mocks.walletInfo.hasEligibleFidelityBondUtxo = false
 
     render(<EarnPage walletFileName="wallet.jmdat" />)
 

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -2,14 +2,22 @@ import { useEffect, useMemo, useState } from 'react'
 import { startmakerMutation, stopmakerOptions } from '@joinmarket-webui/joinmarket-ng-api-ts/@tanstack/react-query'
 import type { StartMakerRequest } from '@joinmarket-webui/joinmarket-ng-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { FileTextIcon, HourglassIcon, PlusIcon, RefreshCwIcon, ShuffleIcon, UnlockIcon } from 'lucide-react'
+import {
+  AlertTriangleIcon,
+  FileTextIcon,
+  HourglassIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  ShuffleIcon,
+  UnlockIcon,
+} from 'lucide-react'
 import type { SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useStore } from 'zustand'
 import { DevBadge } from '@/components/dev/DevBadge'
 import { FeeConfigDialog } from '@/components/settings/fees/FeeConfigDialog'
-import { Alert, AlertTitle } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { FeeConfigErrorAlert } from '@/components/ui/jam/FeeConfigErrorAlert'
@@ -130,6 +138,13 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   const waitingForOfferUpdate = makerRunning && !isCurrentOfferAvailable
 
   const hasFidelityBond = walletInfo.fidelityBondSummary.fbOutputs.length > 0
+  const hasEligibleFidelityBondUtxo = useMemo(
+    () =>
+      walletInfo.jars.some((jar) =>
+        jar.utxos.some((utxo) => fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status)),
+      ),
+    [walletInfo.addressSummary, walletInfo.jars],
+  )
   const isFidelityBondActionsEnabled =
     jmSession?.rescanning === false &&
     jmSession.maker_running === false &&
@@ -139,7 +154,9 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
     !walletInfo.isFetching
 
   const isCreateFidelityBondEnabled =
-    isFidelityBondActionsEnabled && (!hasFidelityBond || JAM_EARN_CREATE_MULTIPLE_FIDELITY_BONDS_ENABLED)
+    isFidelityBondActionsEnabled &&
+    hasEligibleFidelityBondUtxo &&
+    (!hasFidelityBond || JAM_EARN_CREATE_MULTIPLE_FIDELITY_BONDS_ENABLED)
   const showCreateAdditionalFidelityBond = JAM_EARN_CREATE_MULTIPLE_FIDELITY_BONDS_ENABLED
 
   const numberOfNonFrozenFidelityBondOutputs = !hasFidelityBond
@@ -319,6 +336,17 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
               <CardDescription>{t('earn.fidelity_bond.subtitle')}</CardDescription>
               <CardAction></CardAction>
             </CardHeader>
+            {!hasEligibleFidelityBondUtxo && (
+              <CardContent>
+                <Alert variant="warning">
+                  <AlertTriangleIcon />
+                  <AlertTitle>{t('earn.fidelity_bond.create_form.alert_no_eligible_utxos_title')}</AlertTitle>
+                  <AlertDescription>
+                    {t('earn.fidelity_bond.create_form.alert_no_eligible_utxos_description')}
+                  </AlertDescription>
+                </Alert>
+              </CardContent>
+            )}
             <CardFooter className="gap-2">
               <Button
                 variant="default"

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -2,17 +2,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { startmakerMutation, stopmakerOptions } from '@joinmarket-webui/joinmarket-ng-api-ts/@tanstack/react-query'
 import type { StartMakerRequest } from '@joinmarket-webui/joinmarket-ng-api-ts/jm'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import {
-  AlertTriangleIcon,
-  FileTextIcon,
-  HourglassIcon,
-  PlusIcon,
-  RefreshCwIcon,
-  ShuffleIcon,
-  UnlockIcon,
-} from 'lucide-react'
+import { FileTextIcon, HourglassIcon, InfoIcon, PlusIcon, RefreshCwIcon, ShuffleIcon, UnlockIcon } from 'lucide-react'
 import type { SubmitHandler } from 'react-hook-form'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { useStore } from 'zustand'
 import { DevBadge } from '@/components/dev/DevBadge'
@@ -25,6 +18,7 @@ import { PageLoading } from '@/components/ui/jam/PageLoading'
 import PageTitle from '@/components/ui/jam/PageTitle'
 import { isDevMode } from '@/constants/debugFeatures'
 import * as JAM from '@/constants/jam'
+import { routes } from '@/constants/routes'
 import { useJamWalletInfoContext } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeeConfigValidation } from '@/hooks/useFeeConfigValidation'
@@ -331,11 +325,17 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
             </CardHeader>
             {!walletInfo.hasEligibleFidelityBondUtxo && (
               <CardContent>
-                <Alert variant="warning">
-                  <AlertTriangleIcon />
+                <Alert variant="default">
+                  <InfoIcon />
                   <AlertTitle>{t('earn.fidelity_bond.create_form.alert_no_eligible_utxos_title')}</AlertTitle>
                   <AlertDescription>
-                    {t('earn.fidelity_bond.create_form.alert_no_eligible_utxos_description')}
+                    <Trans
+                      i18nKey="earn.fidelity_bond.create_form.alert_no_eligible_utxos_description"
+                      components={{
+                        '1': <Link to={routes.send} className="font-semibold" />,
+                        '3': <Link to={routes.walletJarsDetails} className="font-semibold" />,
+                      }}
+                    />
                   </AlertDescription>
                 </Alert>
               </CardContent>

--- a/src/components/earn/EarnPage.tsx
+++ b/src/components/earn/EarnPage.tsx
@@ -138,13 +138,6 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
   const waitingForOfferUpdate = makerRunning && !isCurrentOfferAvailable
 
   const hasFidelityBond = walletInfo.fidelityBondSummary.fbOutputs.length > 0
-  const hasEligibleFidelityBondUtxo = useMemo(
-    () =>
-      walletInfo.jars.some((jar) =>
-        jar.utxos.some((utxo) => fb.utxo.isEligibleForCreation(utxo, walletInfo.addressSummary[utxo.address]?.status)),
-      ),
-    [walletInfo.addressSummary, walletInfo.jars],
-  )
   const isFidelityBondActionsEnabled =
     jmSession?.rescanning === false &&
     jmSession.maker_running === false &&
@@ -155,7 +148,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
 
   const isCreateFidelityBondEnabled =
     isFidelityBondActionsEnabled &&
-    hasEligibleFidelityBondUtxo &&
+    walletInfo.hasEligibleFidelityBondUtxo &&
     (!hasFidelityBond || JAM_EARN_CREATE_MULTIPLE_FIDELITY_BONDS_ENABLED)
   const showCreateAdditionalFidelityBond = JAM_EARN_CREATE_MULTIPLE_FIDELITY_BONDS_ENABLED
 
@@ -336,7 +329,7 @@ export const EarnPage = ({ walletFileName }: EarnPageProps) => {
               <CardDescription>{t('earn.fidelity_bond.subtitle')}</CardDescription>
               <CardAction></CardAction>
             </CardHeader>
-            {!hasEligibleFidelityBondUtxo && (
+            {!walletInfo.hasEligibleFidelityBondUtxo && (
               <CardContent>
                 <Alert variant="warning">
                   <AlertTriangleIcon />

--- a/src/components/sweep/SweepPage.test.tsx
+++ b/src/components/sweep/SweepPage.test.tsx
@@ -331,6 +331,7 @@ const makeWalletInfo = (overrides: Partial<WalletInfo> = {}): WalletInfo => {
     detectedNetwork: null,
     error: null,
     fidelityBondSummary: { fbOutputs: [] },
+    hasEligibleFidelityBondUtxo: false,
     isFetching: false,
     isLoading: false,
     jars: [jar, emptyJar(1), emptyJar(2)],

--- a/src/context/JamWalletInfoContext.ts
+++ b/src/context/JamWalletInfoContext.ts
@@ -84,6 +84,7 @@ interface JamWalletInfoContextType {
   walletName: string | null
   walletBalanceSummary: WalletBalanceSummary
   maxJarAvailableBalance: AmountSats
+  hasEligibleFidelityBondUtxo: boolean
   fidelityBondSummary: FidelityBondSummary
   addressSummary: AddressSummary
   accountSummary: AccountSummary

--- a/src/context/JamWalletInfoContextProvider.test.tsx
+++ b/src/context/JamWalletInfoContextProvider.test.tsx
@@ -75,7 +75,7 @@ const utxo = (overrides: Partial<Utxo>): Utxo => ({
   ...overrides,
 })
 
-const walletInfo = (): WalletInfoApiObject =>
+const walletInfo = (status = 'new'): WalletInfoApiObject =>
   ({
     wallet_name: 'testing.jmdat',
     total_balance: '0',
@@ -89,7 +89,7 @@ const walletInfo = (): WalletInfoApiObject =>
               {
                 address,
                 hd_path: "m/84'/1'/0'/0/0",
-                status: 'new',
+                status,
                 label: '',
                 balance: 0,
                 used_count: 0,
@@ -145,6 +145,7 @@ describe('<JamWalletInfoContextProvider />', () => {
     expect(context?.jars.map((jar) => jar.jarIndex)).toEqual([0, 1, 2, 3, 4, 7])
     expect(context?.jars.find((jar) => jar.jarIndex === 7)?.name).toBe('Jar #7')
     expect(context?.fidelityBondSummary.fbOutputs.map((entry) => entry.utxo)).toEqual([`${txid('c')}:2`])
+    expect(context?.hasEligibleFidelityBondUtxo).toBe(false)
     expect(context?.accountSummary[0].branches[0]).toMatchObject({
       type: 'external addresses',
       derivation: "m/84'/1'/0'/0",
@@ -158,6 +159,19 @@ describe('<JamWalletInfoContextProvider />', () => {
     expect(context?.isLoading).toBe(false)
     expect(context?.isFetching).toBe(false)
     expect(context?.error).toBeNull()
+  })
+
+  it('reports when an eligible fidelity-bond UTXO is available', () => {
+    let context: ReturnType<typeof useJamWalletInfoContext> | undefined
+    mocks.walletInfo = walletInfo('cj-out')
+
+    render(
+      <JamWalletInfoContextProvider walletFileName="testing.jmdat">
+        <CaptureWalletInfo onContext={(value) => (context = value)} />
+      </JamWalletInfoContextProvider>,
+    )
+
+    expect(context?.hasEligibleFidelityBondUtxo).toBe(true)
   })
 
   it('handles malformed accounts, missing branches, and entries without a status', () => {

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -198,6 +198,9 @@ export const JamWalletInfoContextProvider = ({
       : toAccountSummary(displayWalletQuery.walletInfo)
   const addressSummary =
     displayWalletQuery.walletInfo === undefined ? EMPTY_ADDRESS_SUMMARY : toAddressSummary(accountSummary)
+  const hasEligibleFidelityBondUtxo = utxos.some((utxo) =>
+    fb.utxo.isEligibleForCreation(utxo, addressSummary[utxo.address]?.status),
+  )
 
   const detectedNetwork = useMemo(() => {
     const eligibleAddress = Object.values(addressSummary).find((it) => it.info !== undefined)
@@ -248,6 +251,7 @@ export const JamWalletInfoContextProvider = ({
     walletName: walletFileName ? walletDisplayName(walletFileName) : null,
     walletBalanceSummary: walletBalanceSummary,
     maxJarAvailableBalance,
+    hasEligibleFidelityBondUtxo,
     fidelityBondSummary,
     addressSummary,
     accountSummary,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -675,7 +675,7 @@
         "confirmation_toggle_title": "I have reviewed my inputs carefully",
         "confirmation_toggle_subtitle": "I understand that the locked funds will be inaccessible for the given duration",
         "alert_no_eligible_utxos_title": "No eligible UTXOs",
-        "alert_no_eligible_utxos_description": "A Fidelity Bond must be funded by an unfrozen collaborative transaction output (cj-out). Complete a collaborative transaction or unfreeze an eligible UTXO to continue.",
+        "alert_no_eligible_utxos_description": "A Fidelity Bond must be funded by an unfrozen collaborative transaction output (cj-out). <1>Complete a collaborative transaction</1> or <3>unfreeze an eligible UTXO</3> to continue.",
         "button_create": "Create Fidelity Bond"
       },
       "existing": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -674,6 +674,8 @@
       "create_form": {
         "confirmation_toggle_title": "I have reviewed my inputs carefully",
         "confirmation_toggle_subtitle": "I understand that the locked funds will be inaccessible for the given duration",
+        "alert_no_eligible_utxos_title": "No eligible UTXOs",
+        "alert_no_eligible_utxos_description": "A Fidelity Bond must be funded by an unfrozen collaborative transaction output (cj-out). Complete a collaborative transaction or unfreeze an eligible UTXO to continue.",
         "button_create": "Create Fidelity Bond"
       },
       "existing": {

--- a/src/lib/fidelityBondUtils.test.ts
+++ b/src/lib/fidelityBondUtils.test.ts
@@ -180,6 +180,19 @@ describe('utils', () => {
       expect(fb.utxo.allAreFrozen(utxos)).toBe(false)
     })
 
+    it('should identify UTXOs eligible for fidelity-bond creation', () => {
+      expect(fb.utxo.isEligibleForCreation(makeUtxo('foo:0'), 'cj-out')).toBe(true)
+      expect(fb.utxo.isEligibleForCreation(makeUtxo('foo:0', '', true), 'cj-out')).toBe(false)
+      expect(fb.utxo.isEligibleForCreation(makeUtxo('foo:0'), 'deposit')).toBe(false)
+      expect(fb.utxo.isEligibleForCreation(makeUtxo('foo:0'))).toBe(false)
+
+      const fidelityBond = {
+        ...makeUtxo('foo:0'),
+        locktime: '2999-01-01 00:00:00',
+      } as Utxo
+      expect(fb.utxo.isEligibleForCreation(fidelityBond, 'cj-out')).toBe(false)
+    })
+
     describe('isLocked', () => {
       const now = Date.UTC(2009, 0, 3)
 

--- a/src/lib/fidelityBondUtils.ts
+++ b/src/lib/fidelityBondUtils.ts
@@ -98,6 +98,9 @@ export const utxo = (() => {
 
   const isFidelityBond = (utxo: Utxo): utxo is FidelityBondUtxo => !!utxo.locktime
 
+  const isEligibleForCreation = (utxo: Utxo, addressStatus?: string) =>
+    !utxo.frozen && !isFidelityBond(utxo) && addressStatus === 'cj-out'
+
   const getLocktime = (utxo: Utxo): Milliseconds | null => {
     if (!isFidelityBond(utxo)) return null
 
@@ -115,5 +118,14 @@ export const utxo = (() => {
     return locktime !== null && locktime >= refTime
   }
 
-  return { isEqual, isInList, utxosToFreeze, allAreFrozen, isFidelityBond, isLocked, getLocktime }
+  return {
+    isEqual,
+    isInList,
+    utxosToFreeze,
+    allAreFrozen,
+    isFidelityBond,
+    isEligibleForCreation,
+    isLocked,
+    getLocktime,
+  }
 })()

--- a/src/lib/fidelityBondUtils.ts
+++ b/src/lib/fidelityBondUtils.ts
@@ -98,6 +98,7 @@ export const utxo = (() => {
 
   const isFidelityBond = (utxo: Utxo): utxo is FidelityBondUtxo => !!utxo.locktime
 
+  // TODO: allow selecting frozen UTXOs and unfreeze them before sending the transaction
   const isEligibleForCreation = (utxo: Utxo, addressStatus?: string) =>
     !utxo.frozen && !isFidelityBond(utxo) && addressStatus === 'cj-out'
 


### PR DESCRIPTION
Prevent users from entering the Fidelity Bond creation flow when no eligible funding UTXO is available.
- centralize the eligibility check for unfrozen `cj-out` UTXOs
- disable Fidelity Bond creation when no eligible UTXO exists
- explain how users can obtain an eligible UTXO
- keep the entry-point and wizard eligibility checks consistent

Closes #1375