### PR TITLE
fix(earn): export complete report as CSV

### DIFF
--- a/src/components/earn/report/EarnReportContent.test.tsx
+++ b/src/components/earn/report/EarnReportContent.test.tsx
@@ -209,6 +209,35 @@ describe('EarnReportContent', () => {
     createElement.mockRestore()
   })
 
+  it('exports all filtered rows regardless of pagination', async () => {
+    mocks.entries = Array.from({ length: 30 }, (_, index) =>
+      entry({
+        notes: `maker note ${index + 1}`,
+        timestamp: new Date(Date.UTC(2026, 0, index + 1, 12)),
+      }),
+    )
+
+    render(<EarnReportContent enabled />)
+
+    expect(screen.getByText('pagination:30')).toBeInTheDocument()
+    expect(screen.getAllByText(/maker note/u)).toHaveLength(25)
+
+    fireEvent.click(screen.getByRole('button', { name: 'global.download' }))
+
+    const blob = mocks.createObjectURL.mock.calls[0]?.[0]
+    expect(blob).toBeInstanceOf(Blob)
+    if (!blob) {
+      throw new Error('CSV blob was not created')
+    }
+
+    const csv = await blob.text()
+    const lines = csv.trim().split('\n')
+
+    expect(lines).toHaveLength(31)
+    expect(lines[1]).toContain('2026-01-30T12:00:00.000Z')
+    expect(lines.at(-1)).toContain('2026-01-01T12:00:00.000Z')
+  })
+
   it('adds demo rows in developer mode', () => {
     mocks.developerMode = true
 

--- a/src/components/earn/report/EarnReportContent.tsx
+++ b/src/components/earn/report/EarnReportContent.tsx
@@ -144,11 +144,11 @@ export const EarnReportContent = ({ className, enabled }: EarnReportContentProps
   }, [isShowAll, allEntries.length, table])
 
   const visibleRows = table.getRowModel().rows
+  const exportRows = table.getSortedRowModel().rows
 
-  // Export visible entries as CSV
   const downloadCsv = useCallback(() => {
     const header = 'timestamp,cj_amount,input_count,input_amount,fee,earned,confirm_minutes,notes'
-    const rows = visibleRows.map((row) =>
+    const rows = exportRows.map((row) =>
       [
         row.original.timestamp.toISOString(),
         row.original.cjTotalAmount ?? '',
@@ -170,7 +170,7 @@ export const EarnReportContent = ({ className, enabled }: EarnReportContentProps
     setTimeout(() => {
       URL.revokeObjectURL(url)
     }, 0)
-  }, [visibleRows])
+  }, [exportRows])
 
   const earnedTotal = useMemo(() => sumEarned(allEntries, BITCOIN_GENESIS_DATE), [allEntries])
 


### PR DESCRIPTION
Closes #1425

The Earn Report CSV now uses the filtered and sorted rows before pagination, so downloading does not discard entries outside the current page. The table remains paginated.

A regression test covers a 30-entry report and verifies that the 25-row page exports all 30 rows in the current sort order.

Tests:
- `vitest run --project unit src/components/earn/report/EarnReportContent.test.tsx`
- `tsc -b --pretty false`
- focused ESLint and Prettier checks