### PR TITLE
fix(validation): correctly handle zero block height in blockHeightField

### DIFF
--- a/src/lib/formValidation.test.ts
+++ b/src/lib/formValidation.test.ts
@@ -7,6 +7,8 @@ import {
   isReusedAddress,
   isValidAddress,
   sourceJarField,
+  blockHeightField,
+  INPUT_BLOCK_HEIGHT_MIN,
 } from './formValidation'
 
 const mainnetAddress = '1BitcoinEaterAddressDontSend8MUo1T'
@@ -162,5 +164,45 @@ describe('destinationAddressField', () => {
     })
 
     expect(() => reusedSchema.validateSync(mainnetAddress)).toThrow('reused')
+  })
+})
+
+describe('blockHeightField', () => {
+  const invalidMsg = ({ min, max }: { min: number; max: number }) => `Invalid blockheight ${min}-${max}`
+
+  it('handles currentBlockHeight = 0', () => {
+    const schema = blockHeightField({ currentBlockHeight: 0, messages: { invalid: invalidMsg } })
+    // min should be 0, max should be 0
+    expect(schema.isValidSync(0)).toBe(true)
+    expect(schema.isValidSync(1)).toBe(false)
+  })
+
+  it('handles currentBlockHeight = undefined', () => {
+    const schema = blockHeightField({ currentBlockHeight: undefined, messages: { invalid: invalidMsg } })
+    // min should be 0, max should be Number.MAX_SAFE_INTEGER
+    expect(schema.isValidSync(0)).toBe(true)
+    expect(schema.isValidSync(100)).toBe(true)
+    expect(schema.isValidSync(Number.MAX_SAFE_INTEGER + 1)).toBe(false)
+  })
+
+  it('handles currentBlockHeight = null', () => {
+    // @ts-expect-error Intentionally pass null to test JS boundary cases
+    const schema = blockHeightField({ currentBlockHeight: null, messages: { invalid: invalidMsg } })
+    expect(schema.isValidSync(0)).toBe(true)
+    expect(schema.isValidSync(100)).toBe(true)
+  })
+
+  it('handles currentBlockHeight > minBlockHeight', () => {
+    const schema = blockHeightField({ currentBlockHeight: 100, messages: { invalid: invalidMsg } })
+    // min should be 0, max should be 100
+    expect(schema.isValidSync(50)).toBe(true)
+    expect(schema.isValidSync(100)).toBe(true)
+    expect(schema.isValidSync(101)).toBe(false)
+  })
+
+  it('handles currentBlockHeight == minBlockHeight (0)', () => {
+    const schema = blockHeightField({ currentBlockHeight: INPUT_BLOCK_HEIGHT_MIN, messages: { invalid: invalidMsg } })
+    expect(schema.isValidSync(INPUT_BLOCK_HEIGHT_MIN)).toBe(true)
+    expect(schema.isValidSync(INPUT_BLOCK_HEIGHT_MIN + 1)).toBe(false)
   })
 })

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -121,7 +121,7 @@ export const blockHeightField = ({
   }
 }) => {
   const minBlockHeight = Math.min(INPUT_BLOCK_HEIGHT_MIN, currentBlockHeight || INPUT_BLOCK_HEIGHT_MIN)
-  const maxBlockheight = Math.max(minBlockHeight, currentBlockHeight || INPUT_BLOCK_HEIGHT_MAX)
+  const maxBlockheight = Math.max(minBlockHeight, currentBlockHeight ?? INPUT_BLOCK_HEIGHT_MAX)
   const invalidBlockheightMessage = invalid({ min: minBlockHeight, max: maxBlockheight })
 
   return yup


### PR DESCRIPTION
 # Fix `blockHeightField` validation when `currentBlockHeight` is `0`

## Summary

This PR fixes a bug in the `blockHeightField` validator where the logical OR (`||`) operator was used to determine the maximum allowed block height.

Since `0` is a falsy value in JavaScript, a `currentBlockHeight` of `0` (for example, on a fresh regtest network) incorrectly caused the validator to fall back to `Number.MAX_SAFE_INTEGER`. As a result, block heights greater than the current chain height were incorrectly accepted.

This PR replaces `||` with the nullish coalescing operator (`??`), ensuring that only `null` or `undefined` trigger the fallback while preserving valid values such as `0`.

## Changes

* Replaced the `||` operator with `??` in the `blockHeightField` validator.
* Fixed validation when `currentBlockHeight === 0`.
* Preserved the existing fallback behavior for `null` and `undefined`.
* Added comprehensive unit tests in `formValidation.test.ts` covering:

  * `currentBlockHeight = 0`
  * `currentBlockHeight = undefined`
  * `currentBlockHeight = null`
  * Normal validation behavior

## Why this change?

Using `||` treats `0` as a falsy value:

```ts
const maxBlockHeight = currentBlockHeight || Number.MAX_SAFE_INTEGER;
```

When `currentBlockHeight` is `0`, it evaluates to:

```ts
0 || Number.MAX_SAFE_INTEGER;
// => Number.MAX_SAFE_INTEGER
```

This causes the validator to ignore the actual chain height.

Replacing it with `??` ensures that only `null` and `undefined` use the fallback value:

```ts
const maxBlockHeight = currentBlockHeight ?? Number.MAX_SAFE_INTEGER;
```

As a result, `0` is preserved as a valid block height, preventing invalid values from passing validation.

## Testing

Added unit tests to verify:

* ✅ Validation rejects block heights greater than `0` when `currentBlockHeight` is `0`.
* ✅ `undefined` correctly falls back to `Number.MAX_SAFE_INTEGER`.
* ✅ `null` correctly falls back to `Number.MAX_SAFE_INTEGER`.
* ✅ Existing validation behavior remains unchanged for valid inputs.

## Related Issue

Fixes #XXXX

## Visual Demo

N/A (validation logic change with unit test coverage).

