### PR TITLE
perf(context): optimize combinedUtxosHash from O(n²) to O(n)

### DIFF
--- a/src/context/JamWalletInfoContextProvider.test.tsx
+++ b/src/context/JamWalletInfoContextProvider.test.tsx
@@ -278,7 +278,6 @@ describe('<JamWalletInfoContextProvider />', () => {
  */
 const combinedUtxosHashReference = (utxoList: Utxo[]): string => {
   const utxoIds = utxoList.map((it) => hexToBytes(it.utxo.split(':', 1)[0]))
-  // eslint-disable-next-line unicorn/no-array-reduce
   const combinedUtxoIds = new Uint8Array(utxoIds.reduce((acc, current) => [...acc, ...current], [] as number[]))
   return bytesToHex(sha256(combinedUtxoIds))
 }
@@ -298,7 +297,7 @@ describe('combinedUtxosHash — optimized vs reference (regression)', () => {
     let captured = ''
     render(
       <JamWalletInfoContextProvider walletFileName="testing.jmdat">
-        <CaptureWalletInfo onContext={(ctx) => (captured = ctx.utxosHashHex)} />
+        <CaptureWalletInfo onContext={(context) => (captured = context.utxosHashHex)} />
       </JamWalletInfoContextProvider>,
     )
     return captured

--- a/src/context/JamWalletInfoContextProvider.test.tsx
+++ b/src/context/JamWalletInfoContextProvider.test.tsx
@@ -305,12 +305,29 @@ describe('combinedUtxosHash — optimized vs reference (regression)', () => {
 
   it('produces the same hash for an empty UTXO list', () => {
     const utxoList: Utxo[] = []
-    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+    const actual = captureHash(utxoList)
+    expect(actual).toBe(combinedUtxosHashReference(utxoList))
+    expect(actual).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
   })
 
   it('produces the same hash for a single UTXO', () => {
     const utxoList = [utxo({ utxo: `${txid('a')}:0` })]
-    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+    const actual = captureHash(utxoList)
+    expect(actual).toBe(combinedUtxosHashReference(utxoList))
+    expect(actual).toBe('e0e77a507412b120f6ede61f62295b1a7b2ff19d3dcc8f7253e51663470c888e')
+  })
+
+  it('is okay for it to produce the same hash for different output in same txid', () => {
+    const utxoList0 = [utxo({ utxo: `${txid('a')}:0` })]
+    const actual0 = captureHash(utxoList0)
+    expect(actual0).toBe(combinedUtxosHashReference(utxoList0))
+    expect(actual0).toBe('e0e77a507412b120f6ede61f62295b1a7b2ff19d3dcc8f7253e51663470c888e')
+
+    const utxoList1 = [utxo({ utxo: `${txid('a')}:1` })]
+    const actual1 = captureHash(utxoList1)
+    expect(actual1).toBe(combinedUtxosHashReference(utxoList1))
+    expect(actual1).toBe('e0e77a507412b120f6ede61f62295b1a7b2ff19d3dcc8f7253e51663470c888e')
+    expect(actual1).toBe(actual0)
   })
 
   it('produces the same hash for multiple UTXOs', () => {
@@ -319,7 +336,10 @@ describe('combinedUtxosHash — optimized vs reference (regression)', () => {
       utxo({ utxo: `${txid('b')}:1` }),
       utxo({ utxo: `${txid('c')}:2` }),
     ]
-    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+
+    const actual = captureHash(utxoList)
+    expect(actual).toBe(combinedUtxosHashReference(utxoList))
+    expect(actual).toBe('6bdaf8651d78f983ab7ce864414ace095b2942cbe5ff43deade48d51aa34b2cd')
   })
 
   it('produces the same hash for UTXOs whose txid bytes vary across the full byte range', () => {

--- a/src/context/JamWalletInfoContextProvider.test.tsx
+++ b/src/context/JamWalletInfoContextProvider.test.tsx
@@ -1,3 +1,5 @@
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js'
 import { render, screen, waitFor } from '@testing-library/react'
 import { Network } from 'bitcoin-address-validation'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -267,5 +269,75 @@ describe('<JamWalletInfoContextProvider />', () => {
     await waitFor(() => expect(mocks.utxosRefetch).toHaveBeenCalledWith({ throwOnError: true }))
     expect(mocks.displayWalletRefetch).toHaveBeenCalledWith({ throwOnError: true })
     expect(balanceSummary?.calculatedTotalBalanceInSats).toBe(25_000)
+  })
+})
+
+/**
+ * Reference implementation of the old O(n²) combinedUtxosHash logic.
+ * Used only in tests to verify the optimized implementation is a drop-in replacement.
+ */
+const combinedUtxosHashReference = (utxoList: Utxo[]): string => {
+  const utxoIds = utxoList.map((it) => hexToBytes(it.utxo.split(':', 1)[0]))
+  // eslint-disable-next-line unicorn/no-array-reduce
+  const combinedUtxoIds = new Uint8Array(utxoIds.reduce((acc, current) => [...acc, ...current], [] as number[]))
+  return bytesToHex(sha256(combinedUtxoIds))
+}
+
+describe('combinedUtxosHash — optimized vs reference (regression)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.waitQueryError = null
+    mocks.walletInfo = undefined
+    mocks.utxosRefetch.mockResolvedValue({ data: { utxos: [] } })
+    mocks.displayWalletRefetch.mockResolvedValue({ data: { walletinfo: undefined } })
+  })
+
+  /** Render the provider with the given UTXO list and capture the computed utxosHashHex. */
+  const captureHash = (utxoList: Utxo[]): string => {
+    mocks.utxos = utxoList
+    let captured = ''
+    render(
+      <JamWalletInfoContextProvider walletFileName="testing.jmdat">
+        <CaptureWalletInfo onContext={(ctx) => (captured = ctx.utxosHashHex)} />
+      </JamWalletInfoContextProvider>,
+    )
+    return captured
+  }
+
+  it('produces the same hash for an empty UTXO list', () => {
+    const utxoList: Utxo[] = []
+    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+  })
+
+  it('produces the same hash for a single UTXO', () => {
+    const utxoList = [utxo({ utxo: `${txid('a')}:0` })]
+    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+  })
+
+  it('produces the same hash for multiple UTXOs', () => {
+    const utxoList = [
+      utxo({ utxo: `${txid('a')}:0` }),
+      utxo({ utxo: `${txid('b')}:1` }),
+      utxo({ utxo: `${txid('c')}:2` }),
+    ]
+    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+  })
+
+  it('produces the same hash for UTXOs whose txid bytes vary across the full byte range', () => {
+    const utxoList = [
+      utxo({ utxo: `${txid('1')}:0` }),
+      utxo({ utxo: `${'ab'.repeat(32)}:3` }),
+      utxo({ utxo: `${'ff'.repeat(32)}:7` }),
+    ]
+    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
+  })
+
+  it('produces the same hash for a large UTXO set (50 entries)', () => {
+    const chars = '0123456789abcdef'
+    const utxoList = Array.from({ length: 50 }, (_, i) => {
+      const ch = chars[i % chars.length]
+      return utxo({ utxo: `${ch.repeat(64)}:${i}`, mixdepth: i % 5 })
+    })
+    expect(captureHash(utxoList)).toBe(combinedUtxosHashReference(utxoList))
   })
 })

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type Dispatch, type PropsWithChildren, type SetStateAction } from 'react'
 import { sha256 } from '@noble/hashes/sha2.js'
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js'
+import { bytesToHex, concatBytes, hexToBytes } from '@noble/hashes/utils.js'
 import { CancelledError, useMutation, useQuery } from '@tanstack/react-query'
 import { getAddressInfo } from 'bitcoin-address-validation'
 import { useQueryDisplayWallet, type WalletInfoApiObject } from '@/hooks/useQueryDisplayWallet'
@@ -131,13 +131,7 @@ interface JamWalletInfoContextProviderProps {
 
 const combinedUtxosHash = (utxos: Utxo[]) => {
   const utxoIds = utxos.map((it) => hexToBytes(it.utxo.split(':', 1)[0]))
-  const totalLength = utxoIds.reduce((sum, current) => sum + current.length, 0)
-  const combinedUtxoIds = new Uint8Array(totalLength)
-  let offset = 0
-  for (const current of utxoIds) {
-    combinedUtxoIds.set(current, offset)
-    offset += current.length
-  }
+  const combinedUtxoIds = concatBytes(...utxoIds)
   return sha256(combinedUtxoIds)
 }
 

--- a/src/context/JamWalletInfoContextProvider.tsx
+++ b/src/context/JamWalletInfoContextProvider.tsx
@@ -131,7 +131,13 @@ interface JamWalletInfoContextProviderProps {
 
 const combinedUtxosHash = (utxos: Utxo[]) => {
   const utxoIds = utxos.map((it) => hexToBytes(it.utxo.split(':', 1)[0]))
-  const combinedUtxoIds = new Uint8Array(utxoIds.reduce((acc, current) => [...acc, ...current], [] as number[]))
+  const totalLength = utxoIds.reduce((sum, current) => sum + current.length, 0)
+  const combinedUtxoIds = new Uint8Array(totalLength)
+  let offset = 0
+  for (const current of utxoIds) {
+    combinedUtxoIds.set(current, offset)
+    offset += current.length
+  }
   return sha256(combinedUtxoIds)
 }
 


### PR DESCRIPTION
 

Closes #1421

This PR optimizes `combinedUtxosHash` in `src/context/JamWalletInfoContextProvider.tsx` by replacing the existing spread-inside-reduce concatenation with a pre-allocated `Uint8Array` and `Uint8Array.prototype.set()`.

The change eliminates repeated copying and intermediate array allocations while preserving the exact byte sequence and SHA-256 output.

## Problem

The previous implementation used:

```ts
const combinedUtxoIds = new Uint8Array(
  utxoIds.reduce((acc, current) => [...acc, ...current], [] as number[])
)
```

The `[...acc, ...current]` operation creates a new array on every iteration and re-copies all previously accumulated bytes.

For a total of `n` bytes, this can result in **O(n²) total copying** and creates unnecessary intermediate allocations, increasing memory usage and GC pressure.

## Solution

The new implementation:

1. Calculates the total required byte length.
2. Allocates one `Uint8Array` of the exact required size.
3. Copies each UTXO byte array once using `Uint8Array.set()`.

```ts
const totalLength = utxoIds.reduce(
  (sum, current) => sum + current.length,
  0
)

const combinedUtxoIds = new Uint8Array(totalLength)

let offset = 0

for (const current of utxoIds) {
  combinedUtxoIds.set(current, offset)
  offset += current.length
}
```

This reduces the concatenation from **O(n²) copying to O(n) copying** and removes the repeated intermediate array allocations.

## Behaviour / Compatibility

There is **no intended behaviour change**.

The optimized implementation preserves:

* UTXO ordering
* Byte ordering
* Byte values
* Combined byte sequence
* Final SHA-256 digest

Therefore, the resulting hash remains identical to the previous implementation.

## Tests

Added regression coverage for:

* Empty input
* Single UTXO
* Multiple UTXOs
* Varied byte values
* Larger input with 50 UTXOs

The tests verify that the optimized implementation produces the same SHA-256 digest as the previous implementation.

## Validation

* `git diff --check` ✅
* Hash equivalence verified by regression tests ✅
* Import order fixed according to `.prettierrc.json` ✅
* Only 2 relevant files changed ✅
* No new dependencies introduced ✅
* `@noble/hashes` already exists in production dependencies ✅

### Local CI Note

The repository requires Node.js `>=26.3.0`, while the local environment currently has Node.js `24.11.1`. Because of this version difference, the complete CI suite could not be run locally.

CI should run using the repository's supported Node.js version.

## Merge Request

This is a focused performance optimization with no intended functional or API changes. The implementation is covered by regression tests and preserves the existing hash output.

**Requesting review and merge once CI checks pass.**
