### PR TITLE
fix(fb): don't treat a failed post-broadcast refetch as a bond creati…

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.test.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.test.ts
@@ -101,6 +101,18 @@ const minLockdateOption = (isDeveloperMode = false) => {
   return lockdate
 }
 
+const submitFromReview = async (result: { current: ReturnType<typeof useCreateFidelityBondWizard> }) => {
+  act(() => result.current.setSelectedLockdate(minLockdateOption()))
+  act(() => result.current.setSelectedJarIndex(0))
+  act(() => result.current.toggleUtxoSelection(result.current.availableUtxos[0]))
+  act(() => result.current.setStep('freeze_utxos'))
+  await act(async () => result.current.handleNext())
+  expect(result.current.step).toBe('review')
+
+  act(() => result.current.setConfirmationChecked(true))
+  await act(async () => result.current.handleNext())
+}
+
 describe('useCreateFidelityBondWizard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -546,6 +558,32 @@ describe('useCreateFidelityBondWizard', () => {
       act(() => result.current.handleBack())
 
       expect(result.current.step).toBe('freeze_utxos')
+    })
+  })
+
+  describe('bond creation failures', () => {
+    it('stays on the success step when the wallet refetch after the broadcast fails', async () => {
+      mocks.walletInfoRefetch.mockRejectedValue(new Error('refetch failed'))
+      const { result } = renderHook(() => useCreateFidelityBondWizard(true, vi.fn(), 'wallet.jmdat'))
+
+      await submitFromReview(result)
+
+      expect(mocks.directSendMutateAsync).toHaveBeenCalled()
+      expect(result.current.step).toBe('success')
+      expect(result.current.txResult).toEqual({ txid: 'created-tx' })
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('earn.fidelity_bond.create_fidelity_bond.success_text')
+    })
+
+    it('rolls back to the freeze step when the send itself fails', async () => {
+      mocks.directSendMutateAsync.mockRejectedValue(new Error('broadcast failed'))
+      const { result } = renderHook(() => useCreateFidelityBondWizard(true, vi.fn(), 'wallet.jmdat'))
+
+      await submitFromReview(result)
+
+      expect(result.current.step).toBe('freeze_utxos')
+      expect(result.current.txResult).toBeUndefined()
+      expect(result.current.frozenUtxos).toEqual([])
+      expect(mocks.walletInfoRefetch).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -276,6 +276,8 @@ export function useCreateFidelityBondWizard(
 
     setStep('creating')
 
+    let broadcasted = false
+
     try {
       // TODO: refactor: use the sweep functionality from `useFidelityBondSweep` here
       const result = await directSend.mutateAsync({
@@ -286,6 +288,7 @@ export function useCreateFidelityBondWizard(
           destination: address,
         },
       })
+      broadcasted = true
 
       // Best-effort cleanup — tx already broadcast, don't throw on unfreeze failure
       for (const utxo of frozenUtxos) {
@@ -319,9 +322,9 @@ export function useCreateFidelityBondWizard(
       setTxResult(result)
       setStep('success')
       toast.success(t('earn.fidelity_bond.create_fidelity_bond.success_text'))
-
-      await walletInfo.refetch()
     } catch {
+      if (broadcasted) return
+
       // Best-effort rollback — unfreeze UTXOs that were frozen for this operation
       for (const utxo of frozenUtxos) {
         try {
@@ -336,6 +339,14 @@ export function useCreateFidelityBondWizard(
       }
       setFrozenUtxos([])
       setStep('freeze_utxos')
+    } finally {
+      if (broadcasted) {
+        try {
+          await walletInfo.refetch()
+        } catch (error: unknown) {
+          console.warn('Error while refetching wallet info after creating fidelity bond.', error)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1442.

`handleCreateFidelityBond` awaited `walletInfo.refetch()` inside the same `try` that guards the sweep. That refetch is a mutation's `mutateAsync`, and its `mutationFn` calls `.refetch({ throwOnError: true })` on both wallet queries with `retry: false`, so any transient backend failure rejects.

When that happened after the bond transaction had already broadcast, the catch ran and reset the wizard back to `freeze_utxos`. The user got a success toast, then got bounced back a step with no error message at all (nothing calls `setError` on that path), and the txid was left stranded in state because the success screen only renders at `step === 'success'`. Balances stayed stale too, since the failed refetch is never retried.

Every other post-broadcast step in that function was already individually try/caught. The refetch was the only one that wasn't.

## What changed

The same guard `useFidelityBondSweep` got in #1399, adapted for the create flow:

* track `broadcasted`, set right after `directSend` resolves
* bail out of the catch when `broadcasted` is true, so nothing after the broadcast can rewind the wizard
* move `walletInfo.refetch()` into a `finally` with its own try/catch

The `bondWasUnfrozen` half of #1399 has no equivalent here. The create flow never unfreezes a bond, it freezes the sibling utxos and sweeps a normal utxo into a fresh timelock address.

## Tests

Added a `bond creation failures` block to the existing suite, which had no failure path coverage at all (no `mockRejected` anywhere in the file):

* `stays on the success step when the wallet refetch after the broadcast fails`, which fails on devel with `expected 'freeze_utxos' to be 'success'` and passes here
* `rolls back to the freeze step when the send itself fails`, confirming genuine failures still roll back and still skip the refetch

The 25 existing tests in that file pass both with and without the fix, so the new one is the only test that moves.

Locally green: 27 tests in that file, 164 across `src/components/earn`, plus eslint, prettier and `tsc -b`.
