### PR TITLE
fix: don't hide a recovered wallet behind a generic import-failed error

### DIFF
--- a/src/components/import/ImportWalletPage.test.tsx
+++ b/src/components/import/ImportWalletPage.test.tsx
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => ({
   toastDismiss: vi.fn(),
   toastLoading: vi.fn(() => 'toast-id'),
   toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+  toastError: vi.fn(),
 }))
 
 type MutationOptions = { mutationFn: (input: unknown) => Promise<unknown> }
@@ -61,9 +63,10 @@ vi.mock('react-router-dom', () => ({
 vi.mock('sonner', () => ({
   toast: {
     dismiss: mocks.toastDismiss,
-    error: vi.fn(),
+    error: mocks.toastError,
     loading: mocks.toastLoading,
     success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
   },
 }))
 
@@ -167,6 +170,8 @@ describe('ImportWalletPage', () => {
     mocks.toastDismiss.mockReset()
     mocks.toastLoading.mockClear()
     mocks.toastSuccess.mockReset()
+    mocks.toastWarning.mockReset()
+    mocks.toastError.mockReset()
     authStore.getState().clear()
     jmSessionStore.setState({ state: undefined })
 
@@ -209,5 +214,86 @@ describe('ImportWalletPage', () => {
     expect(jmSessionStore.getState().state?.rescanning).toBe(true)
     expect(mocks.navigate).toHaveBeenCalledWith(routes.home)
     expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-id')
+  })
+
+  it('still signs the user in and shows a warning (not an error) when resetting gaplimit fails', async () => {
+    const user = userEvent.setup()
+    mocks.configSet.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('reset failed'))
+
+    render(<ImportWalletPage />)
+
+    await user.click(screen.getByRole('button', { name: 'wallet details' }))
+    await user.click(screen.getByRole('button', { name: 'import details' }))
+    await user.click(screen.getByRole('button', { name: 'confirm import' }))
+
+    await waitFor(() =>
+      expect(authStore.getState().state).toEqual({
+        walletFileName: 'restored.jmdat',
+        auth: { token: 'unlock-token', refresh_token: 'unlock-refresh' },
+        hashed_password: 'hashed-secret',
+      }),
+    )
+    expect(mocks.navigate).toHaveBeenCalledWith(routes.home)
+    expect(mocks.toastWarning).toHaveBeenCalledWith('import_wallet.warning_partial_import')
+    expect(mocks.toastSuccess).not.toHaveBeenCalledWith('import_wallet.success.title')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('still signs the user in and shows a warning (not an error) when the rescan trigger fails', async () => {
+    const user = userEvent.setup()
+    mocks.rescanBlockchain.mockRejectedValueOnce(new Error('rescan failed'))
+
+    render(<ImportWalletPage />)
+
+    await user.click(screen.getByRole('button', { name: 'wallet details' }))
+    await user.click(screen.getByRole('button', { name: 'import details' }))
+    await user.click(screen.getByRole('button', { name: 'confirm import' }))
+
+    await waitFor(() =>
+      expect(authStore.getState().state).toEqual({
+        walletFileName: 'restored.jmdat',
+        auth: { token: 'unlock-token', refresh_token: 'unlock-refresh' },
+        hashed_password: 'hashed-secret',
+      }),
+    )
+    expect(mocks.navigate).toHaveBeenCalledWith(routes.home)
+    expect(mocks.toastWarning).toHaveBeenCalledWith('import_wallet.warning_partial_import')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('does not sign the user in, sends them to login, and shows a warning (not the generic error) when lock/unlock fails after the wallet was already recovered', async () => {
+    const user = userEvent.setup()
+    mocks.lockWallet.mockRejectedValueOnce(new Error('lock failed'))
+
+    render(<ImportWalletPage />)
+
+    await user.click(screen.getByRole('button', { name: 'wallet details' }))
+    await user.click(screen.getByRole('button', { name: 'import details' }))
+    await user.click(screen.getByRole('button', { name: 'confirm import' }))
+
+    await waitFor(() => expect(mocks.toastWarning).toHaveBeenCalledWith('import_wallet.warning_partial_import'))
+
+    expect(authStore.getState().state).toBeUndefined()
+    expect(mocks.navigate).toHaveBeenCalledWith(routes.login)
+    expect(mocks.rescanBlockchain).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('shows the generic error when the wallet itself was never recovered', async () => {
+    const user = userEvent.setup()
+    mocks.recoverWallet.mockReset()
+    mocks.recoverWallet.mockRejectedValueOnce(new Error('recover failed'))
+
+    render(<ImportWalletPage />)
+
+    await user.click(screen.getByRole('button', { name: 'wallet details' }))
+    await user.click(screen.getByRole('button', { name: 'import details' }))
+    await user.click(screen.getByRole('button', { name: 'confirm import' }))
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('import_wallet.error_importing_failed'))
+
+    expect(authStore.getState().state).toBeUndefined()
+    expect(mocks.navigate).not.toHaveBeenCalled()
+    expect(mocks.toastWarning).not.toHaveBeenCalled()
   })
 })

--- a/src/components/import/ImportWalletPage.tsx
+++ b/src/components/import/ImportWalletPage.tsx
@@ -183,103 +183,138 @@ const ImportWalletPage = () => {
       } catch (hashError: unknown) {
         console.warn('Failed to hash password after wallet import', hashError)
       }
+
+      // From here on, the wallet has already been recovered on the backend
+      // (step #1 above). The remaining steps are best-effort setup: a
+      // failure in any of them must not be reported as "import failed" —
+      // the wallet exists and is usable — it should just be logged and
+      // surfaced as a softer warning instead.
+      let setupWarningReason: string | undefined
+
       // Step #2: update the gaplimit config value if necessary
-      const originalGaplimitResponse = await fetchConfig.mutateAsync({
-        path: { walletname: authState.walletFileName },
-        headers: { ...buildAuthHeaderMap(authState.auth.token) },
-        body: JM_GAPLIMIT_CONFIGKEY,
-      })
-      const originalGaplimit = Number.parseInt(originalGaplimitResponse.configvalue, 10) || JM_GAPLIMIT_DEFAULT
-
-      const gaplimitUpdateNecessary = importDetails.gaplimit !== originalGaplimit
-      if (gaplimitUpdateNecessary) {
-        console.info('Will update gaplimit from %d to %d', originalGaplimit, importDetails.gaplimit)
-
-        await updateConfig.mutateAsync({
-          path: { walletname: authState.walletFileName },
-          headers: { ...buildAuthHeaderMap(authState.auth.token) },
-          body: {
-            ...JM_GAPLIMIT_CONFIGKEY,
-            value: String(importDetails.gaplimit),
-          },
-        })
-      }
-      // Step #3: lock and unlock the wallet (for new addresses to be imported)
-      await lockWallet.mutateAsync({
-        walletFileName: authState.walletFileName,
-        token: authState.auth.token,
-      })
-
-      const unlockResponse = await unlockWallet.mutateAsync({
-        path: { walletname: authState.walletFileName },
-        body: {
-          password: walletDetails.password,
-        },
-      })
-
-      // use new token in requests
-      authState.walletFileName = unlockResponse.walletname as WalletFileName
-      authState.auth = {
-        token: unlockResponse.token,
-        refresh_token: unlockResponse.refresh_token,
-      }
-
-      // Step #4: reset `gaplimit´ to previous value if necessary
-      if (gaplimitUpdateNecessary) {
-        console.info('Will reset gaplimit to previous value %d', originalGaplimit)
-        await updateConfig.mutateAsync({
-          path: { walletname: authState.walletFileName },
-          headers: { ...buildAuthHeaderMap(authState.auth.token) },
-          body: {
-            ...JM_GAPLIMIT_CONFIGKEY,
-            value: String(originalGaplimit),
-          },
-        })
-      }
-
-      // Step #5: invoke rescanning the timechain
-      console.info('Will start rescanning timechain from block %d', importDetails.blockheight)
-      await rescanMutation.mutateAsync({
-        walletFileName: authState.walletFileName,
-        token: authState.auth.token,
-        blockHeight: importDetails.blockheight,
-      })
-
+      let gaplimitUpdateApplied = false
+      let originalGaplimit: number | undefined
       try {
-        const { data: sessionInfo } = await session({ client, throwOnError: true })
-        updateSessionInfo({
-          ...sessionInfo,
-          rescanning: true,
+        const originalGaplimitResponse = await fetchConfig.mutateAsync({
+          path: { walletname: authState.walletFileName },
+          headers: { ...buildAuthHeaderMap(authState.auth.token) },
+          body: JM_GAPLIMIT_CONFIGKEY,
         })
-        toast.success(t('rescan_chain.success_rescan_started'))
+        originalGaplimit = Number.parseInt(originalGaplimitResponse.configvalue, 10) || JM_GAPLIMIT_DEFAULT
+
+        if (importDetails.gaplimit !== originalGaplimit) {
+          console.info('Will update gaplimit from %d to %d', originalGaplimit, importDetails.gaplimit)
+          await updateConfig.mutateAsync({
+            path: { walletname: authState.walletFileName },
+            headers: { ...buildAuthHeaderMap(authState.auth.token) },
+            body: {
+              ...JM_GAPLIMIT_CONFIGKEY,
+              value: String(importDetails.gaplimit),
+            },
+          })
+          gaplimitUpdateApplied = true
+        }
       } catch (error: unknown) {
         const reason = getErrorReason(error, t('global.errors.reason_unknown'))
-        console.warn('Non-critical error while fetching session after wallet import. Continuing with import...', reason)
+        console.warn('Failed to apply temporary gaplimit during wallet import, continuing with import...', reason)
+        setupWarningReason = reason
       }
 
-      updateAuthState(authState)
+      // Step #3: lock and unlock the wallet (for new addresses to be imported).
+      // Unlike steps #2, #4 and #5, a failure here means the auth token in
+      // `authState` may no longer be valid, so the remaining steps that
+      // depend on it are skipped rather than attempted best-effort.
+      let lockUnlockSucceeded = false
+      try {
+        await lockWallet.mutateAsync({
+          walletFileName: authState.walletFileName,
+          token: authState.auth.token,
+        })
 
-      toast.success(t('import_wallet.success.title'))
-      await navigate(routes.home)
+        const unlockResponse = await unlockWallet.mutateAsync({
+          path: { walletname: authState.walletFileName },
+          body: {
+            password: walletDetails.password,
+          },
+        })
+
+        // use new token in requests
+        authState.walletFileName = unlockResponse.walletname as WalletFileName
+        authState.auth = {
+          token: unlockResponse.token,
+          refresh_token: unlockResponse.refresh_token,
+        }
+        lockUnlockSucceeded = true
+      } catch (error: unknown) {
+        const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+        console.warn('Failed to lock/unlock wallet after import, skipping remaining setup steps...', reason)
+        setupWarningReason = reason
+      }
+
+      if (lockUnlockSucceeded) {
+        // Step #4: reset `gaplimit´ to previous value if necessary
+        if (gaplimitUpdateApplied && originalGaplimit !== undefined) {
+          try {
+            console.info('Will reset gaplimit to previous value %d', originalGaplimit)
+            await updateConfig.mutateAsync({
+              path: { walletname: authState.walletFileName },
+              headers: { ...buildAuthHeaderMap(authState.auth.token) },
+              body: {
+                ...JM_GAPLIMIT_CONFIGKEY,
+                value: String(originalGaplimit),
+              },
+            })
+          } catch (error: unknown) {
+            const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+            console.warn('Failed to reset gaplimit after wallet import, continuing with import...', reason)
+            setupWarningReason = reason
+          }
+        }
+
+        // Step #5: invoke rescanning the timechain
+        try {
+          console.info('Will start rescanning timechain from block %d', importDetails.blockheight)
+          await rescanMutation.mutateAsync({
+            walletFileName: authState.walletFileName,
+            token: authState.auth.token,
+            blockHeight: importDetails.blockheight,
+          })
+
+          const { data: sessionInfo } = await session({ client, throwOnError: true })
+          updateSessionInfo({
+            ...sessionInfo,
+            rescanning: true,
+          })
+          toast.success(t('rescan_chain.success_rescan_started'))
+        } catch (error: unknown) {
+          const reason = getErrorReason(error, t('global.errors.reason_unknown'))
+          console.warn('Failed to start rescan after wallet import, continuing with import...', reason)
+          setupWarningReason = reason
+        }
+      }
+
+      if (setupWarningReason === undefined) {
+        toast.success(t('import_wallet.success.title'))
+      } else {
+        toast.warning(t('import_wallet.warning_partial_import', { reason: setupWarningReason }))
+      }
+
+      if (lockUnlockSucceeded) {
+        // token in `authState` is fresh, safe to log the user in directly
+        updateAuthState(authState)
+        await navigate(routes.home)
+      } else {
+        // token may be stale after a failed lock/unlock — send the user to
+        // log in again rather than optimistically using a token that might
+        // no longer work
+        await navigate(routes.login)
+      }
     } catch (error: unknown) {
       console.error('Error while importing wallet', error)
 
       const reason = getErrorReason(error, t('global.errors.reason_unknown'))
       const errorMessage = t('import_wallet.error_importing_failed', { reason })
       toast.error(errorMessage)
-
-      if (authState?.auth.token !== undefined) {
-        try {
-          // try to lock the current wallet on error on a best effort basis
-          await lockWallet.mutateAsync({
-            walletFileName: authState.walletFileName,
-            token: authState.auth.token,
-          })
-        } catch (error: unknown) {
-          const reason = getErrorReason(error, t('global.errors.reason_unknown'))
-          console.warn('Locking wallet attempt failed after import error.', reason)
-        }
-      }
     } finally {
       toast.dismiss(durationHintToastId)
     }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -267,6 +267,7 @@
     "success": {
       "title": "Wallet imported successfully!"
     },
+    "warning_partial_import": "Wallet recovered, but a setup step did not complete. Reason: {{ reason }}",
     "error_importing_failed": "Error while importing the wallet. Reason: {{ reason }}"
   },
   "current_wallet": {


### PR DESCRIPTION
wraps the post-recovery setup steps (gaplimit bump/reset, lock/unlock, rescan trigger) in their own error handling, so a downstream failure doesnt report the whole import as "failed" once the wallet has already been recovered on the backend.

- gaplimit and rescan failures are non-fatal now, they just log a warning and the user still gets signed in, with a softer "recovered but a setup step didnt finish" toast instead of the generic error one
- lock/unlock failure gets treated differently since the token might be stale after that - sends the user to login instead of signing them in with a token that could just not work
- the outer catch (generic "import failed" toast) only fires now if recoverWallet itself actually fails, same pattern CreateWalletPage.tsx already uses

- Fixes #1435

## Visual Demo (For contributors especially)

no visual change on the happy path, this only shows up when something after the wallet gets recovered fails. added 4 new tests for that - gaplimit reset failing, rescan failing, lock/unlock failing, and the original recoverWallet failure case, checking the right toast + navigation happens for each.
