### PR TITLE
fix(send): correctly handle null amount on direct sweep sends

### DIFF
--- a/src/components/send/collaborativeSend.test.ts
+++ b/src/components/send/collaborativeSend.test.ts
@@ -157,6 +157,22 @@ describe('buildNonCollaborativeSendRequest', () => {
     expect(request.amount_sats).toBe(0)
   })
 
+  it('maps sweep direct sends to amount_sats=0 when amount is null (real form-schema shape)', () => {
+    // SendForm.schema.ts transforms amount.amount to `null` (not `undefined`) once isSweep is true,
+    // which is what react-hook-form actually submits in production
+    const request = buildNonCollaborativeSendRequest({
+      ...baseValues(),
+      isCoinJoin: false,
+      amount: {
+        isSweep: true,
+        amount: null as unknown as undefined,
+        sweepAmount: 500_000,
+      },
+    })
+
+    expect(request.amount_sats).toBe(0)
+  })
+
   it('passes direct-send txfee values', () => {
     expect(
       buildNonCollaborativeSendRequest({

--- a/src/components/send/collaborativeSend.ts
+++ b/src/components/send/collaborativeSend.ts
@@ -30,7 +30,7 @@ export const buildNonCollaborativeSendRequest = (data: SendFormValues): DirectSe
   if (data.source?.fromJar === undefined) {
     throw new Error('Cannot trigger non-collaborative transaction: Invalid source jar given.')
   }
-  if (data.amount.isSweep === true && data.amount.amount !== undefined) {
+  if (data.amount.isSweep === true && data.amount.amount != null) {
     throw new Error('Cannot trigger non-collaborative transaction: Invalid amount given for sweep.')
   }
 


### PR DESCRIPTION
Direct (non-CoinJoin) sweep sends throw an error and never complete. SendForm.schema.ts sets amount.amount to null when sweeping, but buildNonCollaborativeSendRequest only checked for undefined, so it rejected every real sweep submission.

Changed the check to catch both null and undefined. Added a test covering the actual null shape the form produces, alongside the existing undefined case.

Tested: npx vitest run src/components/send/collaborativeSend.test.ts (14/14 pass), eslint and prettier clean on changed files.

fixes #1411 